### PR TITLE
fix: 内存/交换显示文字被截断

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -64,7 +64,7 @@ use crate::sftp::{spawn_sftp, SftpHandle};
 use crate::ssh::{
     format_mtime, format_size, spawn_session, SessionCommand, SessionEvent, SessionHandle,
 };
-use crate::system::{format_bytes_per_sec, SystemSampler, SystemSnapshot};
+use crate::system::{format_bytes_per_sec, format_mem_mib, SystemSampler, SystemSnapshot};
 
 type SftpHandles = Arc<Mutex<HashMap<String, SftpHandle>>>;
 /// Per-tab flag: once the user explicitly navigates via the SFTP tree or
@@ -1216,8 +1216,8 @@ fn refresh_sidebar(
         win.set_cpu_percent(snap.cpu_percent);
         win.set_mem_percent(snap.mem_percent);
         win.set_swap_percent(snap.swap_percent);
-        win.set_mem_detail(format!("{}/{}M", snap.mem_used_mib, snap.mem_total_mib).into());
-        win.set_swap_detail(format!("{}/{}M", snap.swap_used_mib, snap.swap_total_mib).into());
+        win.set_mem_detail(format_mem_mib(snap.mem_used_mib, snap.mem_total_mib).into());
+        win.set_swap_detail(format_mem_mib(snap.swap_used_mib, snap.swap_total_mib).into());
     };
     let clear_stats = |win: &AppWindow| {
         win.set_cpu_percent(0.0);
@@ -1244,10 +1244,10 @@ fn refresh_sidebar(
             win.set_mem_percent(pct(st.mem_used_kib, st.mem_total_kib));
             win.set_swap_percent(pct(st.swap_used_kib, st.swap_total_kib));
             win.set_mem_detail(
-                format!("{}/{}M", st.mem_used_kib / 1024, st.mem_total_kib / 1024).into(),
+                format_mem_mib(st.mem_used_kib / 1024, st.mem_total_kib / 1024).into(),
             );
             win.set_swap_detail(
-                format!("{}/{}M", st.swap_used_kib / 1024, st.swap_total_kib / 1024).into(),
+                format_mem_mib(st.swap_used_kib / 1024, st.swap_total_kib / 1024).into(),
             );
             let (name, rx, tx) = selected_iface(&st);
             win.set_net_top_up(format_bytes_per_sec(tx).into());

--- a/src/system.rs
+++ b/src/system.rs
@@ -124,6 +124,25 @@ impl SystemSampler {
     }
 }
 
+/// Human-readable memory size from MiB (e.g. `"1.5G/16G"`).
+pub fn format_mem_mib(used_mib: u64, total_mib: u64) -> String {
+    if total_mib >= 1024 {
+        let used_gib = used_mib as f64 / 1024.0;
+        let total_gib = total_mib as f64 / 1024.0;
+        // Drop decimals for large/round values to keep the string short (sidebar is narrow).
+        let fmt_gib = |g: f64| -> String {
+            if g >= 100.0 || g.fract() == 0.0 {
+                format!("{}", g as u64)
+            } else {
+                format!("{:.1}", g)
+            }
+        };
+        format!("{}G/{}G", fmt_gib(used_gib), fmt_gib(total_gib))
+    } else {
+        format!("{}/{}M", used_mib, total_mib)
+    }
+}
+
 /// Human-readable network throughput (e.g. `"1.2 MB/s"`).
 pub fn format_bytes_per_sec(bytes: u64) -> String {
     const UNITS: [&str; 4] = ["B/s", "KB/s", "MB/s", "GB/s"];

--- a/ui/sidebar.slint
+++ b/ui/sidebar.slint
@@ -35,7 +35,7 @@ component StatRow inherits HorizontalLayout {
         background: Theme.bg-root;
         border-radius: 2px;
         min-width: 60px;
-        horizontal-stretch: 1;
+        horizontal-stretch: 2;
 
         Rectangle {
             x: 0;
@@ -61,7 +61,8 @@ component StatRow inherits HorizontalLayout {
         text: detail;
         color: Theme.text-muted;
         font-size: Theme.fs-xs;
-        width: 56px;
+        min-width: 64px;
+        horizontal-stretch: 1;
         horizontal-alignment: right;
         vertical-alignment: center;
     }


### PR DESCRIPTION
- 新增 format_mem_mib()：总内存 >=1GiB 时自动用 GiB 单位显示
- StatRow detail 文本固定宽度改为 min-width + stretch，不再被进度条挤压
- 大数值(>=100G)或整数G值省略小数点，进一步缩短字符串长度
- detail min-width 从 56px 提升至 64px
修复前：
<img width="197" height="104" alt="监控" src="https://github.com/user-attachments/assets/fa258861-02eb-4d6e-a5bd-3b32f1fb4dd0" />

修复后：
<img width="215" height="124" alt="1" src="https://github.com/user-attachments/assets/e9c7644b-fee4-46e1-b017-b85252a64fc5" />
