### PR TITLE
[codex] 添加 GitHub/Gitea 加密同步功能

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,6 +290,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -685,6 +697,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,6 +944,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -944,6 +978,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -1284,6 +1319,27 @@ name = "data-url"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
+name = "dbus"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "dbus",
+ "zeroize",
+]
 
 [[package]]
 name = "delegate"
@@ -2055,9 +2111,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2323,6 +2381,104 @@ name = "htmlparser"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48ce8546b993eaf241d69ded33b1be6d205dd9857ec879d9d18bd05d3676e144"
+
+[[package]]
+name = "http"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "i-slint-backend-linuxkms"
@@ -2890,6 +3046,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3005,6 +3167,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "dbus-secret-service",
+ "log",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
+ "zeroize",
+]
+
+[[package]]
 name = "khronos_api"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3047,6 +3224,15 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libfuzzer-sys"
@@ -3166,6 +3352,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "lyon_algorithms"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3237,19 +3429,24 @@ version = "0.2.3"
 dependencies = [
  "anyhow",
  "arboard",
+ "argon2",
  "async-trait",
  "base64",
+ "chacha20poly1305",
  "chrono",
  "directories",
  "futures",
  "i-slint-backend-winit",
+ "keyring",
  "rand 0.8.6",
+ "reqwest",
  "rfd",
  "russh",
  "russh-keys",
  "russh-sftp",
  "serde",
  "serde_json",
+ "sha2",
  "slint",
  "slint-build",
  "ssh-key",
@@ -3259,8 +3456,11 @@ dependencies = [
  "tokio-socks",
  "tracing",
  "tracing-subscriber",
+ "url",
+ "urlencoding",
  "uuid",
  "vt100",
+ "webbrowser",
  "winresource",
  "zeroize",
 ]
@@ -4104,6 +4304,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4459,6 +4670,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4705,6 +4971,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
 name = "resvg"
 version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4762,6 +5066,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5012,6 +5330,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5034,6 +5387,12 @@ dependencies = [
  "unicode-properties",
  "unicode-script",
 ]
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "salsa20"
@@ -5110,6 +5469,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "seize"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5182,6 +5577,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -5694,6 +6101,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5961,6 +6377,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-socks"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6074,6 +6500,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.11.1",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6134,6 +6605,12 @@ dependencies = [
  "tracing-core",
  "tracing-log",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "ttf-parser"
@@ -6270,6 +6747,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "unty"
@@ -6435,6 +6918,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -6719,6 +7211,15 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "url",
  "web-sys",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -7793,6 +8294,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,14 @@ zeroize = "1"
 # (HTTP CONNECT proxies are handled in src/proxy.rs without an extra crate.)
 tokio-socks = "0.5"
 base64 = "0.22"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+url = "2"
+urlencoding = "2"
+webbrowser = "1"
+sha2 = "0.10"
+argon2 = "0.5"
+chacha20poly1305 = "0.10"
+keyring = { version = "3.6", features = ["apple-native", "windows-native", "sync-secret-service"] }
 
 [build-dependencies]
 slint-build = "1.8"

--- a/src/app.rs
+++ b/src/app.rs
@@ -6,10 +6,10 @@
 //!   * Manage the tab list + per-tab `SessionHandle` map.
 //!   * Route Slint callbacks to the right domain module.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::rc::Rc;
-use std::sync::{Arc, Mutex};
+use std::sync::{mpsc, Arc, Mutex};
 
 /// Per-terminal state: vt100 parser drives all rendering for both normal
 /// (bash) and alt-screen (vim/nano/htop) modes.
@@ -58,7 +58,7 @@ use i_slint_backend_winit::WinitWindowAccessor;
 use slint::{ComponentHandle, Model, ModelRc, SharedString, VecModel};
 use tokio::runtime::Runtime;
 
-use crate::config::{AuthMethod, ConfigStore, Secret, Session};
+use crate::config::{AuthMethod, CloudProvider, CloudSyncConfig, ConfigStore, Secret, Session};
 use crate::i18n::t;
 use crate::sftp::{spawn_sftp, SftpHandle};
 use crate::ssh::{
@@ -96,6 +96,12 @@ type TabStatuses = Arc<Mutex<HashMap<String, TabStatus>>>;
 /// Last local-machine sample (shown on the welcome tab).
 type LocalSnap = Arc<Mutex<SystemSnapshot>>;
 
+enum CloudUiEvent {
+    Status(String),
+    LoginFinished(std::result::Result<crate::cloud_sync::LoginResult, String>),
+    SyncFinished(std::result::Result<crate::cloud_sync::SyncResult, String>),
+}
+
 // Slint generates types into this scope.
 slint::include_modules!();
 
@@ -104,9 +110,7 @@ const NET_HISTORY_LEN: usize = 60;
 
 pub fn run() -> Result<()> {
     // --- Runtime + store -------------------------------------------------
-    let runtime = Arc::new(
-        Runtime::new().context("failed to start tokio runtime")?,
-    );
+    let runtime = Arc::new(Runtime::new().context("failed to start tokio runtime")?);
     let store = Rc::new(RefCell::new(
         ConfigStore::load().context("failed to load config")?,
     ));
@@ -286,6 +290,31 @@ pub fn run() -> Result<()> {
         });
     }
 
+    // Cloud sync: browser login + private repository encrypted snapshots.
+    apply_cloud_config_to_window(&window, store.borrow().cloud_sync());
+    let (cloud_tx, cloud_rx) = mpsc::channel::<CloudUiEvent>();
+    let cloud_busy = Rc::new(Cell::new(false));
+    wire_cloud_sync_callbacks(
+        &window,
+        store.clone(),
+        runtime.clone(),
+        cloud_tx.clone(),
+        cloud_busy.clone(),
+    );
+    start_cloud_event_pump(
+        &window,
+        store.clone(),
+        sessions_model.clone(),
+        cloud_rx,
+        cloud_busy.clone(),
+    );
+    start_cloud_auto_sync(
+        store.clone(),
+        runtime.clone(),
+        cloud_tx.clone(),
+        cloud_busy.clone(),
+    );
+
     // Transfer records (download/upload progress + history) shown in the popup.
     let transfers_model: Rc<VecModel<TransferInfo>> = Rc::new(VecModel::default());
     window.set_transfers(ModelRc::from(transfers_model.clone()));
@@ -298,23 +327,53 @@ pub fn run() -> Result<()> {
     {
         let libs: Vec<SharedString> = [
             t("Slint — 图形界面框架 (GUI)", "Slint — GUI framework"),
-            t("russh / russh-keys — SSH 协议实现", "russh / russh-keys — SSH protocol"),
-            t("russh-sftp — SFTP 文件传输", "russh-sftp — SFTP file transfer"),
+            t(
+                "russh / russh-keys — SSH 协议实现",
+                "russh / russh-keys — SSH protocol",
+            ),
+            t(
+                "russh-sftp — SFTP 文件传输",
+                "russh-sftp — SFTP file transfer",
+            ),
             t("ssh-key — SSH 密钥解析", "ssh-key — SSH key parsing"),
             t("tokio — 异步运行时", "tokio — async runtime"),
-            t("vt100 — 终端 (VT100/xterm) 解析", "vt100 — terminal (VT100/xterm) parser"),
-            t("sysinfo — 本机资源采集", "sysinfo — local resource sampling"),
-            t("serde / serde_json — 配置序列化", "serde / serde_json — config serialization"),
+            t(
+                "vt100 — 终端 (VT100/xterm) 解析",
+                "vt100 — terminal (VT100/xterm) parser",
+            ),
+            t(
+                "sysinfo — 本机资源采集",
+                "sysinfo — local resource sampling",
+            ),
+            t(
+                "serde / serde_json — 配置序列化",
+                "serde / serde_json — config serialization",
+            ),
             t("arboard — 系统剪贴板", "arboard — system clipboard"),
             t("rfd — 原生文件对话框", "rfd — native file dialogs"),
-            t("directories — 配置目录定位", "directories — config dir lookup"),
+            t(
+                "directories — 配置目录定位",
+                "directories — config dir lookup",
+            ),
             t("chrono — 日期时间处理", "chrono — date/time handling"),
             t("uuid — 唯一标识符", "uuid — unique identifiers"),
-            t("anyhow / thiserror — 错误处理", "anyhow / thiserror — error handling"),
-            t("tracing / tracing-subscriber — 日志", "tracing / tracing-subscriber — logging"),
-            t("futures / async-trait — 异步辅助", "futures / async-trait — async helpers"),
+            t(
+                "anyhow / thiserror — 错误处理",
+                "anyhow / thiserror — error handling",
+            ),
+            t(
+                "tracing / tracing-subscriber — 日志",
+                "tracing / tracing-subscriber — logging",
+            ),
+            t(
+                "futures / async-trait — 异步辅助",
+                "futures / async-trait — async helpers",
+            ),
             t("rand — 随机数", "rand — randomness"),
-            t("winresource — Windows 图标/资源嵌入", "winresource — Windows icon/resource embedding"),
+            t(
+                "winresource — Windows 图标/资源嵌入",
+                "winresource — Windows icon/resource embedding",
+            ),
         ]
         .iter()
         .map(|s| (*s).into())
@@ -332,7 +391,12 @@ pub fn run() -> Result<()> {
         sftp_manual_nav.clone(),
     );
     wire_sftp_callbacks(&window, sftp_handles.clone(), sftp_manual_nav.clone());
-    wire_key_input(&window, handles.clone(), bufs.clone(), last_term_size.clone());
+    wire_key_input(
+        &window,
+        handles.clone(),
+        bufs.clone(),
+        last_term_size.clone(),
+    );
 
     // --- System sampler (1 Hz) ------------------------------------------
     let sampler = Rc::new(Mutex::new(SystemSampler::new()));
@@ -352,10 +416,7 @@ pub fn run() -> Result<()> {
             };
             // Append the raw local throughput to the bottom-graph ring buffer
             // (normalisation happens at display time so the graph auto-scales).
-            push_ring(
-                &mut tick_net.lock().unwrap(),
-                snap.net_bytes_per_sec as f32,
-            );
+            push_ring(&mut tick_net.lock().unwrap(), snap.net_bytes_per_sec as f32);
             // Stash the local sample; the sidebar shows it on the welcome tab
             // and in the bottom network graph.
             *tick_local.lock().unwrap() = snap.clone();
@@ -416,12 +477,18 @@ fn center_window(win: &AppWindow) {
     }
     #[link(name = "user32")]
     extern "system" {
-        fn SystemParametersInfoW(action: u32, uiparam: u32, pvparam: *mut Rect, winini: u32) -> i32;
+        fn SystemParametersInfoW(action: u32, uiparam: u32, pvparam: *mut Rect, winini: u32)
+            -> i32;
     }
     const SPI_GETWORKAREA: u32 = 0x0030;
 
     let size = win.window().size(); // physical pixels
-    let mut wa = Rect { left: 0, top: 0, right: 0, bottom: 0 };
+    let mut wa = Rect {
+        left: 0,
+        top: 0,
+        right: 0,
+        bottom: 0,
+    };
     let ok = unsafe { SystemParametersInfoW(SPI_GETWORKAREA, 0, &mut wa, 0) };
     if ok == 0 {
         return;
@@ -482,10 +549,7 @@ fn handle_file_drop(win: &AppWindow, sftp_handles: &SftpHandles, path: String) {
     let w = win.window();
     let scale = w.scale_factor().max(0.01);
     let size = w.size(); // physical
-    let Some(inner) = w
-        .with_winit_window(|ww| ww.inner_position().ok())
-        .flatten()
-    else {
+    let Some(inner) = w.with_winit_window(|ww| ww.inner_position().ok()).flatten() else {
         return;
     };
     let Some((cx, cy)) = cursor_pos() else {
@@ -503,10 +567,7 @@ fn handle_file_drop(win: &AppWindow, sftp_handles: &SftpHandles, path: String) {
     let zone_left = 381.0_f32;
     let zone_top = h_logical - h_sftp + 51.0;
     let zone_bottom = h_logical - 18.0;
-    if client_x < zone_left
-        || client_x > w_logical
-        || client_y < zone_top
-        || client_y > zone_bottom
+    if client_x < zone_left || client_x > w_logical || client_y < zone_top || client_y > zone_bottom
     {
         return; // dropped outside the file list — ignore
     }
@@ -548,6 +609,343 @@ fn sync_sessions_to_model(store: &ConfigStore, model: &VecModel<SessionInfo>) {
         })
         .collect();
     model.set_vec(rows);
+}
+
+fn apply_cloud_config_to_window(win: &AppWindow, cfg: &CloudSyncConfig) {
+    win.set_cloud_provider(cfg.provider.as_str().into());
+    win.set_cloud_server(cfg.server_url.clone().into());
+    win.set_cloud_repo(cfg.repo_name.clone().into());
+    win.set_cloud_auto_sync(cfg.auto_sync);
+    win.set_cloud_sync_interval(cfg.interval_minutes.max(1).to_string().into());
+    win.set_cloud_username(cfg.username.clone().into());
+    win.set_cloud_logged_in(!cfg.username.is_empty() && !cfg.token_key.is_empty());
+    if cfg.username.is_empty() {
+        win.set_cloud_status(t("未登录同步账号", "Not signed in for sync").into());
+    } else if cfg.last_synced_at > 0 {
+        win.set_cloud_status(
+            format!(
+                "{} {}",
+                t("上次同步", "Last synced"),
+                format_sync_time(cfg.last_synced_at)
+            )
+            .into(),
+        );
+    } else {
+        win.set_cloud_status(format!("{} {}", cfg.provider.label(), cfg.username).into());
+    }
+}
+
+fn wire_cloud_sync_callbacks(
+    window: &AppWindow,
+    store: Rc<RefCell<ConfigStore>>,
+    runtime: Arc<Runtime>,
+    tx: mpsc::Sender<CloudUiEvent>,
+    busy: Rc<Cell<bool>>,
+) {
+    {
+        let weak = window.as_weak();
+        let store = store.clone();
+        window.on_cloud_save_settings(move |provider, server, repo, auto, interval| {
+            let provider = cloud_provider_from_str(&provider.to_string());
+            let interval = parse_sync_interval(&interval.to_string());
+            let cfg = {
+                let mut s = store.borrow_mut();
+                let cfg = crate::cloud_sync::normalized_config(
+                    provider,
+                    server.to_string(),
+                    repo.to_string(),
+                    auto,
+                    interval,
+                    s.cloud_sync(),
+                );
+                s.set_cloud_sync(cfg.clone());
+                if let Err(err) = s.save() {
+                    tracing::warn!("failed to save cloud sync settings: {err:#}");
+                }
+                cfg
+            };
+            if let Some(w) = weak.upgrade() {
+                apply_cloud_config_to_window(&w, &cfg);
+                w.set_cloud_status(t("同步设置已保存", "Sync settings saved").into());
+            }
+        });
+    }
+
+    {
+        let store = store.clone();
+        let runtime = runtime.clone();
+        let tx = tx.clone();
+        let busy = busy.clone();
+        window.on_cloud_login(move |provider, server, repo, password, auto, interval| {
+            if busy.get() {
+                let _ = tx.send(CloudUiEvent::Status(
+                    t("同步任务正在运行", "Sync task is already running").to_string(),
+                ));
+                return;
+            }
+            let provider = cloud_provider_from_str(&provider.to_string());
+            let interval = parse_sync_interval(&interval.to_string());
+            let password = password.to_string();
+            let cfg = {
+                let mut s = store.borrow_mut();
+                let cfg = crate::cloud_sync::normalized_config(
+                    provider,
+                    server.to_string(),
+                    repo.to_string(),
+                    auto,
+                    interval,
+                    s.cloud_sync(),
+                );
+                s.set_cloud_sync(cfg.clone());
+                let _ = s.save();
+                cfg
+            };
+            busy.set(true);
+            let _ = tx.send(CloudUiEvent::Status(
+                t("正在启动浏览器登录...", "Starting browser login...").to_string(),
+            ));
+            launch_cloud_login(&runtime, tx.clone(), cfg, password);
+        });
+    }
+
+    {
+        let store = store.clone();
+        let runtime = runtime.clone();
+        let tx = tx.clone();
+        let busy = busy.clone();
+        window.on_cloud_sync_now(move |provider, server, repo, password, auto, interval| {
+            if busy.get() {
+                let _ = tx.send(CloudUiEvent::Status(
+                    t("同步任务正在运行", "Sync task is already running").to_string(),
+                ));
+                return;
+            }
+            let provider = cloud_provider_from_str(&provider.to_string());
+            let interval = parse_sync_interval(&interval.to_string());
+            let password = password.to_string();
+            let (cfg, snapshot) = {
+                let mut s = store.borrow_mut();
+                let cfg = crate::cloud_sync::normalized_config(
+                    provider,
+                    server.to_string(),
+                    repo.to_string(),
+                    auto,
+                    interval,
+                    s.cloud_sync(),
+                );
+                s.set_cloud_sync(cfg.clone());
+                let _ = s.save();
+                (cfg, s.snapshot())
+            };
+            busy.set(true);
+            let _ = tx.send(CloudUiEvent::Status(
+                t("正在同步...", "Syncing...").to_string(),
+            ));
+            launch_cloud_sync(&runtime, tx.clone(), cfg, snapshot, Some(password));
+        });
+    }
+
+    {
+        let weak = window.as_weak();
+        let store = store.clone();
+        window.on_cloud_disconnect(move || {
+            let cfg = {
+                let mut s = store.borrow_mut();
+                let old = s.cloud_sync().clone();
+                crate::cloud_sync::clear_saved_secrets(&old);
+                let mut cfg = old;
+                cfg.username.clear();
+                cfg.repo_owner.clear();
+                cfg.token_key.clear();
+                cfg.password_key.clear();
+                cfg.last_synced_at = 0;
+                s.set_cloud_sync(cfg.clone());
+                let _ = s.save();
+                cfg
+            };
+            if let Some(w) = weak.upgrade() {
+                apply_cloud_config_to_window(&w, &cfg);
+                w.set_cloud_status(t("已退出同步账号", "Signed out from sync").into());
+            }
+        });
+    }
+}
+
+fn start_cloud_event_pump(
+    window: &AppWindow,
+    store: Rc<RefCell<ConfigStore>>,
+    sessions_model: Rc<VecModel<SessionInfo>>,
+    rx: mpsc::Receiver<CloudUiEvent>,
+    busy: Rc<Cell<bool>>,
+) {
+    let weak = window.as_weak();
+    let timer = slint::Timer::default();
+    timer.start(
+        slint::TimerMode::Repeated,
+        std::time::Duration::from_millis(200),
+        move || {
+            while let Ok(evt) = rx.try_recv() {
+                match evt {
+                    CloudUiEvent::Status(status) => {
+                        if let Some(w) = weak.upgrade() {
+                            w.set_cloud_status(status.into());
+                        }
+                    }
+                    CloudUiEvent::LoginFinished(result) => {
+                        busy.set(false);
+                        if let Some(w) = weak.upgrade() {
+                            match result {
+                                Ok(result) => {
+                                    {
+                                        let mut s = store.borrow_mut();
+                                        s.set_cloud_sync(result.config.clone());
+                                        let _ = s.save();
+                                    }
+                                    apply_cloud_config_to_window(&w, &result.config);
+                                    w.set_cloud_status(result.status.into());
+                                    w.set_cloud_password("".into());
+                                }
+                                Err(err) => w.set_cloud_status(err.into()),
+                            }
+                        }
+                    }
+                    CloudUiEvent::SyncFinished(result) => {
+                        busy.set(false);
+                        if let Some(w) = weak.upgrade() {
+                            match result {
+                                Ok(mut result) => {
+                                    let apply_result = {
+                                        let mut s = store.borrow_mut();
+                                        if let Some(snapshot) = result.downloaded.take() {
+                                            crate::cloud_sync::apply_downloaded_snapshot(
+                                                &mut s, snapshot,
+                                            )
+                                        } else {
+                                            Ok(())
+                                        }
+                                        .map(|_| {
+                                            s.set_cloud_sync(result.config.clone());
+                                            s.save()
+                                        })
+                                    };
+                                    match apply_result {
+                                        Ok(Ok(())) => {
+                                            let s = store.borrow();
+                                            sync_sessions_to_model(&s, &sessions_model);
+                                            w.set_download_dir(s.download_dir().to_string().into());
+                                            crate::i18n::set_language(s.language());
+                                            crate::i18n::apply_to_slint();
+                                            w.set_lang_en(crate::i18n::is_en());
+                                            apply_cloud_config_to_window(&w, s.cloud_sync());
+                                            w.set_cloud_status(result.status.into());
+                                            w.set_cloud_password("".into());
+                                        }
+                                        Ok(Err(err)) | Err(err) => {
+                                            w.set_cloud_status(
+                                                format!(
+                                                    "{}: {err:#}",
+                                                    t(
+                                                        "保存同步数据失败",
+                                                        "Failed to save synced data"
+                                                    )
+                                                )
+                                                .into(),
+                                            );
+                                        }
+                                    }
+                                }
+                                Err(err) => w.set_cloud_status(err.into()),
+                            }
+                        }
+                    }
+                }
+            }
+        },
+    );
+    Box::leak(Box::new(timer));
+}
+
+fn start_cloud_auto_sync(
+    store: Rc<RefCell<ConfigStore>>,
+    runtime: Arc<Runtime>,
+    tx: mpsc::Sender<CloudUiEvent>,
+    busy: Rc<Cell<bool>>,
+) {
+    let last_attempt = Rc::new(RefCell::new(std::time::Instant::now()));
+    let timer = slint::Timer::default();
+    timer.start(
+        slint::TimerMode::Repeated,
+        std::time::Duration::from_secs(30),
+        move || {
+            let (cfg, snapshot) = {
+                let s = store.borrow();
+                (s.cloud_sync().clone(), s.snapshot())
+            };
+            if !cfg.auto_sync || cfg.username.is_empty() || cfg.token_key.is_empty() {
+                return;
+            }
+            let interval = std::time::Duration::from_secs(cfg.interval_minutes.max(1) * 60);
+            if last_attempt.borrow().elapsed() < interval || busy.get() {
+                return;
+            }
+            *last_attempt.borrow_mut() = std::time::Instant::now();
+            busy.set(true);
+            let _ = tx.send(CloudUiEvent::Status(
+                t("正在自动同步...", "Auto syncing...").to_string(),
+            ));
+            launch_cloud_sync(&runtime, tx.clone(), cfg, snapshot, None);
+        },
+    );
+    Box::leak(Box::new(timer));
+}
+
+fn launch_cloud_login(
+    runtime: &Arc<Runtime>,
+    tx: mpsc::Sender<CloudUiEvent>,
+    cfg: CloudSyncConfig,
+    password: String,
+) {
+    runtime.spawn(async move {
+        let progress_tx = tx.clone();
+        let result = crate::cloud_sync::login(cfg, password, move |status| {
+            let _ = progress_tx.send(CloudUiEvent::Status(status));
+        })
+        .await
+        .map_err(|err| format!("{}: {err:#}", t("登录失败", "Login failed")));
+        let _ = tx.send(CloudUiEvent::LoginFinished(result));
+    });
+}
+
+fn launch_cloud_sync(
+    runtime: &Arc<Runtime>,
+    tx: mpsc::Sender<CloudUiEvent>,
+    cfg: CloudSyncConfig,
+    snapshot: crate::config::ConfigFile,
+    password: Option<String>,
+) {
+    runtime.spawn(async move {
+        let progress_tx = tx.clone();
+        let result = crate::cloud_sync::sync_now(cfg, snapshot, password, move |status| {
+            let _ = progress_tx.send(CloudUiEvent::Status(status));
+        })
+        .await
+        .map_err(|err| format!("{}: {err:#}", t("同步失败", "Sync failed")));
+        let _ = tx.send(CloudUiEvent::SyncFinished(result));
+    });
+}
+
+fn cloud_provider_from_str(value: &str) -> CloudProvider {
+    CloudProvider::from_str(value)
+}
+
+fn parse_sync_interval(value: &str) -> u64 {
+    value.trim().parse::<u64>().unwrap_or(15).max(1)
+}
+
+fn format_sync_time(timestamp_millis: i64) -> String {
+    chrono::DateTime::<chrono::Utc>::from_timestamp_millis(timestamp_millis)
+        .map(|dt| dt.format("%Y-%m-%d %H:%M").to_string())
+        .unwrap_or_else(|| "-".to_string())
 }
 
 // ---------------------------------------------------------------------------
@@ -599,7 +997,9 @@ fn wire_session_callbacks(
             let mut added = 0usize;
             if hosts.is_empty() {
                 if let Some(w) = weak.upgrade() {
-                    w.set_ssh_import_hint(t("未找到 ~/.ssh/config", "no ~/.ssh/config found").into());
+                    w.set_ssh_import_hint(
+                        t("未找到 ~/.ssh/config", "no ~/.ssh/config found").into(),
+                    );
                 }
                 return;
             }
@@ -608,9 +1008,10 @@ fn wire_session_callbacks(
                 for h in hosts {
                     // Skip if a session already has this alias, or the same
                     // host + user pair.
-                    let dup = s.sessions().iter().any(|x| {
-                        x.name == h.alias || (x.host == h.hostname && x.user == h.user)
-                    });
+                    let dup = s
+                        .sessions()
+                        .iter()
+                        .any(|x| x.name == h.alias || (x.host == h.hostname && x.user == h.user));
                     if dup {
                         continue;
                     }
@@ -624,7 +1025,11 @@ fn wire_session_callbacks(
                         name: h.alias,
                         host: h.hostname,
                         port: h.port,
-                        user: if h.user.is_empty() { "root".into() } else { h.user },
+                        user: if h.user.is_empty() {
+                            "root".into()
+                        } else {
+                            h.user
+                        },
                         auth,
                         password: Secret::default(),
                         private_key_path: h.identity_file,
@@ -656,7 +1061,9 @@ fn wire_session_callbacks(
         window.on_edit_session(move |id: SharedString| {
             let id = id.to_string();
             let store = store.borrow();
-            let Some(session) = store.get(&id) else { return; };
+            let Some(session) = store.get(&id) else {
+                return;
+            };
             if let Some(w) = weak.upgrade() {
                 w.set_dialog_id(session.id.clone().into());
                 w.set_dialog_name(session.name.clone().into());
@@ -723,7 +1130,11 @@ fn wire_session_callbacks(
                     draft.name.to_string()
                 },
                 host: draft.host.to_string(),
-                port: if draft.port <= 0 { 22 } else { draft.port as u16 },
+                port: if draft.port <= 0 {
+                    22
+                } else {
+                    draft.port as u16
+                },
                 user: draft.user.to_string(),
                 auth: AuthMethod::from_str(&draft.auth.to_string()),
                 password,
@@ -761,7 +1172,8 @@ fn wire_session_callbacks(
     {
         let weak = window.as_weak();
         window.on_session_dialog_pick_key(move || {
-            let mut dialog = rfd::FileDialog::new().set_title(t("选择私钥文件", "Choose private key file"));
+            let mut dialog =
+                rfd::FileDialog::new().set_title(t("选择私钥文件", "Choose private key file"));
             // Start in ~/.ssh if it exists.
             if let Some(home) = directories::UserDirs::new().map(|u| u.home_dir().join(".ssh")) {
                 if home.is_dir() {
@@ -831,14 +1243,12 @@ fn wire_session_callbacks(
                 find_matches: ModelRc::from(std::rc::Rc::new(VecModel::<TermMatch>::default())),
                 selection: ModelRc::from(std::rc::Rc::new(VecModel::<TermMatch>::default())),
                 sftp_path: "/".into(),
-                sftp_entries: ModelRc::from(
-                    std::rc::Rc::new(VecModel::<SftpEntry>::default()),
-                ),
+                sftp_entries: ModelRc::from(std::rc::Rc::new(VecModel::<SftpEntry>::default())),
                 sftp_status: t("SFTP 连接中...", "SFTP connecting...").into(),
                 sftp_loading: true,
-                sftp_tree_nodes: ModelRc::from(
-                    std::rc::Rc::new(VecModel::<SftpTreeNode>::default()),
-                ),
+                sftp_tree_nodes: ModelRc::from(std::rc::Rc::new(
+                    VecModel::<SftpTreeNode>::default(),
+                )),
             });
             // Create vt100 parser for this tab (default 24×80; resized on first
             // terminal-resize callback). 5000-line scrollback is stored for
@@ -857,7 +1267,10 @@ fn wire_session_callbacks(
                 },
             );
             // Start in cd-auto-follow mode (flag = false → follow cd).
-            sftp_manual_nav.lock().unwrap().insert(tab_id.clone(), false);
+            sftp_manual_nav
+                .lock()
+                .unwrap()
+                .insert(tab_id.clone(), false);
             if let Some(w) = weak.upgrade() {
                 w.set_active_tab_id(tab_id.clone().into());
             }
@@ -894,7 +1307,10 @@ fn wire_session_callbacks(
                 // and merge them in the pump thread below.
                 let (sftp_tx, sftp_rx) = tokio::sync::mpsc::unbounded_channel::<SessionEvent>();
                 let sftp_handle = spawn_sftp(runtime.handle(), session, sftp_tx);
-                sftp_handles.lock().unwrap().insert(tab_id.clone(), sftp_handle);
+                sftp_handles
+                    .lock()
+                    .unwrap()
+                    .insert(tab_id.clone(), sftp_handle);
                 sftp_rx
             };
 
@@ -931,9 +1347,9 @@ fn wire_session_callbacks(
                                         let sftp_h = sftp_handles_pump.clone();
                                         let tid = tab_id_pump.clone();
                                         cwd_debounce = Some(rt_pump.spawn(async move {
-                                            tokio::time::sleep(
-                                                std::time::Duration::from_millis(500),
-                                            )
+                                            tokio::time::sleep(std::time::Duration::from_millis(
+                                                500,
+                                            ))
                                             .await;
                                             if let Ok(handles) = sftp_h.lock() {
                                                 if let Some(h) = handles.get(&tid) {
@@ -952,8 +1368,8 @@ fn wire_session_callbacks(
                                 let _ = slint::invoke_from_event_loop(move || {
                                     if let Some(win) = weak_evt.upgrade() {
                                         apply_session_event_to_window(
-                                            &win, &tid, shell_evt, &bufs_evt,
-                                            &st_evt, &lc_evt, &nh_evt,
+                                            &win, &tid, shell_evt, &bufs_evt, &st_evt, &lc_evt,
+                                            &nh_evt,
                                         );
                                     }
                                 });
@@ -989,8 +1405,7 @@ fn wire_session_callbacks(
                                 let _ = slint::invoke_from_event_loop(move || {
                                     if let Some(win) = weak_s.upgrade() {
                                         apply_session_event_to_window(
-                                            &win, &tid, sftp_evt, &bufs_s,
-                                            &st_s, &lc_s, &nh_s,
+                                            &win, &tid, sftp_evt, &bufs_s, &st_s, &lc_s, &nh_s,
                                         );
                                     }
                                 });
@@ -1089,13 +1504,29 @@ fn selection_rects(sr: u16, sc: u16, er: u16, ec: u16, cols: u16) -> Vec<TermMat
     if sr == er {
         let lo = sc.min(ec);
         let hi = sc.max(ec);
-        out.push(TermMatch { row: sr as i32, col: lo as i32, len: (hi - lo + 1) as i32 });
+        out.push(TermMatch {
+            row: sr as i32,
+            col: lo as i32,
+            len: (hi - lo + 1) as i32,
+        });
     } else {
-        out.push(TermMatch { row: sr as i32, col: sc as i32, len: (cols - sc) as i32 });
+        out.push(TermMatch {
+            row: sr as i32,
+            col: sc as i32,
+            len: (cols - sc) as i32,
+        });
         for r in (sr + 1)..er {
-            out.push(TermMatch { row: r as i32, col: 0, len: cols as i32 });
+            out.push(TermMatch {
+                row: r as i32,
+                col: 0,
+                len: cols as i32,
+            });
         }
-        out.push(TermMatch { row: er as i32, col: 0, len: (ec + 1) as i32 });
+        out.push(TermMatch {
+            row: er as i32,
+            col: 0,
+            len: (ec + 1) as i32,
+        });
     }
     out
 }
@@ -1139,7 +1570,9 @@ fn extract_selection(rows: &[String], sr: u16, sc: u16, er: u16, ec: u16) -> Str
 fn rebuild_tab_display(win: &AppWindow, bufs: &TermBuffers, tab_id: &str) {
     let data = {
         let mut map = bufs.lock().unwrap();
-        let Some(buf) = map.get_mut(tab_id) else { return };
+        let Some(buf) = map.get_mut(tab_id) else {
+            return;
+        };
         let cols = buf.parser.screen().size().1;
         let b = buf.render(); // also refreshes buf.displayed_text
         let matches = compute_find_matches(&buf.displayed_text, &buf.find_query);
@@ -1255,8 +1688,7 @@ fn refresh_sidebar(
             win.set_net_top_history(normalized_model(&st.net_hist));
             win.set_net_show_selector(!st.net.is_empty());
             win.set_net_selected(name.into());
-            let ifaces: Vec<SharedString> =
-                st.net.iter().map(|e| e.0.clone().into()).collect();
+            let ifaces: Vec<SharedString> = st.net.iter().map(|e| e.0.clone().into()).collect();
             win.set_net_ifaces(ModelRc::from(Rc::new(VecModel::from(ifaces))));
             win.set_disks(disk_model(&st.disks));
         }
@@ -1392,7 +1824,9 @@ fn apply_session_event_to_window(
         }
         SessionEvent::Closed(reason) => {
             update_tab(&|t| t.connected = false);
-            update_terminal(&|t| t.status = format!("{} — {reason}", crate::i18n::t("已断开", "Disconnected")).into());
+            update_terminal(&|t| {
+                t.status = format!("{} — {reason}", crate::i18n::t("已断开", "Disconnected")).into()
+            });
             if let Some(st) = statuses.lock().unwrap().get_mut(tab_id) {
                 st.state = 2;
             }
@@ -1454,9 +1888,7 @@ fn apply_session_event_to_window(
                     modified: format_mtime(e.modified).into(),
                 })
                 .collect();
-            let model = ModelRc::from(
-                std::rc::Rc::new(VecModel::from(slint_entries)),
-            );
+            let model = ModelRc::from(std::rc::Rc::new(VecModel::from(slint_entries)));
             update_terminal(&|t| {
                 t.sftp_path = path.clone().into();
                 t.sftp_entries = model.clone();
@@ -1712,23 +2144,21 @@ fn wire_sftp_callbacks(
     // Upload a local file into the current remote directory.
     {
         let sftp_handles = sftp_handles.clone();
-        window.on_sftp_upload_clicked(
-            move |tab_id: SharedString, remote_dir: SharedString| {
-                let tab_id = tab_id.to_string();
-                let remote_dir = remote_dir.to_string();
-                let sftp_handles = sftp_handles.clone();
-                std::thread::spawn(move || {
-                    if let Some(file) = rfd::FileDialog::new().pick_file() {
-                        let local = file.to_string_lossy().to_string();
-                        if let Ok(handles) = sftp_handles.lock() {
-                            if let Some(h) = handles.get(&tab_id) {
-                                h.upload(local, remote_dir);
-                            }
+        window.on_sftp_upload_clicked(move |tab_id: SharedString, remote_dir: SharedString| {
+            let tab_id = tab_id.to_string();
+            let remote_dir = remote_dir.to_string();
+            let sftp_handles = sftp_handles.clone();
+            std::thread::spawn(move || {
+                if let Some(file) = rfd::FileDialog::new().pick_file() {
+                    let local = file.to_string_lossy().to_string();
+                    if let Ok(handles) = sftp_handles.lock() {
+                        if let Some(h) = handles.get(&tab_id) {
+                            h.upload(local, remote_dir);
                         }
                     }
-                });
-            },
-        );
+                }
+            });
+        });
     }
 
     // Refresh the current directory listing.
@@ -1815,8 +2245,7 @@ fn wire_key_input(
         let bufs = bufs.clone();
         // Shared timestamp: the last time the Shift key alone was pressed
         // (key="", shift=true).  Used by the time-based Backspace filter below.
-        let last_shift_time: Arc<Mutex<Option<std::time::Instant>>> =
-            Arc::new(Mutex::new(None));
+        let last_shift_time: Arc<Mutex<Option<std::time::Instant>>> = Arc::new(Mutex::new(None));
         window.on_send_key(move |tab_id: SharedString, key: SharedString, ctrl: bool, alt: bool, shift: bool| {
             // Check whether the remote PTY switched to application cursor mode
             // (DECCKM, set by nano/vim via \x1b[?1h). In that mode the terminal
@@ -2041,17 +2470,14 @@ fn wire_key_input(
     {
         let handles = handles.clone();
         let bufs_resize = bufs.clone(); // keep bufs alive for the copy handler below
-        // The Slint side now measures the real Consolas cell size (via a hidden
-        // probe Text) and passes whole column/row counts directly, so there is
-        // no pixel→cell guesswork here.  This keeps full-screen programs like
-        // nano from over-counting rows and clipping their bottom shortcut bar.
+                                        // The Slint side now measures the real Consolas cell size (via a hidden
+                                        // probe Text) and passes whole column/row counts directly, so there is
+                                        // no pixel→cell guesswork here.  This keeps full-screen programs like
+                                        // nano from over-counting rows and clipping their bottom shortcut bar.
         window.on_terminal_resize(move |tab_id: SharedString, cols_f: f32, rows_f: f32| {
             let cols = (cols_f as u32).max(10);
             let rows = (rows_f as u32).max(5);
-            tracing::debug!(
-                "terminal_resize tab={} cols={} rows={}",
-                tab_id, cols, rows
-            );
+            tracing::debug!("terminal_resize tab={} cols={} rows={}", tab_id, cols, rows);
             // Keep the shared size up-to-date so future connections start
             // with the correct PTY dimensions.
             *last_term_size.lock().unwrap() = (cols, rows);
@@ -2169,12 +2595,9 @@ fn wire_key_input(
             }
             if let Some(win) = weak.upgrade() {
                 set_terminal_row(&win, &tid, |row| {
-                    row.spans =
-                        ModelRc::from(Rc::new(VecModel::<TermSpan>::default()));
-                    row.find_matches =
-                        ModelRc::from(Rc::new(VecModel::<TermMatch>::default()));
-                    row.selection =
-                        ModelRc::from(Rc::new(VecModel::<TermMatch>::default()));
+                    row.spans = ModelRc::from(Rc::new(VecModel::<TermSpan>::default()));
+                    row.find_matches = ModelRc::from(Rc::new(VecModel::<TermMatch>::default()));
+                    row.selection = ModelRc::from(Rc::new(VecModel::<TermMatch>::default()));
                     row.cursor_row = 0;
                     row.cursor_col = 0;
                     row.rows_used = 0;
@@ -2295,8 +2718,7 @@ fn wire_key_input(
                 Some(t) if !t.is_empty() => {
                     // Auto-copy on release (select-to-copy, PuTTY style).
                     std::thread::spawn(move || {
-                        let _ = arboard::Clipboard::new()
-                            .and_then(|mut cb| cb.set_text(t));
+                        let _ = arboard::Clipboard::new().and_then(|mut cb| cb.set_text(t));
                     });
                 }
                 _ => {}
@@ -2326,7 +2748,9 @@ fn wire_key_input(
                 let last = rows.saturating_sub(1);
                 let max_off = buf.history.len();
                 let step = 2usize;
-                let Some((sr, sc, _er, ec)) = buf.sel else { return };
+                let Some((sr, sc, _er, ec)) = buf.sel else {
+                    return;
+                };
                 if dir < 0 {
                     // Mouse above the top → reveal older lines.
                     let new_off = (buf.view_offset + step).min(max_off);
@@ -2392,23 +2816,23 @@ fn key_to_pty_bytes(key: &str, ctrl: bool, alt: bool, app_cursor: bool) -> Vec<u
         "\u{F701}" => Some(if app_cursor { b"\x1bOB" } else { b"\x1b[B" }), // Down
         "\u{F702}" => Some(if app_cursor { b"\x1bOD" } else { b"\x1b[D" }), // Left
         "\u{F703}" => Some(if app_cursor { b"\x1bOC" } else { b"\x1b[C" }), // Right
-        "\u{F729}" => Some(b"\x1b[H"),   // Home
-        "\u{F72B}" => Some(b"\x1b[F"),   // End
-        "\u{F72C}" => Some(b"\x1b[5~"),  // PageUp
-        "\u{F72D}" => Some(b"\x1b[6~"),  // PageDown
-        "\u{F728}" => Some(b"\x1b[3~"),  // Delete (forward)
-        "\u{F704}" => Some(b"\x1bOP"),   // F1
-        "\u{F705}" => Some(b"\x1bOQ"),   // F2
-        "\u{F706}" => Some(b"\x1bOR"),   // F3
-        "\u{F707}" => Some(b"\x1bOS"),   // F4
-        "\u{F708}" => Some(b"\x1b[15~"), // F5
-        "\u{F709}" => Some(b"\x1b[17~"), // F6
-        "\u{F70A}" => Some(b"\x1b[18~"), // F7
-        "\u{F70B}" => Some(b"\x1b[19~"), // F8
-        "\u{F70C}" => Some(b"\x1b[20~"), // F9
-        "\u{F70D}" => Some(b"\x1b[21~"), // F10
-        "\u{F70E}" => Some(b"\x1b[23~"), // F11
-        "\u{F70F}" => Some(b"\x1b[24~"), // F12
+        "\u{F729}" => Some(b"\x1b[H"),                                      // Home
+        "\u{F72B}" => Some(b"\x1b[F"),                                      // End
+        "\u{F72C}" => Some(b"\x1b[5~"),                                     // PageUp
+        "\u{F72D}" => Some(b"\x1b[6~"),                                     // PageDown
+        "\u{F728}" => Some(b"\x1b[3~"),                                     // Delete (forward)
+        "\u{F704}" => Some(b"\x1bOP"),                                      // F1
+        "\u{F705}" => Some(b"\x1bOQ"),                                      // F2
+        "\u{F706}" => Some(b"\x1bOR"),                                      // F3
+        "\u{F707}" => Some(b"\x1bOS"),                                      // F4
+        "\u{F708}" => Some(b"\x1b[15~"),                                    // F5
+        "\u{F709}" => Some(b"\x1b[17~"),                                    // F6
+        "\u{F70A}" => Some(b"\x1b[18~"),                                    // F7
+        "\u{F70B}" => Some(b"\x1b[19~"),                                    // F8
+        "\u{F70C}" => Some(b"\x1b[20~"),                                    // F9
+        "\u{F70D}" => Some(b"\x1b[21~"),                                    // F10
+        "\u{F70E}" => Some(b"\x1b[23~"),                                    // F11
+        "\u{F70F}" => Some(b"\x1b[24~"),                                    // F12
         _ => None,
     };
     if let Some(seq) = special {
@@ -2455,8 +2879,8 @@ fn key_to_pty_bytes(key: &str, ctrl: bool, alt: bool, app_cursor: bool) -> Vec<u
             if key.chars().count() == 1 {
                 let upper = c.to_ascii_uppercase() as u8;
                 let ctrl_char: Option<u8> = match upper {
-                    b'A'..=b'Z' => Some(upper - b'A' + 1),      // Ctrl+A=\x01 … Ctrl+Z=\x1A
-                    b'[' => Some(0x1b),                           // Ctrl+[ = ESC
+                    b'A'..=b'Z' => Some(upper - b'A' + 1), // Ctrl+A=\x01 … Ctrl+Z=\x1A
+                    b'[' => Some(0x1b),                    // Ctrl+[ = ESC
                     b'\\' => Some(0x1c),
                     b']' => Some(0x1d),
                     b'^' => Some(0x1e),
@@ -2703,7 +3127,11 @@ impl TermBuffer {
                     } else {
                         // Not a CSI (could be another ESC, OSC, etc.).  Re-arm on
                         // a fresh ESC, otherwise fall back to normal text.
-                        self.csi_state = if b == 0x1b { CsiState::Esc } else { CsiState::Normal };
+                        self.csi_state = if b == 0x1b {
+                            CsiState::Esc
+                        } else {
+                            CsiState::Normal
+                        };
                     }
                     out.push(b);
                 }
@@ -2730,9 +3158,9 @@ impl TermBuffer {
         // btop configured with `alt-screen = false`).
         // We look for \033[H (cursor-home) and \033[2J / \033[J (erase display)
         // as indicators that the program is doing a full-screen refresh.
-        let has_cursor_home   = bytes.windows(3).any(|w| w == b"\x1b[H");
-        let has_erase_display = bytes.windows(4).any(|w| w == b"\x1b[2J")
-                             || bytes.windows(3).any(|w| w == b"\x1b[J");
+        let has_cursor_home = bytes.windows(3).any(|w| w == b"\x1b[H");
+        let has_erase_display =
+            bytes.windows(4).any(|w| w == b"\x1b[2J") || bytes.windows(3).any(|w| w == b"\x1b[J");
         let is_fullscreen_refresh = has_cursor_home && has_erase_display;
 
         self.parser.process(bytes);
@@ -2808,7 +3236,11 @@ impl TermBuffer {
                 displayed.push(plain.trim_end().to_string());
             }
             self.displayed_text = displayed;
-            let rows_used = if is_alt { rows as i32 } else { last_content + 1 };
+            let rows_used = if is_alt {
+                rows as i32
+            } else {
+                last_content + 1
+            };
             return BuiltScreen {
                 spans,
                 cursor_row: cur_row as i32,

--- a/src/cloud_sync.rs
+++ b/src/cloud_sync.rs
@@ -1,0 +1,847 @@
+//! GitHub/Gitea browser-login private-repository sync.
+//!
+//! The repository stores one encrypted snapshot file. The sync password is
+//! never written to that repository; local OAuth tokens and the password are
+//! persisted through the OS credential store so automatic sync can survive an
+//! app restart.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use anyhow::{anyhow, bail, Context, Result};
+use argon2::Argon2;
+use base64::engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD};
+use base64::Engine as _;
+use chacha20poly1305::aead::{Aead, KeyInit};
+use chacha20poly1305::{XChaCha20Poly1305, XNonce};
+use chrono::Utc;
+use rand::rngs::OsRng;
+use rand::RngCore;
+use reqwest::{Client, StatusCode};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::time::timeout;
+use url::Url;
+
+use crate::config::{CloudProvider, CloudSyncConfig, ConfigFile, ConfigStore, Session};
+
+const SYNC_FILE: &str = "meatshell-sync.enc";
+const KEYRING_SERVICE: &str = "meatshell";
+const GITEA_TEA_CLIENT_ID: &str = "d57cb8c4-630c-4168-8324-ec79935e18d4";
+const GITHUB_CLI_CLIENT_ID: &str = "178c6fc778ccc68e1d6a";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncSnapshot {
+    pub version: u32,
+    pub updated_at: i64,
+    pub sessions: Vec<Session>,
+    pub download_dir: String,
+    pub language: String,
+    #[serde(default)]
+    pub private_keys: Vec<SyncedPrivateKey>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncedPrivateKey {
+    pub session_id: String,
+    pub file_name: String,
+    pub content_b64: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct SyncResult {
+    pub config: CloudSyncConfig,
+    pub downloaded: Option<SyncSnapshot>,
+    pub status: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct LoginResult {
+    pub config: CloudSyncConfig,
+    pub status: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct EncryptedBundle {
+    version: u32,
+    kdf: String,
+    cipher: String,
+    salt_b64: String,
+    nonce_b64: String,
+    ciphertext_b64: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct UserInfo {
+    login: Option<String>,
+    username: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OAuthTokenResponse {
+    access_token: Option<String>,
+    error: Option<String>,
+    error_description: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubDeviceCode {
+    device_code: String,
+    user_code: String,
+    verification_uri: String,
+    expires_in: u64,
+    interval: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubDevicePoll {
+    access_token: Option<String>,
+    error: Option<String>,
+    error_description: Option<String>,
+    interval: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RepoInfo {
+    owner: Option<RepoOwner>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RepoOwner {
+    login: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ContentInfo {
+    content: Option<String>,
+    sha: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct RemoteFile {
+    bytes: Vec<u8>,
+    sha: String,
+}
+
+pub fn normalized_config(
+    provider: CloudProvider,
+    server_url: String,
+    repo_name: String,
+    auto_sync: bool,
+    interval_minutes: u64,
+    current: &CloudSyncConfig,
+) -> CloudSyncConfig {
+    let mut cfg = current.clone();
+    let server = normalize_server(provider, &server_url);
+    let account_changed = current.provider != provider || current.server_url != server;
+    cfg.provider = provider;
+    cfg.server_url = server;
+    cfg.repo_name = if repo_name.trim().is_empty() {
+        "meatshell-sync".to_string()
+    } else {
+        repo_name.trim().to_string()
+    };
+    cfg.auto_sync = auto_sync;
+    cfg.interval_minutes = interval_minutes.max(1);
+    if account_changed {
+        cfg.username.clear();
+        cfg.repo_owner.clear();
+        cfg.token_key.clear();
+        cfg.password_key.clear();
+        cfg.last_synced_at = 0;
+    }
+    cfg
+}
+
+pub async fn login<F>(
+    mut cfg: CloudSyncConfig,
+    sync_password: String,
+    mut progress: F,
+) -> Result<LoginResult>
+where
+    F: FnMut(String) + Send,
+{
+    if sync_password.is_empty() {
+        bail!("请输入同步密码");
+    }
+
+    let client = http_client()?;
+    progress("正在打开浏览器授权...".to_string());
+    let (token, username) = match cfg.provider {
+        CloudProvider::Github => github_login(&client, &cfg, &mut progress).await?,
+        CloudProvider::Gitea => gitea_login(&client, &cfg, &mut progress).await?,
+    };
+
+    cfg.username = username.clone();
+    if cfg.repo_owner.trim().is_empty() {
+        cfg.repo_owner = username.clone();
+    }
+    cfg.token_key = secret_key(&cfg, "token");
+    cfg.password_key = secret_key(&cfg, "sync-password");
+
+    store_secret(&cfg.token_key, &token).context("保存登录凭据失败")?;
+    store_secret(&cfg.password_key, &sync_password).context("保存同步密码失败")?;
+
+    ensure_repo(&client, &cfg, &token)
+        .await
+        .context("创建或检查私有同步仓库失败")?;
+
+    Ok(LoginResult {
+        status: format!(
+            "{} 已登录为 {}，同步仓库 {} 已准备好",
+            cfg.provider.label(),
+            cfg.username,
+            cfg.repo_name
+        ),
+        config: cfg,
+    })
+}
+
+pub async fn sync_now<F>(
+    mut cfg: CloudSyncConfig,
+    local_config: ConfigFile,
+    sync_password: Option<String>,
+    mut progress: F,
+) -> Result<SyncResult>
+where
+    F: FnMut(String) + Send,
+{
+    if cfg.username.trim().is_empty() {
+        bail!("请先登录同步账号");
+    }
+    let token = read_secret(&cfg.token_key).context("读取登录凭据失败，请重新登录")?;
+    let password = match sync_password {
+        Some(p) if !p.is_empty() => {
+            if !cfg.password_key.is_empty() {
+                let _ = store_secret(&cfg.password_key, &p);
+            }
+            p
+        }
+        _ => read_secret(&cfg.password_key).context("读取同步密码失败，请输入同步密码后再同步")?,
+    };
+
+    let client = http_client()?;
+    progress("正在检查同步仓库...".to_string());
+    ensure_repo(&client, &cfg, &token).await?;
+
+    progress("正在读取远端快照...".to_string());
+    let remote = get_sync_file(&client, &cfg, &token).await?;
+    if let Some(file) = remote.clone() {
+        let remote_snapshot = decrypt_snapshot(&file.bytes, &password)
+            .context("远端同步文件无法解密，请检查同步密码")?;
+        if remote_snapshot.updated_at > cfg.last_synced_at {
+            cfg.last_synced_at = remote_snapshot.updated_at;
+            return Ok(SyncResult {
+                status: "已从远端恢复较新的同步数据".to_string(),
+                config: cfg,
+                downloaded: Some(remote_snapshot),
+            });
+        }
+    }
+
+    progress("正在加密并上传本机快照...".to_string());
+    let snapshot = build_snapshot(&local_config);
+    let encrypted = encrypt_snapshot(&snapshot, &password)?;
+    put_sync_file(&client, &cfg, &token, encrypted, remote.map(|f| f.sha)).await?;
+    cfg.last_synced_at = snapshot.updated_at;
+
+    Ok(SyncResult {
+        status: "已上传本机同步数据".to_string(),
+        config: cfg,
+        downloaded: None,
+    })
+}
+
+pub fn apply_downloaded_snapshot(store: &mut ConfigStore, snapshot: SyncSnapshot) -> Result<()> {
+    let mut sessions = snapshot.sessions;
+    restore_private_keys(&mut sessions, snapshot.private_keys)?;
+    store.replace_synced_data(sessions, snapshot.download_dir, snapshot.language);
+    Ok(())
+}
+
+pub fn clear_saved_secrets(cfg: &CloudSyncConfig) {
+    if !cfg.token_key.is_empty() {
+        let _ = delete_secret(&cfg.token_key);
+    }
+    if !cfg.password_key.is_empty() {
+        let _ = delete_secret(&cfg.password_key);
+    }
+}
+
+fn build_snapshot(cfg: &ConfigFile) -> SyncSnapshot {
+    SyncSnapshot {
+        version: 1,
+        updated_at: Utc::now().timestamp_millis(),
+        sessions: cfg.sessions.clone(),
+        download_dir: cfg.download_dir.clone(),
+        language: cfg.language.clone(),
+        private_keys: collect_private_keys(&cfg.sessions),
+    }
+}
+
+fn collect_private_keys(sessions: &[Session]) -> Vec<SyncedPrivateKey> {
+    let mut keys = Vec::new();
+    for session in sessions {
+        let path = session.private_key_path.trim();
+        if path.is_empty() {
+            continue;
+        }
+        let Ok(bytes) = fs::read(path) else {
+            continue;
+        };
+        let file_name = Path::new(path)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("id_key");
+        keys.push(SyncedPrivateKey {
+            session_id: session.id.clone(),
+            file_name: sanitize_file_name(file_name),
+            content_b64: STANDARD.encode(bytes),
+        });
+    }
+    keys
+}
+
+fn restore_private_keys(sessions: &mut [Session], keys: Vec<SyncedPrivateKey>) -> Result<()> {
+    if keys.is_empty() {
+        return Ok(());
+    }
+    let dir = ConfigStore::synced_keys_dir()?;
+    fs::create_dir_all(&dir).with_context(|| format!("failed to create {}", dir.display()))?;
+
+    for key in keys {
+        let bytes = STANDARD
+            .decode(key.content_b64.as_bytes())
+            .context("invalid private-key payload")?;
+        let path = unique_key_path(&dir, &key.session_id, &key.file_name);
+        fs::write(&path, bytes).with_context(|| format!("failed to write {}", path.display()))?;
+        set_private_key_permissions(&path);
+        if let Some(session) = sessions.iter_mut().find(|s| s.id == key.session_id) {
+            session.private_key_path = path.to_string_lossy().replace('\\', "/");
+        }
+    }
+    Ok(())
+}
+
+fn unique_key_path(dir: &Path, session_id: &str, name: &str) -> PathBuf {
+    let prefix = session_id.chars().take(8).collect::<String>();
+    dir.join(format!("{}_{}", prefix, sanitize_file_name(name)))
+}
+
+#[cfg(unix)]
+fn set_private_key_permissions(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o600));
+}
+
+#[cfg(not(unix))]
+fn set_private_key_permissions(_path: &Path) {}
+
+fn sanitize_file_name(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    for ch in name.chars() {
+        if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-') {
+            out.push(ch);
+        } else {
+            out.push('_');
+        }
+    }
+    if out.is_empty() {
+        "id_key".to_string()
+    } else {
+        out
+    }
+}
+
+fn encrypt_snapshot(snapshot: &SyncSnapshot, password: &str) -> Result<Vec<u8>> {
+    let plaintext = serde_json::to_vec(snapshot)?;
+    let mut salt = [0u8; 16];
+    let mut nonce = [0u8; 24];
+    OsRng.fill_bytes(&mut salt);
+    OsRng.fill_bytes(&mut nonce);
+    let key = derive_key(password, &salt)?;
+    let cipher = XChaCha20Poly1305::new((&key).into());
+    let ciphertext = cipher
+        .encrypt(XNonce::from_slice(&nonce), plaintext.as_ref())
+        .map_err(|err| anyhow!("encrypt failed: {err}"))?;
+    let bundle = EncryptedBundle {
+        version: 1,
+        kdf: "argon2id".to_string(),
+        cipher: "xchacha20poly1305".to_string(),
+        salt_b64: STANDARD.encode(salt),
+        nonce_b64: STANDARD.encode(nonce),
+        ciphertext_b64: STANDARD.encode(ciphertext),
+    };
+    Ok(serde_json::to_vec_pretty(&bundle)?)
+}
+
+fn decrypt_snapshot(bytes: &[u8], password: &str) -> Result<SyncSnapshot> {
+    let bundle: EncryptedBundle = serde_json::from_slice(bytes)?;
+    if bundle.kdf != "argon2id" || bundle.cipher != "xchacha20poly1305" {
+        bail!("unsupported sync encryption format");
+    }
+    let salt = STANDARD.decode(bundle.salt_b64.as_bytes())?;
+    let nonce = STANDARD.decode(bundle.nonce_b64.as_bytes())?;
+    if nonce.len() != 24 {
+        bail!("invalid sync nonce");
+    }
+    let key = derive_key(password, &salt)?;
+    let cipher = XChaCha20Poly1305::new((&key).into());
+    let plaintext = cipher
+        .decrypt(
+            XNonce::from_slice(&nonce),
+            STANDARD.decode(bundle.ciphertext_b64)?.as_ref(),
+        )
+        .map_err(|_| anyhow!("decrypt failed"))?;
+    Ok(serde_json::from_slice(&plaintext)?)
+}
+
+fn derive_key(password: &str, salt: &[u8]) -> Result<[u8; 32]> {
+    let mut key = [0u8; 32];
+    Argon2::default()
+        .hash_password_into(password.as_bytes(), salt, &mut key)
+        .map_err(|err| anyhow!("key derivation failed: {err}"))?;
+    Ok(key)
+}
+
+async fn github_login<F>(
+    client: &Client,
+    cfg: &CloudSyncConfig,
+    progress: &mut F,
+) -> Result<(String, String)>
+where
+    F: FnMut(String) + Send,
+{
+    let client_id = oauth_client_id(cfg, GITHUB_CLI_CLIENT_ID);
+    let code: GitHubDeviceCode = client
+        .post("https://github.com/login/device/code")
+        .header("Accept", "application/json")
+        .form(&[
+            ("client_id", client_id.as_str()),
+            ("scope", "repo read:user"),
+        ])
+        .send()
+        .await?
+        .json()
+        .await?;
+
+    let _ = webbrowser::open(&code.verification_uri);
+    progress(format!("请在浏览器授权 GitHub，验证码：{}", code.user_code));
+
+    let started = std::time::Instant::now();
+    let mut interval = code.interval.unwrap_or(5).max(1);
+    loop {
+        if started.elapsed() > Duration::from_secs(code.expires_in) {
+            bail!("GitHub 授权已超时");
+        }
+        tokio::time::sleep(Duration::from_secs(interval)).await;
+        let poll: GitHubDevicePoll = client
+            .post("https://github.com/login/oauth/access_token")
+            .header("Accept", "application/json")
+            .form(&[
+                ("client_id", client_id.as_str()),
+                ("device_code", code.device_code.as_str()),
+                ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
+            ])
+            .send()
+            .await?
+            .json()
+            .await?;
+
+        if let Some(token) = poll.access_token {
+            let username = fetch_username(client, cfg.provider, "", &token).await?;
+            return Ok((token, username));
+        }
+        match poll.error.as_deref() {
+            Some("authorization_pending") => {}
+            Some("slow_down") => interval += 5,
+            Some("expired_token") => bail!("GitHub 授权已过期"),
+            Some(err) => bail!(
+                "GitHub 授权失败：{}",
+                poll.error_description.unwrap_or_else(|| err.to_string())
+            ),
+            None => {
+                if let Some(next) = poll.interval {
+                    interval = next.max(1);
+                }
+            }
+        }
+    }
+}
+
+async fn gitea_login<F>(
+    client: &Client,
+    cfg: &CloudSyncConfig,
+    progress: &mut F,
+) -> Result<(String, String)>
+where
+    F: FnMut(String) + Send,
+{
+    let server = cfg.server_url.trim_end_matches('/');
+    let client_id = oauth_client_id(cfg, GITEA_TEA_CLIENT_ID);
+    let verifier = random_urlsafe(64);
+    let challenge = URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()));
+    let state = random_urlsafe(24);
+
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .context("无法启动本地 OAuth 回调端口")?;
+    let port = listener.local_addr()?.port();
+    let redirect_uri = format!("http://127.0.0.1:{port}");
+
+    let mut auth_url = Url::parse(&format!("{server}/login/oauth/authorize"))?;
+    auth_url
+        .query_pairs_mut()
+        .append_pair("client_id", &client_id)
+        .append_pair("redirect_uri", &redirect_uri)
+        .append_pair("response_type", "code")
+        .append_pair("scope", "repository user")
+        .append_pair("state", &state)
+        .append_pair("code_challenge", &challenge)
+        .append_pair("code_challenge_method", "S256");
+
+    let _ = webbrowser::open(auth_url.as_str());
+    progress("请在浏览器完成 Gitea 授权...".to_string());
+
+    let (code, returned_state) = wait_for_oauth_callback(listener).await?;
+    if returned_state != state {
+        bail!("OAuth state 校验失败");
+    }
+
+    let token_resp: OAuthTokenResponse = client
+        .post(format!("{server}/login/oauth/access_token"))
+        .header("Accept", "application/json")
+        .form(&[
+            ("grant_type", "authorization_code"),
+            ("code", code.as_str()),
+            ("redirect_uri", redirect_uri.as_str()),
+            ("client_id", client_id.as_str()),
+            ("code_verifier", verifier.as_str()),
+        ])
+        .send()
+        .await?
+        .json()
+        .await?;
+    if let Some(err) = token_resp.error {
+        bail!(
+            "Gitea 授权失败：{}",
+            token_resp.error_description.unwrap_or(err)
+        );
+    }
+    let token = token_resp
+        .access_token
+        .ok_or_else(|| anyhow!("Gitea 未返回 access_token"))?;
+    let username = fetch_username(client, cfg.provider, server, &token).await?;
+    Ok((token, username))
+}
+
+async fn wait_for_oauth_callback(listener: TcpListener) -> Result<(String, String)> {
+    let (mut stream, _) = timeout(Duration::from_secs(120), listener.accept())
+        .await
+        .context("等待浏览器授权超时")??;
+    let mut buf = [0u8; 8192];
+    let n = timeout(Duration::from_secs(5), stream.read(&mut buf))
+        .await
+        .context("读取 OAuth 回调超时")??;
+    let request = String::from_utf8_lossy(&buf[..n]);
+    let first_line = request.lines().next().unwrap_or_default();
+    let path = first_line.split_whitespace().nth(1).unwrap_or("/");
+    let callback_url = Url::parse(&format!("http://127.0.0.1{path}"))?;
+    let mut code = String::new();
+    let mut state = String::new();
+    let mut error = String::new();
+    for (key, value) in callback_url.query_pairs() {
+        match key.as_ref() {
+            "code" => code = value.into_owned(),
+            "state" => state = value.into_owned(),
+            "error" => error = value.into_owned(),
+            _ => {}
+        }
+    }
+    let body = if error.is_empty() {
+        "<html><body><h3>meatshell login complete</h3><p>You can close this window.</p></body></html>"
+    } else {
+        "<html><body><h3>meatshell login failed</h3><p>You can close this window.</p></body></html>"
+    };
+    let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(),
+        body
+    );
+    let _ = stream.write_all(response.as_bytes()).await;
+    if !error.is_empty() {
+        bail!("浏览器授权失败：{error}");
+    }
+    if code.is_empty() {
+        bail!("OAuth 回调缺少授权码");
+    }
+    Ok((code, state))
+}
+
+async fn fetch_username(
+    client: &Client,
+    provider: CloudProvider,
+    server: &str,
+    token: &str,
+) -> Result<String> {
+    let url = match provider {
+        CloudProvider::Github => "https://api.github.com/user".to_string(),
+        CloudProvider::Gitea => format!("{}/api/v1/user", server.trim_end_matches('/')),
+    };
+    let resp = client.get(url).bearer_auth(token).send().await?;
+    let text = checked_text(resp).await?;
+    let user: UserInfo = serde_json::from_str(&text)?;
+    user.login
+        .or(user.username)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| anyhow!("无法读取账号用户名"))
+}
+
+async fn ensure_repo(client: &Client, cfg: &CloudSyncConfig, token: &str) -> Result<()> {
+    if get_repo(client, cfg, token).await?.is_some() {
+        return Ok(());
+    }
+    let api = api_base(cfg);
+    let resp = match cfg.provider {
+        CloudProvider::Github => {
+            client
+                .post(format!("{api}/user/repos"))
+                .bearer_auth(token)
+                .json(&serde_json::json!({
+                    "name": cfg.repo_name,
+                    "private": true,
+                    "auto_init": true,
+                }))
+                .send()
+                .await?
+        }
+        CloudProvider::Gitea => {
+            client
+                .post(format!("{api}/user/repos"))
+                .bearer_auth(token)
+                .json(&serde_json::json!({
+                    "name": cfg.repo_name,
+                    "private": true,
+                    "auto_init": true,
+                }))
+                .send()
+                .await?
+        }
+    };
+    let text = checked_text(resp).await?;
+    let repo: RepoInfo = serde_json::from_str(&text).unwrap_or(RepoInfo { owner: None });
+    if cfg.repo_owner.is_empty() {
+        if let Some(owner) = repo.owner {
+            tracing::debug!("created sync repo under {}", owner.login);
+        }
+    }
+    Ok(())
+}
+
+async fn get_repo(client: &Client, cfg: &CloudSyncConfig, token: &str) -> Result<Option<RepoInfo>> {
+    let api = api_base(cfg);
+    let owner = repo_owner(cfg)?;
+    let repo = urlencoding::encode(&cfg.repo_name);
+    let url = format!("{api}/repos/{owner}/{repo}");
+    let resp = client.get(url).bearer_auth(token).send().await?;
+    if resp.status() == StatusCode::NOT_FOUND {
+        return Ok(None);
+    }
+    let text = checked_text(resp).await?;
+    Ok(Some(serde_json::from_str(&text)?))
+}
+
+async fn get_sync_file(
+    client: &Client,
+    cfg: &CloudSyncConfig,
+    token: &str,
+) -> Result<Option<RemoteFile>> {
+    let api = api_base(cfg);
+    let owner = repo_owner(cfg)?;
+    let repo = urlencoding::encode(&cfg.repo_name);
+    let path = urlencoding::encode(SYNC_FILE);
+    let url = format!("{api}/repos/{owner}/{repo}/contents/{path}");
+    let resp = client.get(url).bearer_auth(token).send().await?;
+    if resp.status() == StatusCode::NOT_FOUND {
+        return Ok(None);
+    }
+    let text = checked_text(resp).await?;
+    let info: ContentInfo = serde_json::from_str(&text)?;
+    let mut content = info.content.unwrap_or_default();
+    content.retain(|ch| !ch.is_whitespace());
+    let bytes = STANDARD
+        .decode(content.as_bytes())
+        .context("远端同步文件不是有效 base64")?;
+    let sha = info.sha.unwrap_or_default();
+    Ok(Some(RemoteFile { bytes, sha }))
+}
+
+async fn put_sync_file(
+    client: &Client,
+    cfg: &CloudSyncConfig,
+    token: &str,
+    content: Vec<u8>,
+    sha: Option<String>,
+) -> Result<()> {
+    let api = api_base(cfg);
+    let owner = repo_owner(cfg)?;
+    let repo = urlencoding::encode(&cfg.repo_name);
+    let path = urlencoding::encode(SYNC_FILE);
+    let url = format!("{api}/repos/{owner}/{repo}/contents/{path}");
+    let mut body = serde_json::json!({
+        "message": "sync meatshell data",
+        "content": STANDARD.encode(content),
+    });
+    if let Some(sha) = sha.filter(|s| !s.is_empty()) {
+        body["sha"] = serde_json::Value::String(sha);
+    }
+    let resp = client
+        .put(url)
+        .bearer_auth(token)
+        .json(&body)
+        .send()
+        .await?;
+    let _ = checked_text(resp).await?;
+    Ok(())
+}
+
+async fn checked_text(resp: reqwest::Response) -> Result<String> {
+    let status = resp.status();
+    let text = resp.text().await.unwrap_or_default();
+    if !status.is_success() {
+        let short = text.chars().take(300).collect::<String>();
+        bail!("HTTP {status}: {short}");
+    }
+    Ok(text)
+}
+
+fn api_base(cfg: &CloudSyncConfig) -> String {
+    match cfg.provider {
+        CloudProvider::Github => "https://api.github.com".to_string(),
+        CloudProvider::Gitea => format!("{}/api/v1", cfg.server_url.trim_end_matches('/')),
+    }
+}
+
+fn repo_owner(cfg: &CloudSyncConfig) -> Result<String> {
+    let owner = if cfg.repo_owner.trim().is_empty() {
+        cfg.username.trim()
+    } else {
+        cfg.repo_owner.trim()
+    };
+    if owner.is_empty() {
+        bail!("缺少同步仓库 owner");
+    }
+    Ok(urlencoding::encode(owner).to_string())
+}
+
+fn http_client() -> Result<Client> {
+    Client::builder()
+        .user_agent(format!("meatshell/{}", env!("CARGO_PKG_VERSION")))
+        .timeout(Duration::from_secs(30))
+        .build()
+        .context("failed to build HTTP client")
+}
+
+fn random_urlsafe(len: usize) -> String {
+    let mut bytes = vec![0u8; len];
+    OsRng.fill_bytes(&mut bytes);
+    URL_SAFE_NO_PAD.encode(bytes)
+}
+
+fn oauth_client_id(cfg: &CloudSyncConfig, fallback: &str) -> String {
+    if !cfg.client_id.trim().is_empty() {
+        return cfg.client_id.trim().to_string();
+    }
+    match cfg.provider {
+        CloudProvider::Github => std::env::var("MEATSHELL_GITHUB_CLIENT_ID")
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| fallback.to_string()),
+        CloudProvider::Gitea => std::env::var("MEATSHELL_GITEA_CLIENT_ID")
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| fallback.to_string()),
+    }
+}
+
+fn normalize_server(provider: CloudProvider, server: &str) -> String {
+    match provider {
+        CloudProvider::Github => "https://github.com".to_string(),
+        CloudProvider::Gitea => {
+            let trimmed = server.trim().trim_end_matches('/');
+            if trimmed.is_empty() {
+                "https://gitea.com".to_string()
+            } else if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+                trimmed.to_string()
+            } else {
+                format!("https://{trimmed}")
+            }
+        }
+    }
+}
+
+fn secret_key(cfg: &CloudSyncConfig, kind: &str) -> String {
+    let server = cfg.server_url.replace(['/', ':'], "_");
+    let user = if cfg.username.is_empty() {
+        "unknown"
+    } else {
+        cfg.username.as_str()
+    };
+    format!("sync:{}:{server}:{user}:{kind}", cfg.provider.as_str())
+}
+
+fn store_secret(key: &str, secret: &str) -> Result<()> {
+    let entry = keyring::Entry::new(KEYRING_SERVICE, key)?;
+    entry.set_password(secret)?;
+    Ok(())
+}
+
+fn read_secret(key: &str) -> Result<String> {
+    if key.is_empty() {
+        bail!("empty secret key");
+    }
+    let entry = keyring::Entry::new(KEYRING_SERVICE, key)?;
+    Ok(entry.get_password()?)
+}
+
+fn delete_secret(key: &str) -> Result<()> {
+    let entry = keyring::Entry::new(KEYRING_SERVICE, key)?;
+    entry.delete_credential()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{AuthMethod, Secret};
+
+    #[test]
+    fn encrypted_snapshot_roundtrip() {
+        let snapshot = SyncSnapshot {
+            version: 1,
+            updated_at: 42,
+            sessions: vec![Session {
+                id: "s1".to_string(),
+                name: "demo".to_string(),
+                host: "127.0.0.1".to_string(),
+                port: 22,
+                user: "root".to_string(),
+                auth: AuthMethod::Password,
+                password: Secret::new("pw"),
+                private_key_path: String::new(),
+                proxy: String::new(),
+                last_used: None,
+            }],
+            download_dir: "/tmp".to_string(),
+            language: "zh".to_string(),
+            private_keys: Vec::new(),
+        };
+        let encrypted = encrypt_snapshot(&snapshot, "sync-pass").unwrap();
+        let decrypted = decrypt_snapshot(&encrypted, "sync-pass").unwrap();
+        assert_eq!(decrypted.updated_at, 42);
+        assert_eq!(decrypted.sessions[0].password.as_str(), "pw");
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,7 +44,11 @@ impl Drop for Secret {
 impl std::fmt::Debug for Secret {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // Never reveal the contents in logs / debug output.
-        f.write_str(if self.0.is_empty() { "Secret(\"\")" } else { "Secret(***)" })
+        f.write_str(if self.0.is_empty() {
+            "Secret(\"\")"
+        } else {
+            "Secret(***)"
+        })
     }
 }
 
@@ -122,6 +126,100 @@ impl Session {
     }
 }
 
+/// Browser-login sync provider.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum CloudProvider {
+    Github,
+    Gitea,
+}
+
+impl CloudProvider {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            CloudProvider::Github => "github",
+            CloudProvider::Gitea => "gitea",
+        }
+    }
+
+    pub fn label(&self) -> &'static str {
+        match self {
+            CloudProvider::Github => "GitHub",
+            CloudProvider::Gitea => "Gitea",
+        }
+    }
+
+    pub fn from_str(s: &str) -> Self {
+        match s {
+            "gitea" => CloudProvider::Gitea,
+            _ => CloudProvider::Github,
+        }
+    }
+}
+
+/// Non-secret sync settings. OAuth tokens and the sync password live in the
+/// OS credential store under the key names below; the remote repository only
+/// receives password-encrypted snapshots.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CloudSyncConfig {
+    #[serde(default = "default_cloud_provider")]
+    pub provider: CloudProvider,
+    #[serde(default = "default_gitea_server")]
+    pub server_url: String,
+    #[serde(default = "default_sync_repo")]
+    pub repo_name: String,
+    #[serde(default)]
+    pub repo_owner: String,
+    #[serde(default)]
+    pub username: String,
+    #[serde(default)]
+    pub auto_sync: bool,
+    #[serde(default = "default_sync_interval_minutes")]
+    pub interval_minutes: u64,
+    #[serde(default)]
+    pub last_synced_at: i64,
+    #[serde(default)]
+    pub token_key: String,
+    #[serde(default)]
+    pub password_key: String,
+    #[serde(default)]
+    pub client_id: String,
+}
+
+fn default_cloud_provider() -> CloudProvider {
+    CloudProvider::Gitea
+}
+
+fn default_gitea_server() -> String {
+    "https://gitea.com".to_string()
+}
+
+fn default_sync_repo() -> String {
+    "meatshell-sync".to_string()
+}
+
+fn default_sync_interval_minutes() -> u64 {
+    15
+}
+
+impl Default for CloudSyncConfig {
+    fn default() -> Self {
+        Self {
+            provider: default_cloud_provider(),
+            server_url: default_gitea_server(),
+            repo_name: default_sync_repo(),
+            repo_owner: String::new(),
+            username: String::new(),
+            auto_sync: false,
+            interval_minutes: default_sync_interval_minutes(),
+            last_synced_at: 0,
+            token_key: String::new(),
+            password_key: String::new(),
+            client_id: String::new(),
+        }
+    }
+}
+
 /// On-disk layout. Keep additive to ease forward-compat.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ConfigFile {
@@ -133,6 +231,9 @@ pub struct ConfigFile {
     /// UI language code: "zh" (default) or "en".
     #[serde(default)]
     pub language: String,
+    /// Optional GitHub/Gitea private-repository sync settings.
+    #[serde(default)]
+    pub cloud_sync: CloudSyncConfig,
 }
 
 pub struct ConfigStore {
@@ -147,9 +248,8 @@ impl ConfigStore {
     pub fn load() -> Result<Self> {
         let path = Self::config_path()?;
         if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).with_context(|| {
-                format!("failed to create config dir {}", parent.display())
-            })?;
+            fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create config dir {}", parent.display()))?;
         }
 
         let cache = if path.exists() {
@@ -180,6 +280,12 @@ impl ConfigStore {
         Ok(dirs.config_dir().join("sessions.json"))
     }
 
+    pub fn synced_keys_dir() -> Result<PathBuf> {
+        let dirs = ProjectDirs::from("dev", "meatshell", "meatshell")
+            .context("could not determine user config directory")?;
+        Ok(dirs.config_dir().join("synced_keys"))
+    }
+
     pub fn sessions(&self) -> &[Session] {
         &self.cache.sessions
     }
@@ -190,12 +296,7 @@ impl ConfigStore {
     }
 
     pub fn upsert(&mut self, session: Session) {
-        if let Some(existing) = self
-            .cache
-            .sessions
-            .iter_mut()
-            .find(|s| s.id == session.id)
-        {
+        if let Some(existing) = self.cache.sessions.iter_mut().find(|s| s.id == session.id) {
             *existing = session;
         } else {
             self.cache.sessions.push(session);
@@ -231,13 +332,35 @@ impl ConfigStore {
         self.cache.language = lang;
     }
 
+    pub fn cloud_sync(&self) -> &CloudSyncConfig {
+        &self.cache.cloud_sync
+    }
+
+    pub fn set_cloud_sync(&mut self, cfg: CloudSyncConfig) {
+        self.cache.cloud_sync = cfg;
+    }
+
+    pub fn snapshot(&self) -> ConfigFile {
+        self.cache.clone()
+    }
+
+    pub fn replace_synced_data(
+        &mut self,
+        sessions: Vec<Session>,
+        download_dir: String,
+        language: String,
+    ) {
+        self.cache.sessions = sessions;
+        self.cache.download_dir = download_dir;
+        self.cache.language = language;
+    }
+
     pub fn save(&self) -> Result<()> {
         let raw = serde_json::to_string_pretty(&self.cache)?;
         // Write to a sibling temp file then rename — cheap atomicity on most
         // platforms. Good enough for a config file.
         let tmp = self.path.with_extension("json.tmp");
-        fs::write(&tmp, raw)
-            .with_context(|| format!("failed to write {}", tmp.display()))?;
+        fs::write(&tmp, raw).with_context(|| format!("failed to write {}", tmp.display()))?;
         fs::rename(&tmp, &self.path)
             .with_context(|| format!("failed to finalise {}", self.path.display()))?;
         Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 mod app;
+mod cloud_sync;
 mod config;
 mod i18n;
 mod proxy;

--- a/ui/app.slint
+++ b/ui/app.slint
@@ -88,6 +88,7 @@ export component AppWindow inherits Window {
     in-out property <bool> download-open: false;  // download manager popup
     in-out property <bool> settings-open: false;  // settings menu popup
     in-out property <bool> about-open: false;     // centered About dialog
+    in-out property <bool> sync-open: false;      // cloud sync dialog
     in property <string> download-dir;      // preset SFTP download folder ("" = ask)
     in property <[TransferInfo]> transfers; // download/upload records (newest first)
     in property <[string]> about-libs;      // open-source libraries used
@@ -97,6 +98,21 @@ export component AppWindow inherits Window {
     callback open-download-dir();            // reveal the folder in the OS
     callback clear-transfers();              // wipe the transfer history
     callback set-language(string);           // switch UI language ("zh" / "en")
+
+    // --- Cloud sync settings ---------------------------------------------
+    in-out property <string> cloud-provider: "gitea";
+    in-out property <string> cloud-server: "https://gitea.com";
+    in-out property <string> cloud-repo: "meatshell-sync";
+    in-out property <string> cloud-password;
+    in-out property <bool> cloud-auto-sync: false;
+    in-out property <string> cloud-sync-interval: "15";
+    in property <string> cloud-status;
+    in property <string> cloud-username;
+    in property <bool> cloud-logged-in: false;
+    callback cloud-save-settings(string, string, string, bool, string);
+    callback cloud-login(string, string, string, string, bool, string);
+    callback cloud-sync-now(string, string, string, string, bool, string);
+    callback cloud-disconnect();
 
     // --- Session list ------------------------------------------------------
     in property <[SessionInfo]> sessions;
@@ -519,7 +535,7 @@ export component AppWindow inherits Window {
         x: parent.width - 196px;
         y: 40px;
         width: 198px;
-        height: 104px;
+        height: 136px;
         visible: root.settings-open;
         background: Theme.bg-panel;
         border-radius: Theme.radius-md;
@@ -572,6 +588,27 @@ export component AppWindow inherits Window {
                            color: Theme.text-secondary; font-size: Theme.fs-sm;
                            vertical-alignment: center; }
                     Text { text: root.lang-en ? "切换到中文" : "Switch to English";
+                           color: Theme.text-primary; font-size: Theme.fs-md;
+                           vertical-alignment: center; horizontal-stretch: 1; }
+                }
+            }
+            Rectangle {
+                height: 28px;
+                border-radius: Theme.radius-sm;
+                background: sync-ta.has-hover ? Theme.bg-hover : transparent;
+                sync-ta := TouchArea {
+                    mouse-cursor: pointer;
+                    clicked => {
+                        root.settings-open = false;
+                        root.sync-open = true;
+                    }
+                }
+                HorizontalLayout {
+                    padding-left: 8px; spacing: 8px;
+                    Text { text: "\u{E627}"; font-family: "Material Icons"; // sync
+                           color: Theme.text-secondary; font-size: Theme.fs-sm;
+                           vertical-alignment: center; }
+                    Text { text: root.lang-en ? "Sync settings" : "同步设置";
                            color: Theme.text-primary; font-size: Theme.fs-md;
                            vertical-alignment: center; horizontal-stretch: 1; }
                 }
@@ -683,6 +720,286 @@ export component AppWindow inherits Window {
                             wrap: no-wrap;
                             overflow: elide;
                         }
+                    }
+                }
+            }
+        }
+    }
+
+    // --- Cloud sync dialog ------------------------------------------------
+    Rectangle {
+        width: parent.width;
+        height: parent.height;
+        visible: root.sync-open;
+        background: #00000080;
+        TouchArea { clicked => { root.sync-open = false; } }
+
+        Rectangle {
+            x: (parent.width - self.width) / 2;
+            y: (parent.height - self.height) / 2;
+            width: min(parent.width - 40px, 480px);
+            height: min(parent.height - 40px, 560px);
+            background: Theme.bg-panel;
+            border-radius: Theme.radius-md;
+            border-width: 1px;
+            border-color: Theme.border-strong;
+            drop-shadow-blur: 24px;
+            drop-shadow-color: #000000a0;
+
+            TouchArea {}
+
+            VerticalLayout {
+                padding: 18px;
+                spacing: 10px;
+
+                HorizontalLayout {
+                    Text {
+                        text: root.lang-en ? "Sync settings" : "同步设置";
+                        color: Theme.text-primary;
+                        font-size: Theme.fs-lg;
+                        font-weight: 700;
+                        horizontal-stretch: 1;
+                        vertical-alignment: center;
+                    }
+                    Rectangle {
+                        width: 22px; height: 22px;
+                        border-radius: Theme.radius-sm;
+                        background: sync-close-ta.has-hover ? Theme.bg-hover : transparent;
+                        sync-close-ta := TouchArea {
+                            mouse-cursor: pointer;
+                            clicked => { root.sync-open = false; }
+                        }
+                        Text { text: "\u{E5CD}"; font-family: "Material Icons";
+                               color: Theme.text-secondary; font-size: Theme.fs-sm;
+                               horizontal-alignment: center; vertical-alignment: center; }
+                    }
+                }
+
+                HorizontalLayout {
+                    spacing: 8px;
+                    Rectangle {
+                        height: 30px;
+                        horizontal-stretch: 1;
+                        border-radius: Theme.radius-sm;
+                        border-width: 1px;
+                        border-color: root.cloud-provider == "gitea" ? Theme.accent : Theme.border-subtle;
+                        background: root.cloud-provider == "gitea" ? Theme.bg-active : (gitea-ta.has-hover ? Theme.bg-hover : Theme.bg-root);
+                        gitea-ta := TouchArea {
+                            mouse-cursor: pointer;
+                            clicked => {
+                                root.cloud-provider = "gitea";
+                                if root.cloud-server == "" || root.cloud-server == "https://github.com" {
+                                    root.cloud-server = "https://gitea.com";
+                                }
+                            }
+                        }
+                        Text { text: "Gitea"; color: Theme.text-primary; font-size: Theme.fs-md;
+                               horizontal-alignment: center; vertical-alignment: center; }
+                    }
+                    Rectangle {
+                        height: 30px;
+                        horizontal-stretch: 1;
+                        border-radius: Theme.radius-sm;
+                        border-width: 1px;
+                        border-color: root.cloud-provider == "github" ? Theme.accent : Theme.border-subtle;
+                        background: root.cloud-provider == "github" ? Theme.bg-active : (github-ta.has-hover ? Theme.bg-hover : Theme.bg-root);
+                        github-ta := TouchArea {
+                            mouse-cursor: pointer;
+                            clicked => {
+                                root.cloud-provider = "github";
+                                root.cloud-server = "https://github.com";
+                            }
+                        }
+                        Text { text: "GitHub"; color: Theme.text-primary; font-size: Theme.fs-md;
+                               horizontal-alignment: center; vertical-alignment: center; }
+                    }
+                }
+
+                Text {
+                    text: root.cloud-logged-in
+                        ? (root.lang-en ? "Signed in as " : "已登录：") + root.cloud-username
+                        : (root.lang-en ? "Not signed in" : "未登录");
+                    color: root.cloud-logged-in ? Theme.success : Theme.text-muted;
+                    font-size: Theme.fs-sm;
+                    overflow: elide;
+                }
+
+                Text { text: root.lang-en ? "Server" : "服务器"; color: Theme.text-secondary; font-size: Theme.fs-sm; }
+                Rectangle {
+                    height: 32px;
+                    border-radius: Theme.radius-sm;
+                    border-width: 1px;
+                    border-color: sync-server-input.has-focus ? Theme.accent : Theme.border-subtle;
+                    background: root.cloud-provider == "github" ? Theme.bg-elevated : Theme.bg-root;
+                    sync-server-input := TextInput {
+                        x: 10px; y: 0px; width: parent.width - 20px; height: parent.height;
+                        enabled: root.cloud-provider != "github";
+                        text <=> root.cloud-server;
+                        color: root.cloud-provider == "github" ? Theme.text-muted : Theme.text-primary;
+                        font-size: Theme.fs-md;
+                        vertical-alignment: center;
+                        single-line: true;
+                    }
+                }
+
+                Text { text: root.lang-en ? "Private repository" : "私有仓库"; color: Theme.text-secondary; font-size: Theme.fs-sm; }
+                Rectangle {
+                    height: 32px;
+                    border-radius: Theme.radius-sm;
+                    border-width: 1px;
+                    border-color: sync-repo-input.has-focus ? Theme.accent : Theme.border-subtle;
+                    background: Theme.bg-root;
+                    sync-repo-input := TextInput {
+                        x: 10px; y: 0px; width: parent.width - 20px; height: parent.height;
+                        text <=> root.cloud-repo;
+                        color: Theme.text-primary;
+                        font-size: Theme.fs-md;
+                        vertical-alignment: center;
+                        single-line: true;
+                    }
+                }
+
+                Text { text: root.lang-en ? "Sync password" : "同步密码"; color: Theme.text-secondary; font-size: Theme.fs-sm; }
+                Rectangle {
+                    height: 32px;
+                    border-radius: Theme.radius-sm;
+                    border-width: 1px;
+                    border-color: sync-pass-input.has-focus ? Theme.accent : Theme.border-subtle;
+                    background: Theme.bg-root;
+                    sync-pass-input := TextInput {
+                        x: 10px; y: 0px; width: parent.width - 20px; height: parent.height;
+                        text <=> root.cloud-password;
+                        color: Theme.text-primary;
+                        font-size: Theme.fs-md;
+                        vertical-alignment: center;
+                        single-line: true;
+                        input-type: InputType.password;
+                    }
+                    if root.cloud-password == "" : Text {
+                        x: 10px; y: 0px; height: parent.height;
+                        text: root.lang-en ? "Required for first login or password change" : "首次登录或更换密码时填写";
+                        color: Theme.text-muted;
+                        font-size: Theme.fs-sm;
+                        vertical-alignment: center;
+                    }
+                }
+
+                HorizontalLayout {
+                    spacing: 10px;
+                    Rectangle {
+                        width: 22px; height: 22px;
+                        border-radius: Theme.radius-sm;
+                        border-width: 1px;
+                        border-color: Theme.border-subtle;
+                        background: root.cloud-auto-sync ? Theme.accent : Theme.bg-root;
+                        auto-ta := TouchArea {
+                            mouse-cursor: pointer;
+                            clicked => { root.cloud-auto-sync = !root.cloud-auto-sync; }
+                        }
+                        Text { text: root.cloud-auto-sync ? "\u{E5CA}" : "";
+                               font-family: "Material Icons"; color: #ffffff; font-size: Theme.fs-sm;
+                               horizontal-alignment: center; vertical-alignment: center; }
+                    }
+                    Text { text: root.lang-en ? "Auto sync every" : "自动同步间隔";
+                           color: Theme.text-primary; font-size: Theme.fs-md;
+                           vertical-alignment: center; }
+                    Rectangle {
+                        width: 64px; height: 30px;
+                        border-radius: Theme.radius-sm;
+                        border-width: 1px;
+                        border-color: sync-interval-input.has-focus ? Theme.accent : Theme.border-subtle;
+                        background: Theme.bg-root;
+                        sync-interval-input := TextInput {
+                            x: 8px; y: 0px; width: parent.width - 16px; height: parent.height;
+                            text <=> root.cloud-sync-interval;
+                            color: Theme.text-primary;
+                            font-size: Theme.fs-md;
+                            horizontal-alignment: center;
+                            vertical-alignment: center;
+                            single-line: true;
+                        }
+                    }
+                    Text { text: root.lang-en ? "minutes" : "分钟";
+                           color: Theme.text-primary; font-size: Theme.fs-md;
+                           vertical-alignment: center; horizontal-stretch: 1; }
+                }
+
+                Rectangle {
+                    height: 54px;
+                    border-radius: Theme.radius-sm;
+                    background: Theme.bg-root;
+                    Text {
+                        x: 10px; y: 0px;
+                        width: parent.width - 20px;
+                        height: parent.height;
+                        text: root.cloud-status;
+                        color: Theme.text-secondary;
+                        font-size: Theme.fs-sm;
+                        vertical-alignment: center;
+                        wrap: word-wrap;
+                    }
+                }
+
+                VerticalLayout {
+                    vertical-stretch: 1;
+                }
+
+                HorizontalLayout {
+                    spacing: 8px;
+                    Rectangle {
+                        width: 82px; height: 30px;
+                        border-radius: Theme.radius-sm;
+                        border-width: 1px;
+                        border-color: Theme.border-subtle;
+                        background: save-sync-ta.has-hover ? Theme.bg-hover : Theme.bg-panel;
+                        save-sync-ta := TouchArea {
+                            mouse-cursor: pointer;
+                            clicked => {
+                                root.cloud-save-settings(root.cloud-provider, root.cloud-server, root.cloud-repo, root.cloud-auto-sync, root.cloud-sync-interval);
+                            }
+                        }
+                        Text { text: root.lang-en ? "Save" : "保存"; color: Theme.text-primary; font-size: Theme.fs-md;
+                               horizontal-alignment: center; vertical-alignment: center; }
+                    }
+                    Rectangle {
+                        width: 82px; height: 30px;
+                        border-radius: Theme.radius-sm;
+                        border-width: 1px;
+                        border-color: Theme.border-subtle;
+                        background: logout-sync-ta.has-hover ? Theme.bg-hover : Theme.bg-panel;
+                        logout-sync-ta := TouchArea {
+                            mouse-cursor: pointer;
+                            clicked => { root.cloud-disconnect(); }
+                        }
+                        Text { text: root.lang-en ? "Sign out" : "退出"; color: Theme.text-primary; font-size: Theme.fs-md;
+                               horizontal-alignment: center; vertical-alignment: center; }
+                    }
+                    Rectangle { horizontal-stretch: 1; }
+                    Rectangle {
+                        width: 86px; height: 30px;
+                        border-radius: Theme.radius-sm;
+                        background: manual-sync-ta.has-hover ? Theme.bg-hover : Theme.bg-elevated;
+                        manual-sync-ta := TouchArea {
+                            mouse-cursor: pointer;
+                            clicked => {
+                                root.cloud-sync-now(root.cloud-provider, root.cloud-server, root.cloud-repo, root.cloud-password, root.cloud-auto-sync, root.cloud-sync-interval);
+                            }
+                        }
+                        Text { text: root.lang-en ? "Sync now" : "手动同步"; color: Theme.text-primary; font-size: Theme.fs-md;
+                               horizontal-alignment: center; vertical-alignment: center; }
+                    }
+                    Rectangle {
+                        width: 86px; height: 30px;
+                        border-radius: Theme.radius-sm;
+                        background: login-sync-ta.has-hover ? Theme.accent-hover : Theme.accent;
+                        login-sync-ta := TouchArea {
+                            mouse-cursor: pointer;
+                            clicked => {
+                                root.cloud-login(root.cloud-provider, root.cloud-server, root.cloud-repo, root.cloud-password, root.cloud-auto-sync, root.cloud-sync-interval);
+                            }
+                        }
+                        Text { text: root.lang-en ? "Login" : "登录"; color: #ffffff; font-size: Theme.fs-md;
+                               font-weight: 600; horizontal-alignment: center; vertical-alignment: center; }
                     }
                 }
             }


### PR DESCRIPTION
## 变更内容

本 PR 添加账号同步功能，支持通过 GitHub 或 Gitea 登录后，将 meatshell 的配置同步到私有仓库。

主要内容：

- 新增 `cloud_sync` 模块，负责 GitHub/Gitea 登录、私有仓库创建、同步文件读写和加密快照处理。
- 支持 Gitea OAuth2 Authorization Code + PKCE 浏览器登录流程，并保留环境变量覆盖 client id 的能力。
- 支持 GitHub device flow 浏览器登录。
- 同步数据写入私有仓库中的 `meatshell-sync.enc`，使用同步密码经 Argon2 派生密钥后用 XChaCha20-Poly1305 加密。
- OAuth token 和同步密码通过系统 keyring 保存，不写入配置文件明文。
- 扩展配置结构，保存同步 provider、server、仓库名、用户名、自动同步间隔和上次同步时间等非敏感元数据。
- 在设置菜单中新增“同步设置”弹窗，提供登录、退出、保存设置、手动同步、自动同步开关和同步间隔配置。
- 同步快照包含会话、下载目录、语言设置；如果私钥路径对应的本地文件存在，也会加密打包，恢复时写入 `synced_keys` 目录并更新会话私钥路径。

## 用户影响

用户可以在多台机器之间通过自己的 GitHub/Gitea 私有仓库同步 meatshell 配置。首次登录需要填写同步密码，后续可使用保存的凭据自动定时同步，也可以手动触发同步。

## 验证

已执行：

```bash
cargo check
cargo test
```

结果：通过。现有 warning 仍为项目已有的 dead-code / Slint padding 提示。
