### PR TITLE
fix(terminal):修复按下ALT后导致的命令清空

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2580,6 +2580,23 @@ fn key_to_pty_bytes(key: &str, ctrl: bool, alt: bool, app_cursor: bool) -> Vec<u
         return vec![];
     }
 
+    // --- Slint modifier key codes — never forward to PTY -------------------
+    // Slint encodes bare modifier keys as C0 control characters:
+    //   Shift=0x10, Ctrl=0x11, Alt=0x12, AltGr=0x13, CapsLock=0x14,
+    //   ShiftR=0x15, CtrlR=0x16, Meta=0x17, MetaR=0x18
+    // When the user presses Alt alone, key="\u{0012}" with alt=true reaches
+    // the Alt+key branch below, which prefixes it with ESC (0x1b) and sends
+    // both bytes to the PTY.  Bash/readline interprets the leading ESC as
+    // an interrupt and discards the current input line — the "Alt clears the
+    // command" bug.  The same applies to the other modifier key codes: they
+    // must never be sent to the remote terminal.
+    if let Some(c) = key.chars().next() {
+        let cp = c as u32;
+        if key.chars().count() == 1 && (0x10..=0x18).contains(&cp) {
+            return vec![];
+        }
+    }
+
     // --- Ctrl + letter: synthesise C0 control character --------------------
     // Two cases:
     //   A) Platform already encoded the control char in `key` (e.g. "\x18" for


### PR DESCRIPTION
… (#43)

Slint 将单独的修饰键编码为 C0 控制字符（Shift=0x10, Ctrl=0x11, Alt=0x12,
AltGr=0x13, CapsLock=0x14, ShiftR=0x15, CtrlR=0x16, Meta=0x17, MetaR=0x18）。

当用户单独按下 Alt 键时，Slint 将 key="\u{0012}" 及 alt=true 传入
key_to_pty_bytes()。随后 Alt+key 分支在其前面加上 ESC (0x1b) 前缀，并将
这两个字节发送至 PTY。Bash/readline 将前导 ESC 解释为中断信号，从而丢弃
当前输入行——这就是"按下 Alt 清空命令"这一 bug 的成因。

修复方案：在 Alt+key 处理逻辑之前过滤掉 Slint 修饰键码（0x10–0x18），
返回空字节数组，确保不会向 PTY 发送任何内容。