### PR TITLE
feat: 添加终端双击选词功能并适配macOS快捷键

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -202,6 +202,7 @@ pub fn run() -> Result<()> {
     // its native decorations, so turn the custom bar off there.
     #[cfg(target_os = "macos")]
     window.set_custom_titlebar(false);
+    window.set_is_mac(cfg!(target_os = "macos"));
 
     // --- Detachable process monitor window (#23) -----------------------------
     // The process table is its own top-level OS window so it can be dragged
@@ -5120,6 +5121,27 @@ fn wire_key_input(
             }
         });
     }
+    {
+        let bufs_sel = bufs.clone();
+        let weak = window.as_weak();
+        window.on_term_select_word(move |tab_id: SharedString, row: i32, col: i32| {
+            let tid = tab_id.to_string();
+            let text = {
+                let mut map = bufs_sel.lock().unwrap();
+                let Some(buf) = map.get_mut(&tid) else { return };
+                let (rows, cols) = buf.parser.screen().size();
+                let r = row.clamp(0, rows.saturating_sub(1) as i32) as u16;
+                let c = col.clamp(0, cols.saturating_sub(1) as i32) as u16;
+                buf.select_word_at(r, c)
+            };
+            if let Some(t) = text {
+                std::thread::spawn(move || clipboard_set_text(t));
+            }
+            if let Some(win) = weak.upgrade() {
+                rebuild_tab_display(&win, &bufs_sel, &tid);
+            }
+        });
+    }
     // Auto-scroll while drag-selecting past the visible top/bottom edge.  The
     // anchor is in absolute coordinates so it stays pinned no matter how far the
     // view moves; we only advance the scrollback view and re-point the focus at
@@ -5887,6 +5909,77 @@ impl TermBuffer {
             }
         }
         out
+    }
+
+    fn select_word_at(&mut self, vis_row: u16, vis_col: u16) -> Option<String> {
+        let abs = self.vis_to_abs(vis_row);
+        let s = self.parser.screen();
+        let (rows, cols) = s.size();
+        let line_str = if abs < self.history.len() {
+            self.history[abs].0.clone()
+        } else {
+            let live_row_idx = abs - self.history.len();
+            if live_row_idx < rows as usize {
+                build_row(s, live_row_idx as u16, cols).0
+            } else {
+                return None;
+            }
+        };
+
+        let chars: Vec<char> = line_str.chars().collect();
+        if chars.is_empty() {
+            return None;
+        }
+        let prefix = cell_prefix(&chars);
+        let char_idx = char_at_cell_start(&prefix, vis_col as usize);
+        if char_idx >= chars.len() {
+            return None;
+        }
+
+        let is_word_char = |c: char| {
+            c.is_alphanumeric()
+                || c == '_'
+                || c == '-'
+                || c == '.'
+                || c == '/'
+                || c == '\\'
+                || c == '~'
+                || c == '@'
+                || c == ':'
+                || c == '+'
+                || c == '$'
+                || c == '%'
+        };
+
+        if !is_word_char(chars[char_idx]) {
+            return None;
+        }
+
+        // Expand left
+        let mut start_idx = char_idx;
+        while start_idx > 0 && is_word_char(chars[start_idx - 1]) {
+            start_idx -= 1;
+        }
+
+        // Expand right
+        let mut end_idx = char_idx;
+        while end_idx + 1 < chars.len() && is_word_char(chars[end_idx + 1]) {
+            end_idx += 1;
+        }
+
+        // Map back to columns
+        let c0 = prefix[start_idx];
+        let c1 = prefix[end_idx + 1].saturating_sub(1);
+
+        self.sel_anchor = Some((abs, c0 as u16));
+        self.sel_focus = Some((abs, c1 as u16));
+
+        let extracted = self.extract_selection_text();
+        if extracted.is_empty() {
+            None
+        } else {
+            Some(extracted)
+        }
     }
 
     /// Feed bytes to vt100 and capture scrolled-off lines into history.

--- a/ui/app.slint
+++ b/ui/app.slint
@@ -233,6 +233,7 @@ export component AppWindow inherits Window {
     // Default true so the window is frameless from creation (no native-bar flash);
     // Rust sets it false on macOS, which keeps native decorations.
     in-out property <bool> custom-titlebar: true;
+    in property <bool> is-mac: false;
     in-out property <bool> window-maximized: false;
     callback win-minimize();
     callback win-maximize-toggle();
@@ -590,6 +591,7 @@ export component AppWindow inherits Window {
     callback term-select-update(string /* tab-id */, int /* row */, int /* col */);
     callback term-select-end(string /* tab-id */);
     callback term-select-autoscroll(string /* tab-id */, int /* dir */);
+    callback term-select-word(string /* tab-id */, int /* row */, int /* col */);
 
     // Immersive wallpaper layer — painted behind everything, filling the window.
     // Panels/terminal frost over it (see Theme.frost). Only present when active.
@@ -862,6 +864,7 @@ export component AppWindow inherits Window {
                     is-alt-screen: term.is-alt-screen;
                     find-matches: term.find-matches;
                     selection: term.selection;
+                    is-mac: root.is-mac;
                     sftp-panel-height <=> root.sftp-panel-height;
                     sftp-panel-width <=> root.sftp-panel-width;
                     sftp-dock <=> root.sftp-dock;
@@ -960,6 +963,7 @@ export component AppWindow inherits Window {
                     select-update(r, c) => { root.term-select-update(term.id, r, c); }
                     select-end() => { root.term-select-end(term.id); }
                     select-autoscroll(dir) => { root.term-select-autoscroll(term.id, dir); }
+                    select-word(r, c) => { root.term-select-word(term.id, r, c); }
                 }
             }
             }

--- a/ui/terminal_view.slint
+++ b/ui/terminal_view.slint
@@ -96,6 +96,8 @@ export component TerminalView inherits Rectangle {
     in property <bool>   is-alt-screen;
     in property <[TermMatch]> find-matches; // search-highlight rectangles
     in property <[TermMatch]> selection;    // drag-selection highlight rectangles
+    in property <bool> is-mac;
+    callback select-word(int, int);
 
     in property <string>  sftp-path: "/";
     in property <[SftpEntry]> sftp-entries;
@@ -479,6 +481,12 @@ export component TerminalView inherits Rectangle {
                                 }
                                 accept
                             }
+                            double-clicked => {
+                                root.select-word(
+                                    floor(self.mouse-y / root.cell-h),
+                                    floor(self.mouse-x / root.cell-w)
+                                );
+                            }
                         }
 
                         // Drag-selection highlights (under the text, blue tint).
@@ -626,8 +634,21 @@ export component TerminalView inherits Rectangle {
                 }
 
                 key-pressed(event) => {
+                    // ── macOS: Physical Cmd+C (control+c) is Copy ───────────────────
+                    if (root.is-mac && event.modifiers.control
+                            && (event.text == "c" || event.text == "C"
+                                || event.text == "\u{0003}")) {
+                        root.copy-terminal-text();
+                        accept
+                    // ── macOS: Physical Cmd+V (control+v) is Paste ──────────────────
+                    } else if (root.is-mac && event.modifiers.control
+                            && (event.text == "v" || event.text == "V"
+                                || event.text == "\u{0016}")) {
+                        root.paste-from-clipboard();
+                        ime-input.focus();
+                        accept
                     // ── Ctrl+F: open the find bar (mirrors right-click → Find) ──
-                    if (event.modifiers.control && !event.modifiers.shift
+                    } else if (event.modifiers.control && !event.modifiers.shift
                             && (event.text == "f" || event.text == "F"
                                 || event.text == "\u{0006}")) {
                         root.find-active = true;
@@ -640,21 +661,17 @@ export component TerminalView inherits Rectangle {
                                 || event.text == "\u{0012}")) {
                         root.history-open = true;
                         accept
-                    // ── Ctrl+Shift+C: copy terminal buffer ───────────────────
-                    } else if (event.modifiers.control && event.modifiers.shift
+                    // ── Non-macOS: Ctrl+Shift+C: copy terminal buffer ───────
+                    } else if (!root.is-mac && event.modifiers.control && event.modifiers.shift
                             && (event.text == "c" || event.text == "C"
                                 || event.text == "\u{0003}")) {
                         root.copy-terminal-text();
                         accept
-                    // ── Ctrl+V or Ctrl+Shift+V: paste from clipboard ─────────
-                    // We accept Ctrl+V (with or without Shift) so the familiar
-                    // Windows paste shortcut works in addition to Ctrl+Shift+V.
-                    } else if (event.modifiers.control
+                    // ── Non-macOS: Ctrl+V or Ctrl+Shift+V: paste from clipboard ──
+                    } else if (!root.is-mac && event.modifiers.control
                             && (event.text == "v" || event.text == "V"
                                 || event.text == "\u{0016}")) {
                         root.paste-from-clipboard();
-                        // Clipboard access on Windows can deliver WM_KILLFOCUS.
-                        // Restore focus explicitly so the cursor keeps blinking.
                         ime-input.focus();
                         accept
                     // ── All other keys (printable, Ctrl+X, arrows, …) ────────
@@ -662,7 +679,8 @@ export component TerminalView inherits Rectangle {
                     // inserting the char into TextInput, so `edited` never fires
                     // for regular keystrokes — the character would be lost.
                     } else {
-                        root.send-key(event.text, event.modifiers.control,
+                        root.send-key(event.text,
+                                      root.is-mac ? event.modifiers.meta : event.modifiers.control,
                                       event.modifiers.alt, event.modifiers.shift);
                         accept
                     }


### PR DESCRIPTION
1. 新增终端双击触发选词并复制到剪贴板的功能
2. 适配macOS系统的Cmd+C/V复制粘贴快捷键
3. 调整非macOS系统的快捷键逻辑，统一操作体验