### PR TITLE
fix(sidebar): 壁纸高透明度下收起资源面板后仍可见

### DIFF
--- a/ui/app.slint
+++ b/ui/app.slint
@@ -880,6 +880,7 @@ export component AppWindow inherits Window {
             width: root.sidebar-horizontal ? parent.sb-w : parent.width;
             height: root.sidebar-horizontal ? parent.height : parent.sb-h;
             clip: true;
+            visible: !root.sidebar-collapsed;
             // Docked top/bottom → lay the resource widgets out in a row.
             lay-horizontal: !root.sidebar-horizontal;
             dock-edge: root.sidebar-dock;


### PR DESCRIPTION
收起时 Sidebar 仅缩到 36px + clip 裁剪,未隐藏。壁纸模式下
frost() 半透明背景会透过 ToolStrip 显示。添加 visible 控制,
收起时从渲染树完全移除。