### PR TITLE
fix fish shell hang on startup

### DIFF
--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -1765,6 +1765,15 @@ async fn run_session(
             msg = channel.wait() => {
                 match msg {
                     Some(ChannelMsg::Data { data }) => {
+                        // Reply to Primary Device Attribute query (ESC [ c or ESC [ 0 c)
+                        // so shells like fish don't hang for 10 seconds waiting for it.
+                        let bytes = &data[..];
+                        if bytes.windows(3).any(|w| w == b"\x1b[c")
+                            || bytes.windows(4).any(|w| w == b"\x1b[0c")
+                        {
+                            let _ = channel.data(&b"\x1b[?1;2c"[..]).await;
+                        }
+
                         // A `sz` in the terminal starts a ZMODEM send. Receive it
                         // straight to the Downloads dir (FinalShell style, #76).
                         // On any protocol error, cancel so the session recovers.


### PR DESCRIPTION
# Pull Request: 修复连接 fish shell 时的启动卡顿问题 (主设备属性查询超时)

## 问题描述

本 PR 修复了当连接的远程主机默认 shell 为 fish 时，会出现的 10 秒卡顿和终端兼容性警告的问题。

### 表现症状

当建立 SSH 连接到运行 fish 的远程主机时，终端输出会挂起约 10
秒钟，之后才能显示命令提示符，并伴有以下警告：

  warning: fish could not read response to Primary Device Attribute query after waiting for 10 seconds.
This is often due to a missing feature in your terminal. See 'help terminal-compatibility' or 'man
fish-terminal-compatibility'. This fish process will no longer wait for outstanding queries, which
disables some optional features.

### 根本原因

fish 启动时，会向 stdout 发送一个主设备属性 (Primary Device Attributes, DA1) 查询请求（转义序列 ESC [ c
或 ESC [ 0 c），以查询终端能力支持，并阻塞等待 stdin 上的响应。
由于 meatshell 的 SSH 工作线程原先没有拦截处理此查询并进行回复，该请求被直接忽略，导致远程 shell
保持阻塞，直到触发其内部 10 秒的读取超时。

---

## 解决方案

本 PR 在 SSH 连接的主力泵循环（src/ssh.rs）中，为该查询实现了自动拦截与响应机制。

1. 检测 (Detection)：检查接收到的数据块（ChannelMsg::Data）中是否包含匹配 b"\x1b[c" 或 b"\x1b[0c" 的子切片。
2. 应答 (Response)：一旦检测到查询，我们立即向通道写回标准的 VT100 DA1 响应序列 \x1b[?1;2c（表示带有 Advanced Video Option 选项的 VT100）。

  // 响应主设备属性查询 (ESC [ c 或 ESC [ 0 c)
  // 避免像 fish 这样的 shell 因等待响应而卡顿 10 秒。
  let bytes = &data[..];
  if bytes.windows(3).any(|w| w == b"\x1b[c")
      || bytes.windows(4).any(|w| w == b"\x1b[0c")
  {
      let _ = channel.data(&b"\x1b[?1;2c"[..]).await;
  }

---

## 验证与影响

- 验证结果：在配置了 fish 作为默认 shell 的远程主机上进行测试，连接立即建立（无需等待 10
秒），命令提示符立刻显示且无任何警告信息。
- 兼容性：此修复仅使用标准切片操作（.windows()），不会影响其他终端 shell（如 bash、zsh 等）的正常交互。
- 构建验证：已验证代码可通过 cargo check 正常编译，未引入任何新的编译器警告。