### PR TITLE
fix: 修复 macOS 打开下载目录和外部编辑

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2048,13 +2048,22 @@ pub fn run() -> Result<()> {
             if dir.is_empty() {
                 return;
             }
-            #[cfg(windows)]
-            {
-                let _ = std::process::Command::new("explorer").arg(&dir).spawn();
-            }
-            #[cfg(not(windows))]
-            {
-                let _ = std::process::Command::new("xdg-open").arg(&dir).spawn();
+            let result = {
+                #[cfg(windows)]
+                {
+                    std::process::Command::new("explorer").arg(&dir).spawn()
+                }
+                #[cfg(target_os = "macos")]
+                {
+                    std::process::Command::new("open").arg(&dir).spawn()
+                }
+                #[cfg(all(not(windows), not(target_os = "macos")))]
+                {
+                    std::process::Command::new("xdg-open").arg(&dir).spawn()
+                }
+            };
+            if let Err(e) = result {
+                tracing::warn!("failed to open download directory {dir:?}: {e}");
             }
         });
     }

--- a/src/sftp/impls/sftp_impl.rs
+++ b/src/sftp/impls/sftp_impl.rs
@@ -1266,27 +1266,34 @@ async fn run_sftp(
                 )
                 .await
                 {
-                    Ok(_) => {
-                        open_with_os(&local_str);
-                        let _ = events.send(SessionEvent::SftpStatus(format!(
-                            "{}: {}",
+                    Ok(_) => match open_with_os(&local_str) {
+                        Ok(()) => {
+                            let _ = events.send(SessionEvent::SftpStatus(format!(
+                                "{}: {}",
+                                if edit {
+                                    t("已打开编辑", "Opened for editing")
+                                } else {
+                                    t("已打开", "Opened")
+                                },
+                                filename
+                            )));
                             if edit {
-                                t("已打开编辑", "Opened for editing")
-                            } else {
-                                t("已打开", "Opened")
-                            },
-                            filename
-                        )));
-                        if edit {
-                            spawn_edit_watcher(
-                                self_tx.clone(),
-                                local_str,
-                                remote.clone(),
-                                filename,
-                                events.clone(),
-                            );
+                                spawn_edit_watcher(
+                                    self_tx.clone(),
+                                    local_str,
+                                    remote.clone(),
+                                    filename,
+                                    events.clone(),
+                                );
+                            }
                         }
-                    }
+                        Err(e) => {
+                            let _ = events.send(SessionEvent::SftpStatus(format!(
+                                "{}: {e}",
+                                t("打开失败", "Open failed")
+                            )));
+                        }
+                    },
                     Err(e) => {
                         let _ = events.send(SessionEvent::SftpStatus(format!(
                             "{}: {e}",
@@ -1466,10 +1473,10 @@ fn parent_dir(path: &str) -> String {
 /// containing shell metacharacters (`&` `|` `>` `<` `^` …) — e.g. `foo&calc.exe`
 /// — could inject and run arbitrary commands when the user opened it.  We call
 /// `ShellExecuteW` directly instead: it treats the path as one opaque string, so
-/// no shell parsing happens.  (`xdg-open` on Unix already takes a single argv
-/// argument and never invokes a shell.)
+/// no shell parsing happens. `open` on macOS and `xdg-open` on other Unix
+/// platforms likewise receive the path as one argv value.
 #[cfg(windows)]
-fn open_with_os(path: &str) {
+fn open_with_os(path: &str) -> Result<()> {
     use std::ffi::OsStr;
     use std::os::windows::ffi::OsStrExt;
     #[link(name = "shell32")]
@@ -1491,7 +1498,7 @@ fn open_with_os(path: &str) {
     };
     let op = to_wide("open");
     let file = to_wide(path);
-    unsafe {
+    let result = unsafe {
         ShellExecuteW(
             0,
             op.as_ptr(),
@@ -1499,13 +1506,31 @@ fn open_with_os(path: &str) {
             std::ptr::null(),
             std::ptr::null(),
             1, // SW_SHOWNORMAL
-        );
+        )
+    };
+    if result > 32 {
+        Ok(())
+    } else {
+        Err(anyhow!("ShellExecuteW failed with code {result}"))
     }
 }
 
-#[cfg(not(windows))]
-fn open_with_os(path: &str) {
-    let _ = std::process::Command::new("xdg-open").arg(path).spawn();
+#[cfg(target_os = "macos")]
+fn open_with_os(path: &str) -> Result<()> {
+    std::process::Command::new("open")
+        .arg(path)
+        .spawn()
+        .map(|_| ())
+        .with_context(|| format!("failed to launch open for {path:?}"))
+}
+
+#[cfg(all(not(windows), not(target_os = "macos")))]
+fn open_with_os(path: &str) -> Result<()> {
+    std::process::Command::new("xdg-open")
+        .arg(path)
+        .spawn()
+        .map(|_| ())
+        .with_context(|| format!("failed to launch xdg-open for {path:?}"))
 }
 
 /// Make a remote-supplied file name safe to use as a *local* file name (for


### PR DESCRIPTION
## 变更内容

- macOS 打开下载目录时使用系统原生 `open`，不再错误调用 Linux 的 `xdg-open`
- SFTP“外部打开 / 外部编辑”在 macOS 上同样使用 `open`
- 保留 Windows `ShellExecuteW` 和其他 Unix 平台 `xdg-open` 的现有行为
- 外部程序启动失败时向 SFTP 状态栏返回错误，不再误报“已打开编辑”
- 仅在外部编辑器成功启动后创建文件变更监视器
- 打开下载目录失败时记录 warning，避免完全静默

## 根因

原实现将所有非 Windows 平台统一走 `xdg-open`。macOS 默认提供的是 `/usr/bin/open`，通常没有 `xdg-open`，因此点击“打开文件夹”以及 SFTP 的“外部打开 / 外部编辑”均无法启动 Finder 或默认应用。

## 用户影响

修复后，macOS 用户可以：

- 从下载设置中正常打开保存目录
- 使用系统默认应用打开远程文件
- 使用外部编辑器编辑远程文件，并在保存后继续使用现有的自动回传流程
- 在启动外部应用失败时看到明确错误，而不是收到错误的成功提示

## 验证

- `git diff --check`：通过
- `cargo check --locked`：通过
- `cargo test --locked`：115 passed，0 failed
- `cargo fmt --check`：未通过；upstream `main` 当前已有大量与本 PR 无关的格式差异，为避免大面积格式化噪声未执行全仓改写
