### PR TITLE
fix：修复macos上无法选择无扩展名ssh私钥的问题

### DIFF
--- a/assets/Info.plist
+++ b/assets/Info.plist
@@ -40,5 +40,14 @@
 
     <key>NSHumanReadableCopyright</key>
     <string>Copyright © 2024 meatshell contributors. MIT OR Apache-2.0.</string>
+
+    <!-- Declare supported localizations so macOS native dialogs (NSOpenPanel)
+         display in the system language (e.g. Chinese) instead of English. -->
+    <key>CFBundleLocalizations</key>
+    <array>
+        <string>zh</string>
+        <string>zh_CN</string>
+        <string>zh-Hans</string>
+    </array>
 </dict>
 </plist>

--- a/src/app.rs
+++ b/src/app.rs
@@ -4206,11 +4206,16 @@ fn wire_session_callbacks(
         window.on_session_dialog_pick_key(move || {
             let mut dialog =
                 rfd::FileDialog::new()
-                    .set_title(t("选择私钥文件", "Choose private key file"))
-                    .add_filter(
-                        t("SSH 私钥", "SSH private keys"),
-                        &["ppk", "pem", "key"],
-                    );
+                    .set_title(t("选择私钥文件", "Choose private key file"));
+            // macOS uses UTIs, not extensions — a filter would hide
+            // extensionless keys like id_ed25519. Only filter on Windows/Linux.
+            #[cfg(not(target_os = "macos"))]
+            {
+                dialog = dialog.add_filter(
+                    t("SSH 私钥", "SSH private keys"),
+                    &["ppk", "pem", "key"],
+                );
+            }
             // Start in ~/.ssh if it exists.
             if let Some(home) = directories::UserDirs::new().map(|u| u.home_dir().join(".ssh")) {
                 if home.is_dir() {


### PR DESCRIPTION
## 问题

1. macOS 上选择 SSH 私钥时，`id_ed25519` 等无扩展名的密钥无法选中
2. macOS 原生文件对话框显示英文，即使系统语言是中文

## 修复

- `src/app.rs`: macOS 上不再使用扩展名过滤器（rfd 在 macOS 上使用 UTIs，扩展名过滤不生效）
- `assets/Info.plist`: 添加 `CFBundleLocalizations` 声明，让原生对话框跟随系统语言

## 测试

- [x] macOS 上能正常选择 `id_ed25519` 等无扩展名密钥
- [ ] macOS 打包后原生对话框显示中文（待验证）