### PR TITLE
修复 Cargo.toml 中的 package.repository 字段

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 authors = ["meatshell contributors"]
 description = "A lightweight FinalShell-style SSH/terminal client written in Rust + Slint"
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/your/meatshell"
+repository = "https://github.com/yituorou/meatshell"
 readme = "README.md"
 rust-version = "1.75"
 


### PR DESCRIPTION
修改为 https://github.com/yituorou/meatshell