### PR TITLE
fix: 增加主机搜索框并修复 SSH 辅助通道断线

### DIFF
--- a/lang/en/LC_MESSAGES/meatshell.po
+++ b/lang/en/LC_MESSAGES/meatshell.po
@@ -527,3 +527,12 @@ msgstr "Terminating process..."
 
 msgid "Terminate"
 msgstr "Terminate"
+
+msgid "Search by name or host..."
+msgstr "Search by name or host..."
+
+msgid "No matching sessions"
+msgstr "No matching sessions"
+
+msgid "Clear search"
+msgstr "Clear search"

--- a/lang/zh/LC_MESSAGES/meatshell.po
+++ b/lang/zh/LC_MESSAGES/meatshell.po
@@ -527,3 +527,12 @@ msgstr "正在结束进程..."
 
 msgid "Terminate"
 msgstr "结束进程"
+
+msgid "Search by name or host..."
+msgstr "按名称或主机搜索..."
+
+msgid "No matching sessions"
+msgstr "没有匹配的会话"
+
+msgid "Clear search"
+msgstr "清除搜索"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1337,7 +1337,7 @@ pub fn run() -> Result<()> {
             let _ = s.save();
             if let Some(w) = weak.upgrade() {
                 w.set_wsl_profiles(wsl_profile_model(&s));
-                sync_sessions_to_model(&s, &sessions_model);
+                sync_sessions_for_window(&weak, &s, &sessions_model);
             }
         });
     }
@@ -1351,7 +1351,7 @@ pub fn run() -> Result<()> {
             let _ = s.save();
             if let Some(w) = weak.upgrade() {
                 w.set_wsl_profiles(wsl_profile_model(&s));
-                sync_sessions_to_model(&s, &sessions_model);
+                sync_sessions_for_window(&weak, &s, &sessions_model);
             }
         });
     }
@@ -1393,7 +1393,7 @@ pub fn run() -> Result<()> {
             .and_then(|json| store.borrow_mut().import_json(&json));
             let msg = match res {
                 Ok((added, skipped)) => {
-                    sync_sessions_to_model(&store.borrow(), &sessions_model);
+                    sync_sessions_for_window(&weak, &store.borrow(), &sessions_model);
                     format!(
                         "{} {}, {} {}",
                         t("已导入", "imported"),
@@ -2969,6 +2969,18 @@ fn handle_file_drop(_win: &AppWindow, _sftp_handles: &SftpHandles, _path: std::p
 // Model helpers
 // ---------------------------------------------------------------------------
 
+fn sync_sessions_for_window(
+    window: &slint::Weak<AppWindow>,
+    store: &ConfigStore,
+    model: &VecModel<SessionInfo>,
+) {
+    let query = window
+        .upgrade()
+        .map(|window| window.get_host_search_query().to_string())
+        .unwrap_or_default();
+    sync_sessions_to_model_with_filter(store, model, &query);
+}
+
 /// Parse the batch-import textarea (#150). Each non-empty, non-`#` line is
 /// `host|port|user|password|name`; trailing fields are optional (port → 22,
 /// user → root, password → none, name → user@host). A leading header row such as
@@ -3000,6 +3012,28 @@ fn wire_session_callbacks(
     // Session.forwards; opening the dialog (new/edit) resets it.
     let edit_forwards: Rc<RefCell<Vec<PortFwd>>> =
         Rc::new(RefCell::new(vec![blank_forward_draft()]));
+
+    // Rebuild the session list as the user edits the Quick Connect search.
+    {
+        let weak = window.as_weak();
+        let store = store.clone();
+        let sessions_model = sessions_model.clone();
+        window.on_host_search_changed(move |query| {
+            if let Some(window) = weak.upgrade() {
+                let query = if query.trim().is_empty() {
+                    SharedString::new()
+                } else {
+                    query
+                };
+                window.set_host_search_query(query.clone());
+                sync_sessions_to_model_with_filter(
+                    &store.borrow(),
+                    &sessions_model,
+                    query.as_str(),
+                );
+            }
+        });
+    }
 
     // New session -> open dialog with blank draft.
     let weak = window.as_weak();
@@ -3099,7 +3133,7 @@ fn wire_session_callbacks(
                     let _ = s.save();
                 }
             }
-            sync_sessions_to_model(&store.borrow(), &sessions_model);
+            sync_sessions_for_window(&weak, &store.borrow(), &sessions_model);
             if let Some(w) = weak.upgrade() {
                 let hint = if added > 0 {
                     format!("{} {}", t("已导入", "imported"), added)
@@ -3162,7 +3196,7 @@ fn wire_session_callbacks(
                     let _ = s.save();
                 }
             }
-            sync_sessions_to_model(&store.borrow(), &sessions_model);
+            sync_sessions_for_window(&weak, &store.borrow(), &sessions_model);
             if let Some(w) = weak.upgrade() {
                 let hint = if total == 0 {
                     t("没有可导入的连接", "nothing to import").to_string()
@@ -3190,7 +3224,7 @@ fn wire_session_callbacks(
                 if let Some(w) = weak.upgrade() {
                     let hint = match res {
                         Ok((added, skipped)) => {
-                            sync_sessions_to_model(&store.borrow(), &sessions_model);
+                            sync_sessions_for_window(&weak, &store.borrow(), &sessions_model);
                             format!(
                                 "{} {} / {} {}",
                                 t("已导入", "imported"),
@@ -3276,7 +3310,7 @@ fn wire_session_callbacks(
                     tracing::warn!("failed to save config: {err:#}");
                 }
             }
-            sync_sessions_to_model(&store.borrow(), &sessions_model);
+            sync_sessions_for_window(&weak, &store.borrow(), &sessions_model);
             if let Some(w) = weak.upgrade() {
                 // Touch a property so the list re-renders reliably.
                 let _ = w.get_sessions();
@@ -3303,7 +3337,7 @@ fn wire_session_callbacks(
                     }
                 }
             }
-            sync_sessions_to_model(&store.borrow(), &sessions_model);
+            sync_sessions_for_window(&weak, &store.borrow(), &sessions_model);
             if let Some(w) = weak.upgrade() {
                 let _ = w.get_sessions();
             }
@@ -3335,7 +3369,7 @@ fn wire_session_callbacks(
                     }
                 }
             }
-            sync_sessions_to_model(&store.borrow(), &sessions_model);
+            sync_sessions_for_window(&weak, &store.borrow(), &sessions_model);
             if let Some(w) = weak.upgrade() {
                 let _ = w.get_sessions();
             }
@@ -3350,6 +3384,13 @@ fn wire_session_callbacks(
         let store = store.clone();
         let sessions_model = sessions_model.clone();
         window.on_toggle_group(move |group: SharedString| {
+            if weak
+                .upgrade()
+                .map(|window| !window.get_host_search_query().trim().is_empty())
+                .unwrap_or(false)
+            {
+                return;
+            }
             use slint::Model as _;
             let target = group.to_string();
             let n = sessions_model.row_count();
@@ -3419,7 +3460,7 @@ fn wire_session_callbacks(
                     tracing::warn!("failed to save config: {err:#}");
                 }
             }
-            sync_sessions_to_model(&store.borrow(), &sessions_model);
+            sync_sessions_for_window(&weak, &store.borrow(), &sessions_model);
             if let Some(w) = weak.upgrade() {
                 let _ = w.get_sessions();
             }
@@ -3439,7 +3480,7 @@ fn wire_session_callbacks(
                     tracing::warn!("failed to save config: {err:#}");
                 }
             }
-            sync_sessions_to_model(&store.borrow(), &sessions_model);
+            sync_sessions_for_window(&weak, &store.borrow(), &sessions_model);
             if let Some(w) = weak.upgrade() {
                 let _ = w.get_sessions();
             }
@@ -3557,7 +3598,7 @@ fn wire_session_callbacks(
                     tracing::warn!("failed to save config: {err:#}");
                 }
             }
-            sync_sessions_to_model(&store.borrow(), &sessions_model);
+            sync_sessions_for_window(&weak, &store.borrow(), &sessions_model);
             if let Some(w) = weak.upgrade() {
                 w.set_dialog_open(false);
             }

--- a/src/app/session_models.rs
+++ b/src/app/session_models.rs
@@ -128,37 +128,76 @@ pub(super) fn jump_candidates(
     )
 }
 
-pub(super) fn sync_sessions_to_model(store: &ConfigStore, model: &VecModel<SessionInfo>) {
+fn normalized_query(query: &str) -> String {
+    query.trim().to_lowercase()
+}
+
+fn session_matches_normalized_query(session: &Session, query: &str) -> bool {
+    query.is_empty()
+        || session.name.to_lowercase().contains(query)
+        || session.host.to_lowercase().contains(query)
+}
+
+#[cfg(test)]
+fn session_matches_query(session: &Session, query: &str) -> bool {
+    let query = normalized_query(query);
+    session_matches_normalized_query(session, &query)
+}
+
+fn build_session_rows(
+    sessions: &[Session],
+    explicit_groups: &[String],
+    collapsed_groups: Option<&[String]>,
+    builtin_sessions: &[Session],
+    query: &str,
+) -> Vec<SessionInfo> {
     // Group sessions by their `group` (named groups alphabetically, ungrouped
     // last), then by name within each group, and tag the first row of every
     // group with a header so the welcome list can render a folder heading (#41).
-    let sessions = store.sessions();
-    let collapsed_groups = store.collapsed_session_groups();
+    let query = normalized_query(query);
+    let searching = !query.is_empty();
+    let matches = |session: &Session| session_matches_normalized_query(session, &query);
     let group_is_collapsed = |group: &str| {
-        collapsed_groups
-            .map(|groups| groups.iter().any(|collapsed| collapsed == group))
-            .unwrap_or(true)
+        !searching
+            && collapsed_groups
+                .map(|groups| groups.iter().any(|collapsed| collapsed == group))
+                .unwrap_or(true)
     };
 
     // Ordered list of display groups:
     //  - "default" only when there are ungrouped sessions (group == "")
     //  - named groups: explicit folders (incl. empty ones) ∪ sessions' groups,
     //    de-duplicated, alphabetical.
-    let has_default = sessions
-        .iter()
-        .any(|s| s.group.is_empty() || is_reserved_session_group(s.group.trim()));
-    let mut named: Vec<String> = store
-        .groups()
-        .iter()
-        .filter(|group| !is_reserved_session_group(group.trim()))
-        .cloned()
-        .chain(
-            sessions
-                .iter()
-                .filter(|s| !s.group.is_empty() && !is_reserved_session_group(s.group.trim()))
-                .map(|s| s.group.clone()),
-        )
-        .collect();
+    let has_default = sessions.iter().any(|session| {
+        (session.group.is_empty() || is_reserved_session_group(session.group.trim()))
+            && matches(session)
+    });
+    let mut named: Vec<String> = if searching {
+        sessions
+            .iter()
+            .filter(|session| {
+                !session.group.is_empty()
+                    && !is_reserved_session_group(session.group.trim())
+                    && matches(session)
+            })
+            .map(|session| session.group.clone())
+            .collect()
+    } else {
+        explicit_groups
+            .iter()
+            .filter(|group| !is_reserved_session_group(group.trim()))
+            .cloned()
+            .chain(
+                sessions
+                    .iter()
+                    .filter(|session| {
+                        !session.group.is_empty()
+                            && !is_reserved_session_group(session.group.trim())
+                    })
+                    .map(|session| session.group.clone()),
+            )
+            .collect()
+    };
     named.sort_by_key(|g| g.to_lowercase());
     named.dedup();
 
@@ -185,7 +224,11 @@ pub(super) fn sync_sessions_to_model(store: &ConfigStore, model: &VecModel<Sessi
     };
 
     let mut rows: Vec<SessionInfo> = Vec::new();
-    for (i, s) in builtin_local_sessions(store.wsl_profiles()).iter().enumerate() {
+    for (i, s) in builtin_sessions
+        .iter()
+        .filter(|session| matches(session))
+        .enumerate()
+    {
         rows.push(SessionInfo {
             id: s.id.clone().into(),
             name: s.name.clone().into(),
@@ -204,14 +247,20 @@ pub(super) fn sync_sessions_to_model(store: &ConfigStore, model: &VecModel<Sessi
         let mut gs: Vec<&Session> = if group == "default" {
             sessions
                 .iter()
-                .filter(|s| s.group.is_empty() || is_reserved_session_group(s.group.trim()))
+                .filter(|session| {
+                    (session.group.is_empty() || is_reserved_session_group(session.group.trim()))
+                        && matches(session)
+                })
                 .collect()
         } else {
-            sessions.iter().filter(|s| &s.group == group).collect()
+            sessions
+                .iter()
+                .filter(|session| &session.group == group && matches(session))
+                .collect()
         };
         gs.sort_by_key(|s| s.name.to_lowercase());
 
-        if gs.is_empty() {
+        if gs.is_empty() && !searching {
             rows.push(blank(group));
         } else {
             for (i, s) in gs.iter().enumerate() {
@@ -239,7 +288,26 @@ pub(super) fn sync_sessions_to_model(store: &ConfigStore, model: &VecModel<Sessi
             }
         }
     }
-    model.set_vec(rows);
+    rows
+}
+
+pub(super) fn sync_sessions_to_model_with_filter(
+    store: &ConfigStore,
+    model: &VecModel<SessionInfo>,
+    query: &str,
+) {
+    let builtin_sessions = builtin_local_sessions(store.wsl_profiles());
+    model.set_vec(build_session_rows(
+        store.sessions(),
+        store.groups(),
+        store.collapsed_session_groups(),
+        &builtin_sessions,
+        query,
+    ));
+}
+
+pub(super) fn sync_sessions_to_model(store: &ConfigStore, model: &VecModel<SessionInfo>) {
+    sync_sessions_to_model_with_filter(store, model, "");
 }
 
 pub(super) fn builtin_local_sessions(
@@ -398,5 +466,87 @@ pub(super) fn session_from_draft(
         disable_shell_integration: draft.disable_shell_integration,
         note: draft.note.to_string(),
         jump_session_id: draft.jump_session_id.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod search_tests {
+    use super::*;
+
+    fn session(id: &str, name: &str, host: &str, group: &str) -> Session {
+        let mut value = Session::new_empty();
+        value.id = id.into();
+        value.name = name.into();
+        value.host = host.into();
+        value.group = group.into();
+        value
+    }
+
+    #[test]
+    fn session_search_matches_name_and_host_case_insensitively() {
+        let value = session("1", "Prod API", "DB.EXAMPLE.COM", "prod");
+        assert!(session_matches_query(&value, "  prod  "));
+        assert!(session_matches_query(&value, "example.com"));
+        assert!(!session_matches_query(&value, "staging"));
+    }
+
+    #[test]
+    fn filtered_rows_hide_empty_groups_and_expand_matches() {
+        let saved = vec![session("1", "Prod API", "10.0.0.8", "prod")];
+        let builtins = vec![session("local", "Local terminal", "localhost", "system")];
+        let groups = vec!["empty".to_string(), "prod".to_string()];
+        let collapsed = vec!["prod".to_string(), "system".to_string()];
+
+        let rows = build_session_rows(&saved, &groups, Some(&collapsed), &builtins, "prod");
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].name.as_str(), "Prod API");
+        assert_eq!(rows[0].group_header.as_str(), "prod");
+        assert!(!rows[0].collapsed);
+    }
+
+    #[test]
+    fn filtered_rows_include_matching_builtin_sessions() {
+        let builtins = vec![session("local", "Local terminal", "localhost", "system")];
+
+        let rows = build_session_rows(
+            &[],
+            &[],
+            Some(&["system".to_string()]),
+            &builtins,
+            "LOCALHOST",
+        );
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].name.as_str(), "Local terminal");
+        assert_eq!(rows[0].group_header.as_str(), "system");
+        assert!(rows[0].builtin);
+        assert!(!rows[0].collapsed);
+    }
+
+    #[test]
+    fn filtered_rows_are_empty_when_nothing_matches() {
+        let saved = vec![session("1", "Prod API", "10.0.0.8", "prod")];
+        let builtins = vec![session("local", "Local terminal", "localhost", "system")];
+
+        let rows = build_session_rows(&saved, &[], None, &builtins, "staging");
+
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn empty_query_restores_saved_groups_and_collapse_state() {
+        let saved = vec![session("1", "Prod API", "10.0.0.8", "prod")];
+        let groups = vec!["empty".to_string(), "prod".to_string()];
+        let collapsed = vec!["prod".to_string()];
+
+        let rows = build_session_rows(&saved, &groups, Some(&collapsed), &[], "");
+
+        assert!(rows
+            .iter()
+            .any(|row| row.group.as_str() == "empty" && row.id.is_empty()));
+        assert!(rows
+            .iter()
+            .any(|row| row.group.as_str() == "prod" && row.collapsed));
     }
 }

--- a/src/ssh/impls/ssh.rs
+++ b/src/ssh/impls/ssh.rs
@@ -5,7 +5,6 @@
 //! output lines are pushed back via an `UnboundedSender<SessionEvent>`.
 
 use std::path::Path;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use anyhow::{anyhow, Context, Result};
@@ -103,6 +102,115 @@ const PROMPT_SETUP_HISTORY_MARKER: &str = "__MEATSHELL_INTERNAL_SETUP_1";
 const PROMPT_SETUP_DONE: &str = "\u{1b}]699;ready\u{07}";
 const PROMPT_BODY: &str = "test -z \"$FISH_VERSION\" && eval '__msc(){ __c=\"$(fc -ln -1 2>/dev/null)\"; [ -n \"$__c\" ] && [ \"$__c\" != \"$__cl\" ] && { __cl=\"$__c\"; printf \"\\033]697;%s\\007\" \"$__c\"; }; }; __ms7(){ printf \"\\033]7;file://%s%s\\007\" \"$HOSTNAME\" \"$PWD\"; __msc; }; if [ -n \"$ZSH_VERSION\" ]; then autoload -Uz add-zsh-hook 2>/dev/null; add-zsh-hook precmd __ms7; else PROMPT_COMMAND=\"__ms7${PROMPT_COMMAND:+;$PROMPT_COMMAND}\"; fi; : __MEATSHELL_INTERNAL_SETUP_1; if [ -n \"$BASH_VERSION\" ]; then __md=\"$(history 2>/dev/null | { __md=\"\"; while read -r __mn __mr; do case \"$__mr\" in *\"__ms7()\"*\"PROMPT_COMMAND=\"*) __mn=\"${__mn%\\*}\"; __md=\"$__mn $__md\";; esac; done; printf \"%s\" \"$__md\"; })\"; for __mn in $__md; do history -d \"$__mn\" 2>/dev/null; done; unset __md __mn __mr; fi; __cl=\"$(fc -ln -1 2>/dev/null)\"; printf \"\\033]699;ready\\007\"; __ms7'";
 const PROMPT_SHELL_PROBE: &[u8] = b"if [ -n \"$BASH_VERSION\" ]; then printf '__MEATSHELL_SHELL__:bash\\n'; elif [ -n \"$ZSH_VERSION\" ]; then printf '__MEATSHELL_SHELL__:zsh\\n'; else printf '__MEATSHELL_SHELL__:other\\n'; fi";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AuxiliaryChannelKind {
+    Resources,
+    Processes,
+    SystemInfo,
+}
+
+impl AuxiliaryChannelKind {
+    fn delay(self) -> std::time::Duration {
+        match self {
+            Self::Resources => std::time::Duration::from_millis(750),
+            Self::Processes => std::time::Duration::from_millis(1500),
+            Self::SystemInfo => std::time::Duration::from_millis(2500),
+        }
+    }
+
+    fn next(self) -> Option<Self> {
+        match self {
+            Self::Resources => Some(Self::Processes),
+            Self::Processes => Some(Self::SystemInfo),
+            Self::SystemInfo => None,
+        }
+    }
+}
+
+struct AuxiliaryStartup {
+    pending: Option<AuxiliaryChannelKind>,
+    in_progress: bool,
+}
+
+impl AuxiliaryStartup {
+    fn new(enabled: bool) -> Self {
+        Self {
+            pending: enabled.then_some(AuxiliaryChannelKind::Resources),
+            in_progress: false,
+        }
+    }
+
+    fn pending(&self) -> Option<AuxiliaryChannelKind> {
+        if self.in_progress {
+            None
+        } else {
+            self.pending
+        }
+    }
+
+    fn begin(&mut self) -> Option<AuxiliaryChannelKind> {
+        let kind = self.pending()?;
+        if self.in_progress {
+            return None;
+        }
+        self.in_progress = true;
+        Some(kind)
+    }
+
+    fn complete(&mut self) {
+        if !self.in_progress {
+            return;
+        }
+        self.pending = self.pending.and_then(AuxiliaryChannelKind::next);
+        self.in_progress = false;
+    }
+}
+
+const AUXILIARY_CHANNEL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+
+async fn auxiliary_timeout<F, T>(
+    timeout: std::time::Duration,
+    future: F,
+) -> Result<T, tokio::time::error::Elapsed>
+where
+    F: std::future::Future<Output = T>,
+{
+    tokio::time::timeout(timeout, future).await
+}
+
+async fn open_auxiliary_channel(
+    handle: &Handle<ClientHandler>,
+    command: &'static [u8],
+    label: &'static str,
+) -> Option<Channel<Msg>> {
+    let operation = async {
+        let channel = handle
+            .channel_open_session()
+            .await
+            .with_context(|| format!("{label} channel open"))?;
+        channel
+            .exec(true, command)
+            .await
+            .with_context(|| format!("{label} exec"))?;
+        Ok::<Channel<Msg>, anyhow::Error>(channel)
+    };
+
+    match auxiliary_timeout(AUXILIARY_CHANNEL_TIMEOUT, operation).await {
+        Ok(Ok(channel)) => Some(channel),
+        Ok(Err(error)) => {
+            tracing::warn!("{label} startup failed: {error:#}");
+            None
+        }
+        Err(_) => {
+            tracing::warn!(
+                "{label} startup timed out after {} ms",
+                AUXILIARY_CHANNEL_TIMEOUT.as_millis()
+            );
+            None
+        }
+    }
+}
 
 fn prompt_setup_supported(probe_output: &str) -> Option<bool> {
     if probe_output.contains("__MEATSHELL_SHELL__:bash")
@@ -1435,97 +1543,16 @@ async fn run_session(
     }
     let handle = Arc::new(handle);
 
-    // Auxiliary channels are deliberately outside the terminal-ready critical
-    // path. SFTP gets the first opportunity after Connected; lightweight
-    // resources follow, and process/system enrichment starts last.
-    let (mon_ready_tx, mut mon_ready_rx) = tokio::sync::oneshot::channel();
-    let (proc_ready_tx, mut proc_ready_rx) = tokio::sync::oneshot::channel();
-    let (sys_ready_tx, mut sys_ready_rx) = tokio::sync::oneshot::channel();
-    // Shared flag so the delayed spawn tasks can skip opening a channel
-    // when monitoring was disabled (e.g. sidebar collapsed) during the
-    // sleep window. Opening a channel just to immediately close it can
-    // cause some SSH servers to drop the entire transport (#345).
-    let mon_flag = Arc::new(AtomicBool::new(true));
-    if session.disable_shell_integration {
-        let _ = mon_ready_tx.send(None);
-        let _ = proc_ready_tx.send(None);
-        let _ = sys_ready_tx.send(None);
-    } else {
-        let proc_flag = mon_flag.clone();
-        let sys_flag = mon_flag.clone();
-        let mon_flag = mon_flag.clone();
-        let mon_handle = handle.clone();
-        tokio::spawn(async move {
-            tokio::time::sleep(std::time::Duration::from_millis(750)).await;
-            if !mon_flag.load(Ordering::Relaxed) {
-                let _ = mon_ready_tx.send(None);
-                return;
-            }
-            let channel = match mon_handle.channel_open_session().await {
-                Ok(ch) => match ch.exec(true, MON_CMD).await {
-                    Ok(()) => Some(ch),
-                    Err(error) => {
-                        tracing::warn!("monitor exec failed: {error}");
-                        None
-                    }
-                },
-                Err(error) => {
-                    tracing::warn!("monitor channel open failed: {error}");
-                    None
-                }
-            };
-            let _ = mon_ready_tx.send(channel);
-        });
-        let proc_handle = handle.clone();
-        tokio::spawn(async move {
-            tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
-            if !proc_flag.load(Ordering::Relaxed) {
-                let _ = proc_ready_tx.send(None);
-                return;
-            }
-            let channel = match proc_handle.channel_open_session().await {
-                Ok(ch) => match ch.exec(true, PROC_CMD).await {
-                    Ok(()) => Some(ch),
-                    Err(error) => {
-                        tracing::warn!("process monitor exec failed: {error}");
-                        None
-                    }
-                },
-                Err(error) => {
-                    tracing::warn!("process monitor channel open failed: {error}");
-                    None
-                }
-            };
-            let _ = proc_ready_tx.send(channel);
-        });
-        let sys_handle = handle.clone();
-        tokio::spawn(async move {
-            tokio::time::sleep(std::time::Duration::from_millis(2500)).await;
-            if !sys_flag.load(Ordering::Relaxed) {
-                let _ = sys_ready_tx.send(None);
-                return;
-            }
-            let channel = match sys_handle.channel_open_session().await {
-                Ok(ch) => match ch.exec(true, SYS_CMD).await {
-                    Ok(()) => Some(ch),
-                    Err(error) => {
-                        tracing::warn!("system-info exec failed: {error}");
-                        None
-                    }
-                },
-                Err(error) => {
-                    tracing::warn!("system-info channel open failed: {error}");
-                    None
-                }
-            };
-            let _ = sys_ready_tx.send(channel);
-        });
-    }
-    let mut mon_start_pending = true;
-    let mut proc_start_pending = true;
-    let mut sys_start_pending = true;
+    // Delay auxiliary channels until after the terminal is usable, but open them
+    // from this task. Opening them in detached tasks while `channel.wait()` was
+    // being polled could make russh/strict servers close the primary PTY exactly
+    // when the first monitor started (#264 follow-up).
+    let auxiliary_started_at = tokio::time::Instant::now();
+    let mut auxiliary_startup = AuxiliaryStartup::new(!session.disable_shell_integration);
+    let mut auxiliary_deadline = auxiliary_startup
+        .pending()
+        .map(|kind| auxiliary_started_at + kind.delay());
     let mut resource_monitoring = true;
-    mon_flag.store(true, Ordering::Relaxed);
     let mut first_terminal_output = true;
     // Local (-L) and dynamic (-D) listen client-side; their tasks are aborted
     // on session exit.
@@ -1550,42 +1577,45 @@ async fn run_session(
     // --- Main pump ------------------------------------------------------
     loop {
         tokio::select! {
-            ready = &mut mon_ready_rx, if mon_start_pending => {
-                mon_start_pending = false;
-                let ready_channel = ready.unwrap_or(None);
-                if resource_monitoring {
-                    mon_channel = ready_channel;
-                } else if let Some(channel) = ready_channel {
-                    let _ = channel.close().await;
+            _ = async {
+                match auxiliary_deadline {
+                    Some(deadline) => tokio::time::sleep_until(deadline).await,
+                    None => std::future::pending().await,
                 }
-                tracing::debug!(
-                    "[SESSION_START] id={} stage=resources-started elapsed_ms={}",
-                    session.id,
-                    session_started.elapsed().as_millis()
-                );
-            }
-            ready = &mut proc_ready_rx, if proc_start_pending => {
-                proc_start_pending = false;
-                let ready_channel = ready.unwrap_or(None);
-                if resource_monitoring {
-                    proc_channel = ready_channel;
-                } else if let Some(channel) = ready_channel {
-                    let _ = channel.close().await;
+            } => {
+                if let Some(kind) = auxiliary_startup.begin() {
+                    let auxiliary_channel = match kind {
+                        AuxiliaryChannelKind::Resources if resource_monitoring => {
+                            open_auxiliary_channel(&handle, MON_CMD, "monitor").await
+                        }
+                        AuxiliaryChannelKind::Processes if resource_monitoring => {
+                            open_auxiliary_channel(&handle, PROC_CMD, "process monitor").await
+                        }
+                        AuxiliaryChannelKind::SystemInfo => {
+                            open_auxiliary_channel(&handle, SYS_CMD, "system-info").await
+                        }
+                        _ => None,
+                    };
+                    let auxiliary_available = auxiliary_channel.is_some();
+
+                    match kind {
+                        AuxiliaryChannelKind::Resources => mon_channel = auxiliary_channel,
+                        AuxiliaryChannelKind::Processes => proc_channel = auxiliary_channel,
+                        AuxiliaryChannelKind::SystemInfo => sys_channel = auxiliary_channel,
+                    }
+                    auxiliary_startup.complete();
+                    auxiliary_deadline = auxiliary_startup
+                        .pending()
+                        .map(|next| tokio::time::Instant::now() + next.delay());
+                    tracing::debug!(
+                        "[SESSION_START] id={} stage={kind:?}-startup-finished available={} elapsed_ms={}",
+                        session.id,
+                        auxiliary_available,
+                        session_started.elapsed().as_millis()
+                    );
+                } else {
+                    auxiliary_deadline = None;
                 }
-                tracing::debug!(
-                    "[SESSION_START] id={} stage=process-monitor-started elapsed_ms={}",
-                    session.id,
-                    session_started.elapsed().as_millis()
-                );
-            }
-            ready = &mut sys_ready_rx, if sys_start_pending => {
-                sys_start_pending = false;
-                sys_channel = ready.unwrap_or(None);
-                tracing::debug!(
-                    "[SESSION_START] id={} stage=system-info-started elapsed_ms={}",
-                    session.id,
-                    session_started.elapsed().as_millis()
-                );
             }
             cmd = commands.recv() => {
                 match cmd {
@@ -1607,7 +1637,6 @@ async fn run_session(
                             continue;
                         }
                         resource_monitoring = enabled;
-                        mon_flag.store(enabled, Ordering::Relaxed);
                         if !enabled {
                             if let Some(monitor) = mon_channel.take() {
                                 let _ = monitor.close().await;
@@ -2809,6 +2838,46 @@ mod prompt_setup_echo_tests {
 
         assert_eq!(parser.screen().contents().lines().next(), Some(prompt));
         assert_eq!(parser.screen().cursor_position(), (0, prompt.len() as u16));
+    }
+}
+
+#[cfg(test)]
+mod auxiliary_startup_tests {
+    use super::{auxiliary_timeout, AuxiliaryChannelKind, AuxiliaryStartup};
+
+    #[test]
+    fn starts_channels_in_order_and_never_overlaps_them() {
+        let mut startup = AuxiliaryStartup::new(true);
+
+        assert_eq!(startup.begin(), Some(AuxiliaryChannelKind::Resources));
+        assert_eq!(startup.begin(), None);
+        startup.complete();
+
+        assert_eq!(startup.begin(), Some(AuxiliaryChannelKind::Processes));
+        assert_eq!(startup.begin(), None);
+        startup.complete();
+
+        assert_eq!(startup.begin(), Some(AuxiliaryChannelKind::SystemInfo));
+        startup.complete();
+        assert_eq!(startup.begin(), None);
+    }
+
+    #[test]
+    fn disabled_shell_integration_skips_all_auxiliary_channels() {
+        let mut startup = AuxiliaryStartup::new(false);
+
+        assert_eq!(startup.begin(), None);
+    }
+
+    #[tokio::test]
+    async fn auxiliary_channel_startup_timeout_releases_the_pump() {
+        let result = auxiliary_timeout(
+            std::time::Duration::from_millis(1),
+            std::future::pending::<()>(),
+        )
+        .await;
+
+        assert!(result.is_err());
     }
 }
 

--- a/src/terminal/impls/local.rs
+++ b/src/terminal/impls/local.rs
@@ -233,7 +233,7 @@ fn local_program(session: &Session) -> (String, Vec<String>) {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, windows))]
 mod tests {
     use super::{local_program, WSL_LOGIN_SHELL};
     use crate::config::Session;

--- a/ui/app.slint
+++ b/ui/app.slint
@@ -684,6 +684,8 @@ export component AppWindow inherits Window {
 
     // --- Session list ------------------------------------------------------
     in property <[SessionInfo]> sessions;
+    in-out property <string> host-search-query;
+    callback host-search-changed(string);
 
     // --- Tabs --------------------------------------------------------------
     in property <[TabInfo]> tabs;
@@ -1114,6 +1116,8 @@ export component AppWindow inherits Window {
                 dock-edge: root.welcome-sidebar-dock;
                 sessions: root.sessions;
                 import-hint: root.ssh-import-hint;
+                search-query <=> root.host-search-query;
+                search-changed(query) => { root.host-search-changed(query); }
                 collapse => {
                     root.welcome-collapsed = true;
                     root.set-welcome-collapsed(true);
@@ -1505,6 +1509,8 @@ export component AppWindow inherits Window {
                     height: parent.height;
                     sessions: root.sessions;
                     import-hint: root.ssh-import-hint;
+                    search-query <=> root.host-search-query;
+                    search-changed(query) => { root.host-search-changed(query); }
                     new-session => { root.new-session-clicked(); }
                     import-ssh-config => { root.import-ssh-config(); }
                     connect-session(id) => { root.connect-session(id); }

--- a/ui/terminal_view.slint
+++ b/ui/terminal_view.slint
@@ -1329,10 +1329,12 @@ export component TerminalView inherits Rectangle {
                     }
                     if cmd-input.text == "" : Text {
                         x: 8px;
+                        width: parent.width - 16px;
                         height: parent.height;
                         text: @tr("Type a command, Enter to send");
                         color: Theme.text-muted;
                         font-size: Theme.fs-md;
+                        horizontal-alignment: left;
                         vertical-alignment: center;
                     }
                 }

--- a/ui/welcome.slint
+++ b/ui/welcome.slint
@@ -252,6 +252,7 @@ component CollapseButton inherits Rectangle {
 export component Welcome inherits Rectangle {
     in property <[SessionInfo]> sessions;
     in property <string> import-hint;        // result text after an import
+    in-out property <string> search-query;
     callback new-session();
     callback import-ssh-config();
     callback connect-session(string);
@@ -263,6 +264,7 @@ export component Welcome inherits Rectangle {
     callback edit-group(string /* current-name */);
     callback delete-group(string /* name */);
     callback remove-session(string);
+    callback search-changed(string);
     callback cycle-tab(bool /* reverse */);
     // Compact mode (welcome-as-sidebar): drop the big title/tagline header and
     // tighten padding so the session list fits a narrow docked panel (#v0.5).
@@ -395,6 +397,110 @@ export component Welcome inherits Rectangle {
                     clicked => { root.new-session(); }
                 }
 
+                // Filter saved and built-in sessions by display name or host.
+                Rectangle {
+                    height: 32px;
+                    border-radius: Theme.radius-sm;
+                    border-width: 1px;
+                    border-color: search-input.has-focus ? Theme.accent : Theme.border-subtle;
+                    background: Theme.bg-root;
+
+                    HorizontalLayout {
+                        padding-left: 8px;
+                        padding-right: 4px;
+                        spacing: 6px;
+
+                        Text {
+                            text: "\u{E8B6}";
+                            font-family: "Material Icons";
+                            color: Theme.text-muted;
+                            font-size: Theme.fs-sm;
+                            vertical-alignment: center;
+                        }
+
+                        Rectangle {
+                            horizontal-stretch: 1;
+
+                            search-input := TextInput {
+                                width: parent.width;
+                                height: parent.height;
+                                text <=> root.search-query;
+                                color: Theme.text-primary;
+                                font-family: Theme.ui-font-family;
+                                font-size: Theme.fs-sm;
+                                vertical-alignment: center;
+                                single-line: true;
+                                edited => { root.search-changed(root.search-query); }
+                            }
+
+                            if root.search-query == "" : Text {
+                                width: parent.width;
+                                height: parent.height;
+                                text: @tr("Search by name or host...");
+                                color: Theme.text-muted;
+                                font-size: Theme.fs-sm;
+                                horizontal-alignment: left;
+                                vertical-alignment: center;
+                            }
+                        }
+
+                        if root.search-query != "" : Rectangle {
+                            width: 24px;
+                            height: parent.height;
+
+                            Rectangle {
+                                width: 24px;
+                                height: 24px;
+                                y: (parent.height - self.height) / 2;
+                                border-radius: Theme.radius-sm;
+                                background: clear-search.has-hover ? Theme.bg-hover : transparent;
+                                accessible-role: button;
+                                accessible-label: @tr("Clear search");
+
+                                Text {
+                                    text: "\u{E5CD}";
+                                    font-family: "Material Icons";
+                                    color: Theme.text-muted;
+                                    font-size: Theme.fs-sm;
+                                    horizontal-alignment: center;
+                                    vertical-alignment: center;
+                                }
+                                clear-search := TouchArea {
+                                    mouse-cursor: pointer;
+                                    clicked => {
+                                        root.search-query = "";
+                                        root.search-changed("");
+                                        search-input.focus();
+                                    }
+                                }
+
+                                if clear-search.has-hover : Rectangle {
+                                    x: parent.width - self.width;
+                                    y: parent.height + 4px;
+                                    width: clear-search-tip.preferred-width + 16px;
+                                    height: 22px;
+                                    background: Theme.bg-elevated;
+                                    border-radius: Theme.radius-sm;
+                                    border-width: 1px;
+                                    border-color: Theme.border-strong;
+                                    drop-shadow-blur: 8px;
+                                    drop-shadow-color: #00000070;
+
+                                    clear-search-tip := Text {
+                                        width: parent.width;
+                                        height: parent.height;
+                                        text: @tr("Clear search");
+                                        color: Theme.text-primary;
+                                        font-size: Theme.fs-xs;
+                                        horizontal-alignment: center;
+                                        vertical-alignment: center;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
                 if sessions.length == 0 : Rectangle {
                     vertical-stretch: 1;
                     background: Theme.bg-root;
@@ -406,12 +512,14 @@ export component Welcome inherits Rectangle {
                         alignment: center;
                         spacing: 6px;
                         Text {
-                            text: @tr("No sessions yet");
+                            text: root.search-query == ""
+                                ? @tr("No sessions yet")
+                                : @tr("No matching sessions");
                             color: Theme.text-secondary;
                             font-size: Theme.fs-md;
                             horizontal-alignment: center;
                         }
-                        Text {
+                        if root.search-query == "" : Text {
                             text: @tr("Use 'New session' (top-right) to add your first server");
                             color: Theme.text-muted;
                             font-size: Theme.fs-sm;
@@ -425,8 +533,12 @@ export component Welcome inherits Rectangle {
                     viewport-width: self.visible-width;
                     viewport-height: max(self.visible-height, sess-list.preferred-height);
                     sess-list := VerticalLayout {
-                    spacing: 2px;
+                    spacing: 0px;
                     for session[i] in sessions : VerticalLayout {
+                        // Exclude hidden rows from layout spacing while a group
+                        // is collapsed; keep its first row for the group header.
+                        visible: session.group-header != "" || !session.collapsed;
+                        padding-top: self.visible && i > 0 ? 2px : 0px;
                         spacing: 2px;
                         // Group header on the first row of each group (#41).
                         // Click anywhere on it to collapse / expand the group.
@@ -470,7 +582,11 @@ export component Welcome inherits Rectangle {
                                 mouse-cursor: pointer;
                                 // Left-click toggles collapse (any group, incl.
                                 // empty); right-click opens the group menu.
-                                clicked => { root.toggle-group(session.group); }
+                                clicked => {
+                                    if root.search-query == "" {
+                                        root.toggle-group(session.group);
+                                    }
+                                }
                                 pointer-event(e) => {
                                     if (!session.builtin && e.kind == PointerEventKind.down && e.button == PointerEventButton.right) {
                                         gmx = self.mouse-x;


### PR DESCRIPTION
## 背景

原 PR #264 已关闭且长期未同步 main。本 PR 基于当前最新 main 重新实现主机搜索，并合并验证过程中发现的 SSH 辅助通道断线修复。

本分支已经 rebase 到包含 #354 的最新 main；新的串行辅助通道方案覆盖了原先 detached task + AtomicBool 的启动路径，同时保留“侧栏折叠时不打开监控通道”的目标。

## 主要改动

### 1. Quick Connect 主机搜索

- 新增搜索框，支持按会话名称或主机地址过滤。
- 查询自动去除首尾空白并忽略大小写。
- 搜索范围包含：
  - 保存的 SSH/Telnet/Serial 会话；
  - Linux/macOS 本地 shell；
  - Windows PowerShell、CMD 和 WSL 内置会话。
- 搜索时隐藏没有匹配项的空分组。
- 搜索结果临时展开匹配分组，不覆盖用户保存的折叠状态。
- 清空搜索后恢复完整列表和原折叠状态。
- 新增、编辑、删除、移动、导入会话或修改 WSL 配置后保留当前查询。

### 2. 搜索框 UI 与国际化

- 增加搜索图标、清除按钮、悬浮提示和无障碍标签。
- 增加“没有匹配的会话”空状态。
- 增加中英文翻译：
  - Search by name or host...
  - No matching sessions
  - Clear search
- 修复清除按钮在 32px 搜索框中的垂直居中问题。
- 修复折叠分组仍为隐藏会话累计间距的问题。
- 普通欢迎页和紧凑侧栏共用同一搜索状态。

### 3. 命令输入框占位文字

- 为命令输入框占位文字补充有效宽度。
- 明确设置左对齐，修复占位提示在部分布局中未靠左的问题。

### 4. SSH 辅助通道稳定性

问题现象：

- 主终端已完成 terminal-ready 并显示首屏输出；
- 首个资源监控辅助通道在约 750ms 后启动；
- 部分严格 SSH 服务端随后关闭整个连接；
- 勾选“禁用 Shell 集成”后连接稳定，说明问题集中在辅助通道启动。

修复方案：

- 移除资源、进程、系统信息通道的 detached tokio::spawn 启动方式。
- 在 SSH 主任务内按以下顺序串行启动：
  1. Resources
  2. Processes
  3. SystemInfo
- 每个辅助通道的 open + exec 设置 3 秒超时。
- 单个通道失败或超时后继续下一阶段，不关闭主 PTY。
- 日志记录 startup-finished 和 available 状态，便于诊断。
- 禁用资源监控时跳过尚未启动的资源/进程通道。

### 5. Windows / pwsh 的“禁用 Shell 集成”

默认值和配置格式保持不变。

勾选后：

- 跳过 Bash/Zsh shell probe 和 PROMPT_COMMAND/OSC 注入；
- 跳过资源、进程、系统信息辅助通道；
- 禁止运行时重新开启这些辅助通道。

不受影响：

- SSH 连接与认证；
- PTY 和交互式 shell；
- 命令输入与窗口缩放；
- SFTP 手工浏览/传输；
- SSH 端口转发。

因此 Windows/pwsh 主会话仍可正常使用；仅自动 cwd 跟随、终端命令历史采集和 Linux 资源/进程信息不可用，这正是该选项的设计目的。

### 6. 测试门控

- 将 Windows-only 本地终端测试模块限制为 test + windows。
- 修复 Linux 下 cargo test 因导入 Windows-only WSL_LOGIN_SHELL 而无法编译的问题。
- 不改变任何运行时逻辑。

## 代码范围

- lang/en/LC_MESSAGES/meatshell.po
- lang/zh/LC_MESSAGES/meatshell.po
- src/app.rs
- src/app/session_models.rs
- src/ssh/impls/ssh.rs
- src/terminal/impls/local.rs
- ui/app.slint
- ui/terminal_view.slint
- ui/welcome.slint

## 验证结果

- cargo test --no-fail-fast
  - 164 passed
  - 0 failed
- cargo build
  - 通过，仅有项目既有 warnings
- git diff --check
  - 通过
- 人工验证
  - 主机搜索和清除搜索正常
  - 清除按钮垂直居中
  - 折叠分组间距正常
  - 勾选“禁用 Shell 集成”后远程终端连接稳定

## 已知权衡

辅助通道在主 SSH pump 内串行执行。异常服务器如果让辅助 channel open/exec 无响应，单阶段最多等待 3 秒；超时后会继续，不会无限冻结或关闭主终端。

## 关联

Supersedes #264
