### PR TITLE
fix(ui): 系统信息弹窗表格列对齐并让长内容自动换行 / align system-info table columns and wrap long cell content

### DIFF
--- a/ui/system_info_window.slint
+++ b/ui/system_info_window.slint
@@ -41,24 +41,11 @@ component CellText inherits Text {
     color: root.muted ? Theme.text-muted : Theme.text-primary;
     font-size: Theme.fs-xs;
     font-family: Theme.font-mono;
-    overflow: elide;
+    // Long values (mount paths, CPU breakdown lines, wide headers) wrap into a
+    // second line instead of being elided; rows grow to fit via preferred-height.
+    wrap: char-wrap;
     horizontal-alignment: center;
     vertical-alignment: center;
-}
-
-component CellBox inherits Rectangle {
-    in property <string> text;
-    in property <bool> muted: false;
-    in property <float> weight: 1.0;
-    horizontal-stretch: root.weight;
-    clip: true;
-
-    CellText {
-        text: root.text;
-        muted: root.muted;
-        width: parent.width;
-        height: parent.height;
-    }
 }
 
 component PairGrid inherits InfoCard {
@@ -92,7 +79,7 @@ component PairGrid inherits InfoCard {
                 }
             }
             for r in root.rows : Rectangle {
-                height: 34px;
+                height: max(34px, c1.preferred-height, c2.preferred-height, c3.preferred-height, c4.preferred-height);
                 Rectangle {
                     x: 0;
                     y: parent.height - 1px;
@@ -100,13 +87,10 @@ component PairGrid inherits InfoCard {
                     height: 1px;
                     background: Theme.border-subtle.with-alpha(0.65);
                 }
-                HorizontalLayout {
-                    spacing: 12px;
-                        CellBox { text: r.c1; muted: true; weight: 0.12; }
-                        CellBox { text: r.c2; weight: 0.38; }
-                        CellBox { text: r.c3; muted: true; weight: 0.12; }
-                        CellBox { text: r.c4; weight: 0.38; }
-                }
+                c1 := CellText { text: r.c1; muted: true; x: 14px; width: (parent.width - 28px - 36px) * 0.12; height: parent.height; }
+                c2 := CellText { text: r.c2; x: 14px + (parent.width - 28px - 36px) * 0.12 + 12px; width: (parent.width - 28px - 36px) * 0.38; height: parent.height; }
+                c3 := CellText { text: r.c3; muted: true; x: 14px + (parent.width - 28px - 36px) * 0.50 + 24px; width: (parent.width - 28px - 36px) * 0.12; height: parent.height; }
+                c4 := CellText { text: r.c4; x: 14px + (parent.width - 28px - 36px) * 0.62 + 36px; width: (parent.width - 28px - 36px) * 0.38; height: parent.height; }
             }
         }
     }
@@ -141,18 +125,13 @@ component TableCard inherits InfoCard {
             }
         }
         Rectangle {
-            height: 30px;
+            height: max(30px, h1.preferred-height, h2.preferred-height, h3.preferred-height, h4.preferred-height, h5.preferred-height);
             background: Theme.bg-root.with-alpha(0.28);
-            HorizontalLayout {
-                padding-left: 14px;
-                padding-right: 14px;
-                spacing: 12px;
-                CellBox { text: root.h1; muted: true; weight: root.c1w; }
-                CellBox { text: root.h2; muted: true; weight: root.c2w; }
-                CellBox { text: root.h3; muted: true; weight: root.c3w; }
-                CellBox { text: root.h4; muted: true; weight: root.c4w; }
-                if root.c5w > 0.0 : CellBox { text: root.h5; muted: true; weight: root.c5w; }
-            }
+            h1 := CellText { text: root.h1; muted: true; x: 14px; width: (parent.width - 28px - 48px) * root.c1w; height: parent.height; }
+            h2 := CellText { text: root.h2; muted: true; x: 14px + (parent.width - 28px - 48px) * root.c1w + 12px; width: (parent.width - 28px - 48px) * root.c2w; height: parent.height; }
+            h3 := CellText { text: root.h3; muted: true; x: 14px + (parent.width - 28px - 48px) * (root.c1w + root.c2w) + 24px; width: (parent.width - 28px - 48px) * root.c3w; height: parent.height; }
+            h4 := CellText { text: root.h4; muted: true; x: 14px + (parent.width - 28px - 48px) * (root.c1w + root.c2w + root.c3w) + 36px; width: (parent.width - 28px - 48px) * root.c4w; height: parent.height; }
+            h5 := CellText { text: root.h5; muted: true; x: 14px + (parent.width - 28px - 48px) * (root.c1w + root.c2w + root.c3w + root.c4w) + 48px; width: (parent.width - 28px - 48px) * root.c5w; height: parent.height; }
         }
         if root.rows.length == 0 : Rectangle {
             height: 36px;
@@ -165,7 +144,7 @@ component TableCard inherits InfoCard {
             }
         }
         for r in root.rows : Rectangle {
-            height: 34px;
+            height: max(34px, c1.preferred-height, c2.preferred-height, c3.preferred-height, c4.preferred-height, c5.preferred-height);
             background: row-ta.has-hover ? Theme.bg-hover : transparent;
             Rectangle {
                 width: parent.width;
@@ -173,16 +152,11 @@ component TableCard inherits InfoCard {
                 background: Theme.border-subtle.with-alpha(0.48);
             }
             row-ta := TouchArea {}
-            HorizontalLayout {
-                padding-left: 14px;
-                padding-right: 14px;
-                spacing: 12px;
-                CellBox { text: r.c1; weight: root.c1w; }
-                CellBox { text: r.c2; weight: root.c2w; }
-                CellBox { text: r.c3; weight: root.c3w; }
-                CellBox { text: r.c4; weight: root.c4w; }
-                if root.c5w > 0.0 : CellBox { text: r.c5; weight: root.c5w; }
-            }
+            c1 := CellText { text: r.c1; x: 14px; width: (parent.width - 28px - 48px) * root.c1w; height: parent.height; }
+            c2 := CellText { text: r.c2; x: 14px + (parent.width - 28px - 48px) * root.c1w + 12px; width: (parent.width - 28px - 48px) * root.c2w; height: parent.height; }
+            c3 := CellText { text: r.c3; x: 14px + (parent.width - 28px - 48px) * (root.c1w + root.c2w) + 24px; width: (parent.width - 28px - 48px) * root.c3w; height: parent.height; }
+            c4 := CellText { text: r.c4; x: 14px + (parent.width - 28px - 48px) * (root.c1w + root.c2w + root.c3w) + 36px; width: (parent.width - 28px - 48px) * root.c4w; height: parent.height; }
+            c5 := CellText { text: r.c5; x: 14px + (parent.width - 28px - 48px) * (root.c1w + root.c2w + root.c3w + root.c4w) + 48px; width: (parent.width - 28px - 48px) * root.c5w; height: parent.height; }
         }
     }
 }


### PR DESCRIPTION
## 修改内容 / Changes

仅修改 `ui/system_info_window.slint` 一个文件(系统信息弹窗),纯界面层改动,无任何 Rust/业务逻辑变更。

### 1. 表格逐列对齐(修复"列扭")
弹窗内所有表格(Overview、CPU、GPU、CPU usage、内存、交换、网络、文件系统)原先用 Slint 布局的弹性权重分配列宽,单元格内容一长就会把所在列撑宽、挤压相邻列,导致**每一行的列边界都不一致**,整页表格错位。

改为按**行宽固定比例**定位每个单元格(与仓库内"进程监控"表格的固定列宽同一思路):
- 列宽 = 行宽 × 固定权重,与内容长度无关;
- 表头与数据行共用同一套比例,逐列对齐;
- 删除会导致布局循环退化的 `CellBox` 间接层。

### 2. 长内容自动换行(替代省略号截断)
单元格从 `overflow: elide` 改为 `wrap: char-wrap`:
- 超长内容(如 `/run/credentials/systemd-journald.service` 挂载路径、CPU usage 的 IO/IRQ/SoftIRQ/Steal 明细、宽表头 "Vendor / BogoMips")自动折为两行,不再以 `…` 截断;
- 行高按内容自适应(`max(34px, 各单元格 preferred-height)`),两行内容不会被裁切或压到下一行;
- 短内容不受影响,仍为单行。

### 验证 / Verification
- `cargo check --all-targets` 通过
- `cargo test` 159 通过 / 0 失败
- 已在本地 Windows 实测:表格逐列对齐、长内容自动换行正常(用户确认)

### 影响范围 / Impact
仅系统信息弹窗的表格渲染;无 Rust 逻辑改动,无行为/数据变更。

---

Only `ui/system_info_window.slint` is changed (the system-information window), UI-layer only. Tables are laid out with fixed row-width fractions so columns align across every row and table; cells wrap at character boundaries so overlong content (mount paths, CPU breakdowns, wide headers) flows onto a second line with content-sized row heights instead of being elided.