### PR TITLE
fix(sidebar): 本地终端显示本机资源而非空值

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -3913,6 +3913,7 @@ fn wire_session_callbacks(
                     user: session.user.clone(),
                     session_id: id.clone(),
                     state: 0,
+                    is_local: session.kind == SessionKind::Local,
                     ..Default::default()
                 },
             );

--- a/src/app/sidebar.rs
+++ b/src/app/sidebar.rs
@@ -197,6 +197,23 @@ pub(super) fn refresh_sidebar(
             vm.set_vec(tuple5_rows(&sys.filesystems));
         }
     };
+    let show_local_system_models = |win: &AppWindow| {
+        set_system_models(
+            win,
+            snap.cpu_percent,
+            snap.mem_percent,
+            snap.swap_percent,
+            format_mem(snap.mem_used_mib, snap.mem_total_mib).into(),
+            format_mem(snap.swap_used_mib, snap.swap_total_mib).into(),
+            vec![SysNetRow {
+                name: t("本机", "Local").into(),
+                up: format_bytes_per_sec(snap.net_tx_per_sec).into(),
+                down: format_bytes_per_sec(snap.net_rx_per_sec).into(),
+            }],
+            Vec::new(),
+            SystemDetails::default(),
+        );
+    };
     win.set_proc_available(false);
     win.set_system_info_available(false);
     set_procs(win, &[], "", "");
@@ -209,7 +226,30 @@ pub(super) fn refresh_sidebar(
     };
 
     match status {
-        // A live session tab → remote resources + remote NIC on top.
+        // Local shell tabs: keep the connection status line, but show the local
+        // machine's resources (their TabStatus carries no remote CPU/mem stats).
+        Some(st) if st.is_local => {
+            win.set_conn_state(if st.state == 1 {
+                1
+            } else if st.state == 2 {
+                2
+            } else {
+                0
+            });
+            win.set_connection_state(if st.state == 1 {
+                st.host.clone()
+            } else if st.state == 2 {
+                format!("{} {}", st.host, t("已断开", "disconnected"))
+            } else {
+                format!("{} {}", t("连接中", "Connecting"), st.host)
+            }
+            .into());
+            win.set_conn_host(conn_ip(&st.host).into());
+            show_local_res(win);
+            set_top_local(win);
+            show_local_system_models(win);
+        }
+        // A live remote session tab → remote resources + remote NIC on top.
         Some(st) if st.state == 1 => {
             win.set_conn_state(1);
             win.set_connection_state(st.host.clone().into());
@@ -293,21 +333,7 @@ pub(super) fn refresh_sidebar(
             win.set_conn_host("".into());
             show_local_res(win);
             set_top_local(win);
-            set_system_models(
-                win,
-                snap.cpu_percent,
-                snap.mem_percent,
-                snap.swap_percent,
-                format_mem(snap.mem_used_mib, snap.mem_total_mib).into(),
-                format_mem(snap.swap_used_mib, snap.swap_total_mib).into(),
-                vec![SysNetRow {
-                    name: t("本机", "Local").into(),
-                    up: format_bytes_per_sec(snap.net_tx_per_sec).into(),
-                    down: format_bytes_per_sec(snap.net_rx_per_sec).into(),
-                }],
-                Vec::new(),
-                SystemDetails::default(),
-            );
+            show_local_system_models(win);
         }
     }
 }

--- a/src/resource/struct/system.rs
+++ b/src/resource/struct/system.rs
@@ -60,6 +60,9 @@ pub(crate) struct TabStatus {
     pub(crate) user: String,
     pub(crate) session_id: String,
     pub(crate) state: u8,
+    /// True for built-in local shell tabs (system:*). Those should show the
+    /// local machine's resource panel, not the (empty) remote stats fields.
+    pub(crate) is_local: bool,
     pub(crate) cpu: f32,
     pub(crate) mem_used_kib: u64,
     pub(crate) mem_total_kib: u64,


### PR DESCRIPTION
## 问题

在本地打开终端页面时，右侧资源侧栏的 CPU / 内存 / 交换全部显示为 0。

## 原因

本地终端也会创建 `TabStatus` 并在连接后进入 `state == 1`，侧栏因此走“服务器资源”分支，读取 `st.cpu / st.mem / st.swap` 等远程统计字段；但本地终端不会产生 `ResourceStats`，这些字段始终是默认值 0。

## 修改

- `TabStatus` 增加 `is_local` 标记；
- 创建本地终端会话时设置 `is_local = true`；
- 侧栏刷新时对本地终端单独处理：
  - 保留连接状态显示（连接中 / 已连接 / 已断开）；
  - 资源区改为显示本机 CPU / 内存 / 交换 / 网络 / 磁盘；
  - 不显示远程进程/系统信息入口。

## 验证

`cargo check` 通过。