### PR TITLE
fix(input): route settings wheel events away from macOS terminal fallback

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2226,6 +2226,12 @@ pub fn run() -> Result<()> {
                         let Some(win) = weak.upgrade() else {
                             return EventResult::Propagate;
                         };
+                        if !macos_terminal_wheel_can_target_terminal(win.get_interface_open()) {
+                            // Do not carry a partially accumulated settings gesture
+                            // into the terminal after the modal closes.
+                            macos_wheel_accum = 0.0;
+                            return EventResult::Propagate;
+                        }
                         let wheel_lines = match delta {
                             MouseScrollDelta::LineDelta(_, dy) => dy * 3.0,
                             MouseScrollDelta::PixelDelta(p) => {
@@ -2629,6 +2635,12 @@ fn handle_macos_terminal_wheel(
         win.invoke_terminal_scroll(hit.tab_id.into(), lines);
     }
     true
+}
+
+// The raw macOS wheel fallback runs before the usual Slint hit testing. Keep
+// modal-state routing explicit so it cannot target a terminal behind a dialog.
+fn macos_terminal_wheel_can_target_terminal(interface_open: bool) -> bool {
+    !interface_open
 }
 
 fn terminal_wheel_hit(

--- a/tests/app/terminal_rendering/mod.rs
+++ b/tests/app/terminal_rendering/mod.rs
@@ -38,6 +38,12 @@ fn make_buf(
     }
 }
 
+#[test]
+fn settings_modal_yields_macos_wheel_to_its_own_scroll_view() {
+    assert!(macos_terminal_wheel_can_target_terminal(false));
+    assert!(!macos_terminal_wheel_can_target_terminal(true));
+}
+
 mod colors;
 mod protocol;
 mod selection;


### PR DESCRIPTION
## Summary
- let the settings modal keep macOS trackpad wheel events instead of routing periodic accumulated deltas to the terminal behind it
- reset the native wheel accumulator while the modal is open so closing it cannot scroll the terminal with leftover gesture input
- add a regression test for modal wheel routing

## Testing
- cargo check
- cargo test