### PR TITLE
支持新建窗口、命令栏隐藏、终端字体缩放及主机列表拖动

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ Cargo.lock
 /.codegraph
 /AGENTS.md
 /opencode.jsonc
+/.qoder
+/docs/superpowers

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3464,6 +3464,9 @@ dependencies = [
  "icu_provider",
  "image",
  "md5",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
  "portable-pty",
  "rand 0.8.6",
  "raw-window-handle",
@@ -3492,6 +3495,7 @@ dependencies = [
  "ureq",
  "uuid",
  "vt100",
+ "windows 0.58.0",
  "winresource",
  "zeroize",
 ]
@@ -4079,6 +4083,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
  "block2 0.6.2",
+ "libc",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,13 @@ arboard = { version = "3", features = ["wayland-data-control"] }
 # import library at link time when using the MSVC toolchain (#224).
 [target.'cfg(target_os = "macos")'.dependencies]
 slint = { version = "1.8", features = ["renderer-skia"] }
+# Dock context menu ("新建窗口", see src/app/dock_menu.rs): winit's
+# NSApplication delegate does not implement applicationDockMenu:, so we add
+# that method (plus the menu item's action) to the NSApplication class at
+# runtime via class_addMethod. MSRV 1.71 fits the repo's 1.75 floor.
+objc2 = "0.6"
+objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSMenu", "NSMenuItem"] }
+objc2-foundation = { version = "0.3", features = ["NSString"] }
 
 [build-dependencies]
 slint-build = "1.8"
@@ -125,6 +132,20 @@ slint-build = "1.8"
 # show the app icon. Windows-only; ignored on other targets.
 [target.'cfg(windows)'.build-dependencies]
 winresource = "0.1"
+
+# Win32 COM APIs for the taskbar jump list ("新建窗口" task, see
+# src/app/jump_list.rs). 0.58 matches the version already in Cargo.lock via
+# transitive deps, keeping the lock diff minimal.
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.58", features = [
+    "Win32_Foundation",
+    "Win32_Storage_EnhancedStorage",
+    "Win32_System_Com",
+    "Win32_System_Com_StructuredStorage",
+    "Win32_UI_Shell",
+    "Win32_UI_Shell_Common",
+    "Win32_UI_Shell_PropertiesSystem",
+] }
 
 [profile.release]
 opt-level = 3

--- a/README.en.md
+++ b/README.en.md
@@ -101,6 +101,7 @@ open /Applications/meatshell.app
 - [x] Session passwords encrypted at rest (ChaCha20-Poly1305)
 - [x] Known-hosts (`known_hosts`) verification + first-connect confirmation
 - [x] Split panes for tabbed terminals
+- [x] Multiple windows: Ctrl+Shift+N (macOS ⌘⇧N) or the system "New window" entry (Windows taskbar / macOS Dock / Linux desktop right-click), managed as a single Chrome-style process
 
 Color emoji graphics are provided by [Twemoji](https://github.com/jdecked/twemoji)
 under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/). See

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ open /Applications/meatshell.app
 - [x] 会话密码加密存储（ChaCha20-Poly1305）
 - [x] 已知主机（`known_hosts`）校验 + 首次连接确认
 - [x] 多标签页终端分屏
+- [x] 多窗口：Ctrl+Shift+N（macOS ⌘⇧N）或系统入口“新建窗口”（Windows 任务栏 / macOS Dock / Linux 桌面右键），Chrome 式单进程管理
 
 彩色 emoji 图形来自 [Twemoji](https://github.com/jdecked/twemoji)，按
 [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) 使用；完整署名见

--- a/assets/install-linux.sh
+++ b/assets/install-linux.sh
@@ -65,6 +65,12 @@ Categories=Network;System;TerminalEmulator;Utility;
 Keywords=ssh;sftp;terminal;shell;
 StartupNotify=true
 StartupWMClass=meatshell
+Actions=new-window;
+
+[Desktop Action new-window]
+Name=New Window
+Name[zh_CN]=新建窗口
+Exec=$BIN --new-window
 EOF
 chmod 644 "$APP_DIR/meatshell.desktop"
 

--- a/assets/meatshell.desktop
+++ b/assets/meatshell.desktop
@@ -11,3 +11,9 @@ Categories=Network;System;TerminalEmulator;Utility;
 Keywords=ssh;sftp;terminal;shell;
 StartupNotify=true
 StartupWMClass=meatshell
+Actions=new-window;
+
+[Desktop Action new-window]
+Name=New Window
+Name[zh_CN]=新建窗口
+Exec=meatshell --new-window

--- a/lang/en/LC_MESSAGES/meatshell.po
+++ b/lang/en/LC_MESSAGES/meatshell.po
@@ -536,3 +536,6 @@ msgstr "No matching sessions"
 
 msgid "Clear search"
 msgstr "Clear search"
+
+msgid "新建窗口"
+msgstr "New Window"

--- a/lang/en/LC_MESSAGES/meatshell.po
+++ b/lang/en/LC_MESSAGES/meatshell.po
@@ -539,3 +539,9 @@ msgstr "Clear search"
 
 msgid "新建窗口"
 msgstr "New Window"
+
+msgid "Session name"
+msgstr "Session name"
+
+msgid "Leave empty to restore the default name"
+msgstr "Leave empty to restore the default name"

--- a/lang/zh/LC_MESSAGES/meatshell.po
+++ b/lang/zh/LC_MESSAGES/meatshell.po
@@ -536,3 +536,9 @@ msgstr "没有匹配的会话"
 
 msgid "Clear search"
 msgstr "清除搜索"
+
+msgid "Session name"
+msgstr "会话名称"
+
+msgid "Leave empty to restore the default name"
+msgstr "留空则恢复默认名称"

--- a/src/app.rs
+++ b/src/app.rs
@@ -912,6 +912,17 @@ fn open_window(
         });
     }
 
+    // Toolbar toggle: hide/show the quick-command bar (persisted globally).
+    window.set_cmd_bar_hidden(store.borrow().cmd_bar_hidden());
+    {
+        let store = store.clone();
+        window.on_set_cmd_bar_hidden(move |hidden| {
+            let mut s = store.borrow_mut();
+            s.set_cmd_bar_hidden(hidden);
+            let _ = s.save();
+        });
+    }
+
     // Interface setting: always ask where to save on download (#87). Read live
     // by the download handler from the window property, so just set + persist.
     window.set_download_always_ask(store.borrow().download_always_ask());
@@ -1368,30 +1379,6 @@ fn open_window(
         });
     }
     {
-        // Font zoom shortcuts (Ctrl+= / Ctrl+- / Ctrl+0). direction:
-        // +1 larger, -1 smaller, 0 = reset to the 13px default. Reuses the
-        // settings stepper's persist path; the Theme.term-font-size change
-        // re-measures the cell grid and triggers the PTY resize on its own.
-        let weak = window.as_weak();
-        let store = store.clone();
-        window.on_zoom_term_font(move |direction: i32| {
-            let next = {
-                let mut s = store.borrow_mut();
-                let next = if direction == 0 {
-                    13
-                } else {
-                    s.font_size() as i32 + direction
-                };
-                s.set_font_size(next.clamp(8, 32) as u32);
-                let _ = s.save();
-                s.font_size()
-            };
-            if let Some(w) = weak.upgrade() {
-                w.set_term_font_size(next as f32);
-            }
-        });
-    }
-    {
         let store = store.clone();
         window.on_persist_sftp_tree_width(move |width| {
             let mut s = store.borrow_mut();
@@ -1789,6 +1776,68 @@ fn open_window(
         let terminals_model = terminals_model.clone();
         window.on_set_pane_sftp_collapsed(move |tab_id: SharedString, v: bool| {
             update_terminal_row(&terminals_model, &tab_id, |r| r.sftp_collapsed = v);
+        });
+    }
+    {
+        // Font zoom shortcuts. Ctrl+=/-/0 zooms one session: a per-tab px
+        // override; Ctrl+0 resets that session to the size chosen in
+        // Settings. Ctrl+Shift+=/-/0 zooms every session in this window
+        // (shared term-font-size, cleared per-tab overrides so it visibly
+        // applies to all); Ctrl+Shift+0 resets the window to the Settings
+        // size. Zoom never persists globally — the settings stepper owns
+        // that. Changing the size re-measures the cell grid and triggers the
+        // PTY resize on its own.
+        let weak = window.as_weak();
+        let store = store.clone();
+        let terminals_model = terminals_model.clone();
+        window.on_zoom_term_font(move |tab_id: SharedString, direction: i32, window_wide: bool| {
+            let Some(w) = weak.upgrade() else {
+                return;
+            };
+            let settings_size = store.borrow().font_size() as i32;
+            if window_wide {
+                let next = if direction == 0 {
+                    settings_size
+                } else {
+                    w.get_term_font_size() as i32 + direction
+                };
+                w.set_term_font_size(next.clamp(8, 32) as f32);
+                // Per-tab overrides would pin sessions at their old size and
+                // defeat "zoom everything", so drop them.
+                use slint::Model as _;
+                for row in terminals_model.iter() {
+                    if row.font_size > 0 {
+                        let id = row.id.to_string();
+                        update_terminal_row(&terminals_model, &id, |r| r.font_size = 0);
+                    }
+                }
+                return;
+            }
+            let tab_id = tab_id.to_string();
+            if tab_id.is_empty() || tab_id == "welcome" {
+                return;
+            }
+            use slint::Model as _;
+            let Some(row) = terminals_model
+                .iter()
+                .find(|r| r.id.to_string() == tab_id)
+            else {
+                return;
+            };
+            if direction == 0 {
+                // Back to the Settings size, regardless of the window base.
+                update_terminal_row(&terminals_model, &tab_id, |r| {
+                    r.font_size = settings_size.clamp(8, 32)
+                });
+                return;
+            }
+            let base = if row.font_size > 0 {
+                row.font_size
+            } else {
+                w.get_term_font_size() as i32
+            };
+            let next = (base + direction).clamp(8, 32);
+            update_terminal_row(&terminals_model, &tab_id, |r| r.font_size = next);
         });
     }
     {
@@ -2751,6 +2800,7 @@ fn open_window(
                         // No sessions → the window is about to close; persist layout.
                         if let Some(win) = weak.upgrade() {
                             save_layout(&win, &ev_store);
+                            clear_zen_on_close(&win, &ev_store);
                         }
                         // The event is not prevented, so Slint will destroy this
                         // window. Mirror the confirmed custom-close path: tear down
@@ -2794,6 +2844,7 @@ fn open_window(
             if let Some(w) = weak.upgrade() {
                 w.set_confirm_close_open(false);
                 save_layout(&w, &cc_store);
+                clear_zen_on_close(&w, &cc_store);
                 let _ = w.hide();
             }
             // Ask every worker to stop before the runtime/event loop is torn
@@ -2855,6 +2906,7 @@ fn open_window(
                 {
                     wc_exit_confirmed.set(true);
                     save_layout(&w, &wc_store);
+                    clear_zen_on_close(&w, &wc_store);
                     // Tear down this window's workers and hide its monitor
                     // windows; quit only if it was the last one.
                     teardown_window(
@@ -4402,6 +4454,7 @@ fn wire_session_callbacks(
                 sftp_sort_key: "".into(),
                 sftp_sort_dir: 0,
                 sftp_available: has_sftp,
+                font_size: 0,
                 tunnels: ModelRc::from(std::rc::Rc::new(VecModel::<TunnelInfo>::default())),
                 sftp_collapsed: !has_sftp || sftp_collapsed_default,
                 sftp_panel_height: sftp_h_default,
@@ -4558,6 +4611,19 @@ fn save_layout(win: &AppWindow, store: &Rc<RefCell<ConfigStore>>) {
     let _ = s.save();
 }
 
+/// Zen is a transient per-window state. Closing a window while it is on must
+/// not leak the persisted flag into the next window, which would open stuck in
+/// zen mode (#zen). Called on every confirmed-close path right after
+/// `save_layout`.
+pub(super) fn clear_zen_on_close(win: &AppWindow, store: &Rc<RefCell<ConfigStore>>) {
+    if !win.get_zen_mode() {
+        return;
+    }
+    let mut s = store.borrow_mut();
+    s.set_zen_mode(false);
+    let _ = s.save();
+}
+
 /// Every quick-command group name (used to start with all groups collapsed, #55):
 /// "default" when any ungrouped command exists, plus explicit quick-groups and any
 /// group referenced by a command.
@@ -4637,7 +4703,7 @@ fn refresh_panes(
                 h: p.h,
                 active_id: p.active.clone().into(),
                 focused: p.focused,
-                reserve_right: if top_right { 140.0 } else { 0.0 },
+                reserve_right: if top_right { 180.0 } else { 0.0 },
                 tabs: ModelRc::from(Rc::new(VecModel::from(tabs))),
             }
         })

--- a/src/app.rs
+++ b/src/app.rs
@@ -1875,6 +1875,10 @@ fn open_window(
     let local_snap: LocalSnap = Arc::new(Mutex::new(SystemSnapshot::default()));
     let local_net_hist: NetHist = Arc::new(Mutex::new(vec![0.0; NET_HISTORY_LEN]));
 
+    // Per-tab display-name overrides set via "Rename session" (tab context
+    // menu). Display only — the saved session keeps its own name.
+    let tab_titles: Rc<RefCell<HashMap<String, String>>> = Rc::new(RefCell::new(HashMap::new()));
+
     // Expose this window's state to the rest of the process so tabs can be
     // dragged out into a new window or merged into another one (#tab-detach).
     core.window_states.borrow_mut().insert(
@@ -2007,6 +2011,7 @@ fn open_window(
         local_net_hist.clone(),
         sftp_follow_cd.clone(),
         core.tab_routes.clone(),
+        tab_titles.clone(),
     );
 
     // Recompute the sidebar whenever the active tab changes (fired from Slint's
@@ -2387,6 +2392,7 @@ fn open_window(
         render_gates.clone(),
         sftp_handles.clone(),
         sftp_last_cwd.clone(),
+        tab_titles.clone(),
     );
     wire_sftp_callbacks(&window, sftp_handles.clone(), sftp_last_cwd.clone());
     wire_key_input(
@@ -3456,12 +3462,16 @@ fn wire_session_callbacks(
     local_net_hist: NetHist,
     sftp_follow_cd: Arc<std::sync::atomic::AtomicBool>,
     tab_routes: TabRoutes,
+    tab_titles: Rc<RefCell<HashMap<String, String>>>,
 ) {
     // Working set of port forwards (#56) for the session being created/edited.
     // The forward add/delete callbacks mutate it; saving reads it into
     // Session.forwards; opening the dialog (new/edit) resets it.
     let edit_forwards: Rc<RefCell<Vec<PortFwd>>> =
         Rc::new(RefCell::new(vec![blank_forward_draft()]));
+    // on_connect_session moves the panes_model binding into its closure; the
+    // rename handler below needs its own handle, so clone up front.
+    let panes_model_rename = panes_model.clone();
 
     // Rebuild the session list as the user edits the Quick Connect search.
     {
@@ -3844,6 +3854,65 @@ fn wire_session_callbacks(
             if moved {
                 registry.broadcast_config_changed();
             }
+            if let Some(w) = weak.upgrade() {
+                let _ = w.get_sessions();
+            }
+        });
+    }
+
+    // Drag-to-reorder a host card among its same-group siblings. The stored
+    // Vec order is the display order (no alphabetical sort), so a swap plus
+    // re-sync is all it takes. Reordering while the list is filtered would map
+    // visible hops onto the wrong stored neighbours, so bail out then — the
+    // Slint side already disables the gesture while searching.
+    //
+    // Per-hop updates mutate the model IN PLACE (set_row_data): a full set_vec
+    // rebuild would recreate the rows and drop the dragging row's pointer grab,
+    // ending the drag after one hop. Saving + broadcasting are deferred to
+    // reorder-session-end (pointer release).
+    let sessions_dirty = Rc::new(std::cell::Cell::new(false));
+    {
+        let weak = window.as_weak();
+        let store = store.clone();
+        let sessions_model = sessions_model.clone();
+        let sessions_dirty = sessions_dirty.clone();
+        window.on_reorder_session(move |id: SharedString, dir: i32| {
+            if weak
+                .upgrade()
+                .map(|window| !window.get_host_search_query().trim().is_empty())
+                .unwrap_or(false)
+            {
+                return;
+            }
+            let moved = {
+                let mut s = store.borrow_mut();
+                s.reorder_session(id.as_str(), dir as isize)
+            };
+            if moved {
+                sessions_dirty.set(true);
+                let query = weak
+                    .upgrade()
+                    .map(|w| w.get_host_search_query().to_string())
+                    .unwrap_or_default();
+                refresh_session_rows_in_place(&store.borrow(), &sessions_model, &query);
+            }
+        });
+    }
+    {
+        let weak = window.as_weak();
+        let store = store.clone();
+        let sessions_model = sessions_model.clone();
+        let registry = registry.clone();
+        let sessions_dirty = sessions_dirty.clone();
+        window.on_reorder_session_end(move || {
+            if !sessions_dirty.replace(false) {
+                return;
+            }
+            if let Err(err) = store.borrow_mut().save() {
+                tracing::warn!("failed to save config: {err:#}");
+            }
+            sync_sessions_for_window(&weak, &store.borrow(), &sessions_model);
+            registry.broadcast_config_changed();
             if let Some(w) = weak.upgrade() {
                 let _ = w.get_sessions();
             }
@@ -4566,6 +4635,100 @@ fn wire_session_callbacks(
             }
             if let Some(w) = weak.upgrade() {
                 w.invoke_connect_session(session_id.into());
+            }
+        });
+    }
+
+    // Rename session (tab context menu): open the dialog pre-filled with the
+    // tab's current title.
+    {
+        let weak = window.as_weak();
+        let tabs_model = tabs_model.clone();
+        window.on_tab_rename_request(move |tab_id: SharedString| {
+            let tab_id = tab_id.to_string();
+            if tab_id.is_empty() || tab_id == "welcome" {
+                return;
+            }
+            use slint::Model as _;
+            let title = (0..tabs_model.row_count())
+                .find_map(|i| {
+                    let row = tabs_model.row_data(i)?;
+                    (row.id.as_str() == tab_id).then(|| row.title.to_string())
+                })
+                .unwrap_or_default();
+            if let Some(w) = weak.upgrade() {
+                w.set_tab_rename_id(tab_id.into());
+                w.set_tab_rename_value(title.into());
+                w.set_tab_rename_open(true);
+            }
+        });
+    }
+
+    // Apply the new display name. An empty name clears the override and
+    // restores the saved session's name. Display-only: the config is untouched.
+    {
+        let weak = window.as_weak();
+        let tabs_model = tabs_model.clone();
+        let panes_model = panes_model_rename.clone();
+        let tab_statuses = tab_statuses.clone();
+        let tab_titles = tab_titles.clone();
+        let store = store.clone();
+        window.on_rename_tab(move |tab_id: SharedString, name: SharedString| {
+            use slint::Model as _;
+            if let Some(w) = weak.upgrade() {
+                w.set_tab_rename_open(false);
+            }
+            let tab_id = tab_id.to_string();
+            let name = name.trim().to_string();
+            let title = if name.is_empty() {
+                tab_titles.borrow_mut().remove(&tab_id);
+                let session_id = tab_statuses
+                    .lock()
+                    .unwrap()
+                    .get(&tab_id)
+                    .map(|s| s.session_id.clone())
+                    .unwrap_or_default();
+                // Two separate borrows: the builtin fallback must not run while
+                // the store lookup's RefCell borrow is still alive.
+                let saved = store.borrow().get(&session_id).map(|s| s.name.clone());
+                saved.or_else(|| {
+                    session_models::builtin_local_sessions(store.borrow().wsl_profiles())
+                        .into_iter()
+                        .find(|s| s.id == session_id)
+                        .map(|s| s.name)
+                })
+            } else {
+                tab_titles.borrow_mut().insert(tab_id.clone(), name.clone());
+                Some(name)
+            };
+            let Some(title) = title else {
+                return;
+            };
+            for i in 0..tabs_model.row_count() {
+                if let Some(mut row) = tabs_model.row_data(i) {
+                    if row.id.as_str() == tab_id {
+                        row.title_len = tab_title_len(&title);
+                        row.title = title.clone().into();
+                        tabs_model.set_row_data(i, row);
+                        break;
+                    }
+                }
+            }
+            // The tab strips render pane.tabs — per-pane snapshot sub-models
+            // built by refresh_panes — not tabs_model itself, so update them
+            // in place too.
+            for pi in 0..panes_model.row_count() {
+                if let Some(pane) = panes_model.row_data(pi) {
+                    for ti in 0..pane.tabs.row_count() {
+                        if let Some(mut tab) = pane.tabs.row_data(ti) {
+                            if tab.id.as_str() == tab_id {
+                                tab.title_len = tab_title_len(&title);
+                                tab.title = title.clone().into();
+                                pane.tabs.set_row_data(ti, tab);
+                            }
+                        }
+                    }
+                }
             }
         });
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -3875,6 +3875,7 @@ fn wire_session_callbacks(
         let weak = window.as_weak();
         let store = store.clone();
         let sessions_model = sessions_model.clone();
+        let registry = registry.clone();
         let sessions_dirty = sessions_dirty.clone();
         window.on_reorder_session(move |id: SharedString, dir: i32| {
             if weak
@@ -3894,7 +3895,22 @@ fn wire_session_callbacks(
                     .upgrade()
                     .map(|w| w.get_host_search_query().to_string())
                     .unwrap_or_default();
-                refresh_session_rows_in_place(&store.borrow(), &sessions_model, &query);
+                let in_place = refresh_session_rows_in_place(&store.borrow(), &sessions_model, &query);
+                if !in_place {
+                    // The hop changed the row count (e.g. a cross-group hop
+                    // emptied the ungrouped section): the set_vec rebuild
+                    // dropped the dragging row's pointer grab, so the
+                    // release's reorder-end may never arrive — finalise now.
+                    sessions_dirty.set(false);
+                    if let Err(err) = store.borrow_mut().save() {
+                        tracing::warn!("failed to save config: {err:#}");
+                    }
+                    sync_sessions_for_window(&weak, &store.borrow(), &sessions_model);
+                    registry.broadcast_config_changed();
+                    if let Some(w) = weak.upgrade() {
+                        let _ = w.get_sessions();
+                    }
+                }
             }
         });
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -154,8 +154,8 @@ use tokio::runtime::Runtime;
 
 use crate::app::core::{AppCore, TabRoute, TabRoutes, WindowRegistry, WindowState};
 use crate::config::{
-    is_reserved_session_group, AuthMethod, ConfigStore, OutputHighlightRule, Secret, Session,
-    SessionKind,
+    is_reserved_session_group, named_display_groups, AuthMethod, ConfigStore,
+    OutputHighlightRule, Secret, Session, SessionKind,
 };
 use crate::i18n::t;
 use crate::layout::{LogicalRect, TerminalWheelHit};
@@ -397,6 +397,15 @@ thread_local! {
     static NEW_WINDOW_HOOK: RefCell<Option<Rc<dyn Fn()>>> = RefCell::new(None);
 }
 
+// UI-thread handle to the process core, published by `run()` before the
+// event loop starts. Cross-thread callers (the single-instance IPC
+// listener) run a capture-less closure via `invoke_from_event_loop` and
+// fetch the non-Send `Rc<AppCore>` from here instead of moving it across
+// threads.
+thread_local! {
+    static NEW_WINDOW_CORE: RefCell<Option<Rc<AppCore>>> = const { RefCell::new(None) };
+}
+
 #[cfg(target_os = "macos")]
 fn set_new_window_hook(f: Rc<dyn Fn()>) {
     NEW_WINDOW_HOOK.with(|h| *h.borrow_mut() = Some(f));
@@ -487,18 +496,57 @@ pub fn run(intent: crate::app::launch::LaunchIntent) -> Result<()> {
 
     // IPC listener: forwarded "new-window" requests arrive on the listener
     // thread, but open_window() must run on the Slint UI thread — and
-    // AppCore holds Rc state, so it cannot cross threads via
-    // invoke_from_event_loop either. Bridge the gap with an mpsc channel:
-    // this thread sends one () per request, and a repeating UI-thread timer
-    // (created after the first window below) drains the receiver and opens
-    // the windows.
-    let (tx, rx) = std::sync::mpsc::channel::<()>();
+    // AppCore holds Rc state, so it cannot be captured by the
+    // invoke_from_event_loop closure. The closure therefore captures nothing
+    // and fetches the core from a UI-thread-local set just before the event
+    // loop starts; until then (early startup) the listener retries briefly so
+    // no request is lost.
     if let Some(crate::app::single_instance::Instance::Primary { listen }) = instance {
         std::thread::spawn(move || {
             listen.spawn(move |msg| {
                 if msg == "new-window" {
                     tracing::info!("single-instance: new-window request received");
-                    let _ = tx.send(());
+                    // invoke_from_event_loop fails forever once the event
+                    // loop is gone (app quitting) — retry only briefly so
+                    // this listener callback cannot spin indefinitely.
+                    let deadline =
+                        std::time::Instant::now() + std::time::Duration::from_secs(10);
+                    while slint::invoke_from_event_loop(|| {
+                        NEW_WINDOW_CORE.with(|c| {
+                            if let Some(core) = c.borrow().clone() {
+                                match open_window(core.clone(), true, None) {
+                                    Ok(window_id) => {
+                                        // The request came from an OS entry
+                                        // point while we may be in the
+                                        // background — bring the new window
+                                        // to the front (best effort).
+                                        if let Some(st) =
+                                            core.window_states.borrow().get(&window_id)
+                                        {
+                                            if let Some(w) = st.weak.upgrade() {
+                                                raise_to_front(&w);
+                                            }
+                                        }
+                                    }
+                                    Err(e) => {
+                                        tracing::warn!("failed to open forwarded window: {e:#}")
+                                    }
+                                }
+                            }
+                        });
+                    })
+                    .is_err()
+                    {
+                        if std::time::Instant::now() >= deadline {
+                            tracing::warn!(
+                                "single-instance: event loop unreachable, dropping new-window request"
+                            );
+                            break;
+                        }
+                        // The event loop provider appears after startup begins;
+                        // retry instead of dropping an explicit user action.
+                        std::thread::sleep(std::time::Duration::from_millis(50));
+                    }
                 }
             });
         });
@@ -526,8 +574,15 @@ pub fn run(intent: crate::app::launch::LaunchIntent) -> Result<()> {
     {
         let core = core.clone();
         set_new_window_hook(Rc::new(move || {
-            if let Err(e) = open_window(core.clone(), true, None) {
-                tracing::warn!("failed to open new window: {e:#}");
+            match open_window(core.clone(), true, None) {
+                Ok(window_id) => {
+                    if let Some(st) = core.window_states.borrow().get(&window_id) {
+                        if let Some(w) = st.weak.upgrade() {
+                            raise_to_front(&w);
+                        }
+                    }
+                }
+                Err(e) => tracing::warn!("failed to open new window: {e:#}"),
             }
         }));
     }
@@ -537,36 +592,34 @@ pub fn run(intent: crate::app::launch::LaunchIntent) -> Result<()> {
     #[cfg(target_os = "macos")]
     crate::app::dock_menu::install_dock_menu();
 
-    // UI-thread drain for forwarded new-window requests: the IPC listener
-    // above sends one () per request; this repeating timer picks them up on
-    // the Slint thread where open_window() may run. Each message is an
-    // explicit user action ("新建窗口"), so every pending message opens its
-    // own cascaded window rather than coalescing the batch. `ipc_timer` is
-    // a plain local binding: Slint timers stop when dropped, and run()
-    // blocks on run_event_loop below, so this keeps it alive for exactly the
-    // event loop's lifetime — no leaking needed.
-    let ipc_timer = {
-        let core = core.clone();
-        let timer = slint::Timer::default();
-        timer.start(
-            slint::TimerMode::Repeated,
-            std::time::Duration::from_millis(250),
-            move || {
-                while rx.try_recv().is_ok() {
-                    if let Err(e) = open_window(core.clone(), true, None) {
-                        tracing::warn!("failed to open forwarded window: {e:#}");
-                    }
-                }
-            },
-        );
-        timer
-    };
+    // Publish the core to the UI thread so the IPC listener's
+    // invoke_from_event_loop closures can open windows without capturing the
+    // non-Send Rc<AppCore> (see the listener above).
+    NEW_WINDOW_CORE.with(|c| *c.borrow_mut() = Some(core.clone()));
 
     // Global loop: window.run() returns when *its* window closes, which is
     // wrong once several windows share the loop.
-    slint::run_event_loop().context("event loop exited with error")?;
-    drop(ipc_timer);
-    Ok(())
+    let loop_result = slint::run_event_loop();
+    if let Err(e) = &loop_result {
+        tracing::warn!(
+            "event loop exited with error ({e:#}); running bounded shutdown anyway"
+        );
+    }
+    // Bound the shutdown instead of relying on Rust's drop glue: tokio's
+    // Runtime Drop waits indefinitely for tasks that never finished
+    // (telnet/local/sftp pumps, spawn_blocking helpers) — the observed
+    // windowless lingering process on Windows 11. Take ownership of the
+    // runtime when all holders have gone, give stragglers two seconds, then
+    // hard-exit unconditionally. The event-loop error path goes through here
+    // too: propagating with `?` would hand the runtime to the TLS destructor
+    // chain, where a wedged blocking thread could hang the process forever.
+    NEW_WINDOW_CORE.with(|c| *c.borrow_mut() = None);
+    if let Ok(core_owned) = Rc::try_unwrap(core) {
+        if let Ok(runtime) = Arc::try_unwrap(core_owned.runtime) {
+            runtime.shutdown_timeout(std::time::Duration::from_secs(2));
+        }
+    }
+    std::process::exit(0);
 }
 
 /// Build and wire one application window. Called for the first window by
@@ -661,10 +714,10 @@ fn open_window(
     window.set_sys_swap_rows(ModelRc::from(sys_swap_model.clone()));
     window.set_sys_network_rows(ModelRc::from(sys_network_model.clone()));
     window.set_sys_filesystem_rows(ModelRc::from(sys_filesystem_model.clone()));
-    let proc_win = ProcWindow::new().context("failed to build process window")?;
+    let proc_win = Rc::new(ProcWindow::new().context("failed to build process window")?);
     proc_win.set_custom_titlebar(cfg!(not(target_os = "macos")));
     proc_win.set_proc_list(ModelRc::from(proc_rows_model.clone()));
-    let sys_win = SystemInfoWindow::new().context("failed to build system info window")?;
+    let sys_win = Rc::new(SystemInfoWindow::new().context("failed to build system info window")?);
     // Every fallible construction has now succeeded — register the window.
     // (cascade_origin above was captured before this point, as required.)
     let window_id = registry.register(window.as_weak());
@@ -916,10 +969,13 @@ fn open_window(
     window.set_cmd_bar_hidden(store.borrow().cmd_bar_hidden());
     {
         let store = store.clone();
+        let registry = registry.clone();
         window.on_set_cmd_bar_hidden(move |hidden| {
             let mut s = store.borrow_mut();
             s.set_cmd_bar_hidden(hidden);
             let _ = s.save();
+            drop(s);
+            registry.broadcast_config_changed();
         });
     }
 
@@ -1367,6 +1423,7 @@ fn open_window(
     {
         let weak = window.as_weak();
         let store = store.clone();
+        let registry = registry.clone();
         window.on_set_term_font_size(move |size: i32| {
             {
                 let mut s = store.borrow_mut();
@@ -1376,6 +1433,7 @@ fn open_window(
             if let Some(w) = weak.upgrade() {
                 w.set_term_font_size(size as f32);
             }
+            registry.broadcast_config_changed();
         });
     }
     {
@@ -1548,6 +1606,10 @@ fn open_window(
             apply_dark_mode(&w, &bufs, theme_pref_is_dark(&store.borrow()));
             // Language translations are process-global; refresh our flag only.
             w.set_lang_en(crate::i18n::is_en());
+            // Command-bar visibility is a global preference.
+            w.set_cmd_bar_hidden(store.borrow().cmd_bar_hidden());
+            // Persisted terminal font size (settings stepper) is global too.
+            w.set_term_font_size(store.borrow().font_size() as f32);
         }));
     }
     {
@@ -1879,6 +1941,10 @@ fn open_window(
     // menu). Display only — the saved session keeps its own name.
     let tab_titles: Rc<RefCell<HashMap<String, String>>> = Rc::new(RefCell::new(HashMap::new()));
 
+    // Repeated timers created below (system sampler). Parked in WindowState
+    // so closing the window stops them instead of leaking.
+    let window_timers: Rc<RefCell<Vec<slint::Timer>>> = Rc::new(RefCell::new(Vec::new()));
+
     // Expose this window's state to the rest of the process so tabs can be
     // dragged out into a new window or merged into another one (#tab-detach).
     core.window_states.borrow_mut().insert(
@@ -1899,7 +1965,10 @@ fn open_window(
             terminals_model: terminals_model.clone(),
             panes_model: panes_model.clone(),
             splitters_model: splitters_model.clone(),
+            timers: window_timers.clone(),
             content_size: content_size.clone(),
+            proc_win: proc_win.clone(),
+            sys_win: sys_win.clone(),
             proc_weak: proc_win.as_weak(),
             sys_weak: sys_win.as_weak(),
         },
@@ -2487,10 +2556,10 @@ fn open_window(
             }
         },
     );
-    // Keep the timer alive for the entire event loop by parking it on a
-    // leaked Box. Slint timers drop themselves on Drop, and we don't want
-    // that here.
-    Box::leak(Box::new(timer));
+    // Keep the timer alive as long as this window exists: it lives in the
+    // WindowState timers vec, which forget_window_state drops on close
+    // (Slint timers stop when dropped) — no leaking needed.
+    window_timers.borrow_mut().push(timer);
 
     // OS file drag-and-drop → upload to the active session's SFTP directory,
     // but only when the file is dropped over the file-list area.
@@ -3043,6 +3112,18 @@ fn center_window(win: &AppWindow) {
 #[cfg(not(windows))]
 fn center_window(_win: &AppWindow) {}
 
+/// Bring a window to the front and give it keyboard focus: un-minimize it
+/// and ask the OS for focus. Used when an OS entry point (taskbar jump list,
+/// Dock menu, desktop action) opens a window while the app is sitting in the
+/// background. Best effort — strict environments (Wayland, the Windows
+/// foreground lock) may degrade to a taskbar flash.
+fn raise_to_front(win: &AppWindow) {
+    let _ = win.window().with_winit_window(|w| {
+        w.set_minimized(false);
+        w.focus_window();
+    });
+}
+
 /// The active terminal tab's current SFTP directory ("" if unknown).
 fn active_sftp_path(win: &AppWindow, tab_id: &str) -> String {
     let model = win.get_terminals();
@@ -3094,16 +3175,15 @@ fn terminal_wheel_hit(
     let mut term_w = term.w;
     let mut term_h = term.h;
 
-    // Zen mode removes the status strip and command bar as well as all docks.
+    // Zen mode removes only the 24px status strip; docks and the command bar
+    // stay on screen.
     if !win.get_zen_mode() {
         term_y += 24.0;
         term_h = (term_h - 24.0).max(0.0);
     }
 
     let sftp_dock = win.get_sftp_dock().to_string();
-    let sftp_take = if win.get_zen_mode() {
-        0.0
-    } else if term_state.sftp_collapsed {
+    let sftp_take = if term_state.sftp_collapsed {
         36.0
     } else if sftp_dock == "left" || sftp_dock == "right" {
         term_state.sftp_panel_width + 4.0
@@ -3119,9 +3199,10 @@ fn terminal_wheel_hit(
         sftp_take,
     );
 
-    // Leave the command bar to TextInput/history handling; wheel fallback is for
-    // terminal output only.
-    if !win.get_zen_mode() {
+    // Leave the command bar to TextInput/history handling; wheel fallback is
+    // for terminal output only. The bar is present in every mode unless the
+    // toolbar toggle hid it.
+    if !win.get_cmd_bar_hidden() {
         term_h = (term_h - 34.0).max(0.0);
     }
     if !contains_logical(
@@ -3288,21 +3369,20 @@ fn active_terminal_panel_rects(win: &AppWindow) -> Option<(String, LogicalRect, 
 }
 
 fn active_sftp_file_list_rect(win: &AppWindow) -> Option<LogicalRect> {
-    if win.get_zen_mode() {
-        return None;
-    }
     let (_active, term, term_state) = active_terminal_panel_rects(win)?;
     if term_state.sftp_collapsed {
         return None;
     }
 
-    // TerminalView starts with a 24px connection-status line; SFTP docks inside
-    // the remaining dock-region. This mirrors ui/terminal_view.slint.
+    // TerminalView starts with a 24px connection-status line (hidden in zen
+    // mode); SFTP docks inside the remaining dock-region. This mirrors
+    // ui/terminal_view.slint.
+    let strip = if win.get_zen_mode() { 0.0 } else { 24.0 };
     let dock_region = LogicalRect {
         x: term.x,
-        y: term.y + 24.0,
+        y: term.y + strip,
         w: term.w,
-        h: (term.h - 24.0).max(0.0),
+        h: (term.h - strip).max(0.0),
     };
     let dock = win.get_sftp_dock().to_string();
     let mut panel = LogicalRect {
@@ -3425,11 +3505,16 @@ fn sync_sessions_for_window(
     store: &ConfigStore,
     model: &VecModel<SessionInfo>,
 ) {
-    let query = window
-        .upgrade()
-        .map(|window| window.get_host_search_query().to_string())
-        .unwrap_or_default();
-    sync_sessions_to_model_with_filter(store, model, &query);
+    let Some(window) = window.upgrade() else { return };
+    let query = window.get_host_search_query().to_string();
+    // Prefer in-place row updates: they keep the list's scroll position and
+    // any running drag alive and skip the reallocation. A full set_vec
+    // rebuild — which destroys the dragging row's pointer grab — happens
+    // only when the row count changed, and the revision bump tells Welcome
+    // to clear its stale drag state in exactly that case.
+    if !refresh_session_rows_in_place(store, model, &query) {
+        window.set_sessions_revision(window.get_sessions_revision() + 1);
+    }
 }
 
 /// Parse the batch-import textarea (#150). Each non-empty, non-`#` line is
@@ -3883,7 +3968,7 @@ fn wire_session_callbacks(
                 .map(|window| !window.get_host_search_query().trim().is_empty())
                 .unwrap_or(false)
             {
-                return;
+                return false;
             }
             let moved = {
                 let mut s = store.borrow_mut();
@@ -3912,6 +3997,7 @@ fn wire_session_callbacks(
                     }
                 }
             }
+            moved
         });
     }
     {

--- a/src/app.rs
+++ b/src/app.rs
@@ -6,6 +6,12 @@
 //!   * Manage the tab list + per-tab `SessionHandle` map.
 //!   * Route Slint callbacks to the right domain module.
 mod auth_dialogs;
+pub(crate) mod core;
+#[cfg(target_os = "macos")]
+mod dock_menu;
+#[cfg(windows)]
+mod jump_list;
+pub mod launch;
 mod port_forward;
 mod quick_commands;
 mod resource_ui;
@@ -15,7 +21,9 @@ mod session_runtime;
 mod sftp_callbacks;
 mod sftp_ui;
 mod sidebar;
+mod single_instance;
 mod tab_callbacks;
+mod tab_transfer;
 mod terminal_ui;
 mod webdav;
 mod window;
@@ -31,6 +39,7 @@ use self::sftp_callbacks::*;
 use self::sftp_ui::*;
 use self::sidebar::*;
 use self::tab_callbacks::*;
+use self::tab_transfer::*;
 use self::terminal_ui::*;
 use self::webdav::*;
 use self::window::*;
@@ -143,6 +152,7 @@ use i_slint_backend_winit::WinitWindowAccessor;
 use slint::{ComponentHandle, Model, ModelRc, SharedString, VecModel};
 use tokio::runtime::Runtime;
 
+use crate::app::core::{AppCore, TabRoute, TabRoutes, WindowRegistry, WindowState};
 use crate::config::{
     is_reserved_session_group, AuthMethod, ConfigStore, OutputHighlightRule, Secret, Session,
     SessionKind,
@@ -190,6 +200,40 @@ fn tab_title_len(title: &str) -> i32 {
 
 fn should_block_close(exit_confirmed: bool, has_live_sessions: bool) -> bool {
     !exit_confirmed && has_live_sessions
+}
+
+/// Tear down one window's workers (SSH + SFTP) and hide its detachable
+/// monitor windows. Idempotent: repeated calls see empty maps. Also aborts
+/// every queued auth prompt (host key / credentials / MFA) owned by this
+/// window, answering reject/cancel so the blocked connection attempts fail
+/// cleanly instead of hanging on a dialog that will never show (#multi-window).
+fn teardown_window(
+    window_id: u64,
+    handles: &Rc<RefCell<HashMap<String, SessionHandle>>>,
+    sftp_handles: &SftpHandles,
+    proc_weak: &slint::Weak<ProcWindow>,
+    sys_weak: &slint::Weak<SystemInfoWindow>,
+) {
+    abort_window_prompts(window_id);
+    {
+        let mut sessions = handles.borrow_mut();
+        for handle in sessions.values() {
+            handle.close();
+        }
+        sessions.clear();
+    }
+    if let Ok(mut sftp) = sftp_handles.lock() {
+        for handle in sftp.values() {
+            handle.close();
+        }
+        sftp.clear();
+    }
+    if let Some(w) = proc_weak.upgrade() {
+        let _ = w.hide();
+    }
+    if let Some(w) = sys_weak.upgrade() {
+        let _ = w.hide();
+    }
 }
 
 /// Tab ids currently shown in a pane (`term.id == pane.active-id` in Slint).
@@ -345,6 +389,30 @@ fn do_tab_render_flush(
 /// Number of samples kept for the sparkline.
 const NET_HISTORY_LEN: usize = 60;
 
+/// Set once by `run()`; lets a platform entry point outside the Slint
+/// callback tree (the macOS Dock menu) open a window. Only ever invoked from
+/// the UI/main thread.
+#[cfg(target_os = "macos")]
+thread_local! {
+    static NEW_WINDOW_HOOK: RefCell<Option<Rc<dyn Fn()>>> = RefCell::new(None);
+}
+
+#[cfg(target_os = "macos")]
+fn set_new_window_hook(f: Rc<dyn Fn()>) {
+    NEW_WINDOW_HOOK.with(|h| *h.borrow_mut() = Some(f));
+}
+
+/// Open a new window from a platform entry point (macOS Dock menu action).
+/// Runs on the main/UI thread; a no-op until `run()` installs the hook.
+#[cfg(target_os = "macos")]
+pub(crate) fn request_new_window() {
+    NEW_WINDOW_HOOK.with(|h| {
+        if let Some(f) = h.borrow().as_ref() {
+            f();
+        }
+    });
+}
+
 /// Embed the app icon PNG into the binary and set it as the X11 window icon.
 ///
 /// On X11, the taskbar/dock icon for a running window comes from the
@@ -361,7 +429,7 @@ const NET_HISTORY_LEN: usize = 60;
 ///
 /// Windows gets its icon from the `.ico` embedded by winresource at link
 /// time; macOS from the app bundle — neither path needs runtime decoding.
-pub fn run() -> Result<()> {
+pub fn run(intent: crate::app::launch::LaunchIntent) -> Result<()> {
     // Load the renderer preference before creating any Slint window. Reuse the
     // same store for the rest of the app so startup does not read the config
     // twice merely to select a backend (#280).
@@ -380,12 +448,140 @@ pub fn run() -> Result<()> {
     #[cfg(target_os = "macos")]
     setup_macos_platform(config.renderer_mode());
 
+    // --- Single-instance coordination -------------------------------------
+    // A second `meatshell --new-window` forwards to us and exits; we never
+    // run two GUI instances for that entry point (Chrome-style). Plain
+    // launches pass forward=false and never forward: if the endpoint is
+    // taken they run as an independent second instance. IPC failures fall
+    // through to a normal launch rather than blocking the app.
+    let si_path = crate::app::single_instance::socket_path();
+    let instance = match crate::app::single_instance::acquire(&si_path, intent.new_window) {
+        Ok(i) => Some(i),
+        Err(e) => {
+            tracing::warn!("single-instance acquire failed: {e}");
+            None
+        }
+    };
+    if intent.new_window {
+        if let Some(crate::app::single_instance::Instance::Forwarded) = instance {
+            return Ok(());
+        }
+        // We are the primary (or IPC failed): fall through and open a window.
+    }
+
     // --- Runtime + store -------------------------------------------------
     let runtime = Arc::new(Runtime::new().context("failed to start tokio runtime")?);
     let store = Rc::new(RefCell::new(config));
     // Reachable from the Slint-thread event handler for recording terminal
     // commands into history (#113).
     HISTORY_STORE.with(|s| *s.borrow_mut() = Some(store.clone()));
+
+    let core = Rc::new(AppCore {
+        runtime,
+        store,
+        registry: Rc::new(WindowRegistry::default()),
+        window_states: Rc::new(RefCell::new(HashMap::new())),
+        tab_routes: Arc::new(Mutex::new(HashMap::new())),
+        first_window_done: Cell::new(false),
+    });
+
+    // IPC listener: forwarded "new-window" requests arrive on the listener
+    // thread, but open_window() must run on the Slint UI thread — and
+    // AppCore holds Rc state, so it cannot cross threads via
+    // invoke_from_event_loop either. Bridge the gap with an mpsc channel:
+    // this thread sends one () per request, and a repeating UI-thread timer
+    // (created after the first window below) drains the receiver and opens
+    // the windows.
+    let (tx, rx) = std::sync::mpsc::channel::<()>();
+    if let Some(crate::app::single_instance::Instance::Primary { listen }) = instance {
+        std::thread::spawn(move || {
+            listen.spawn(move |msg| {
+                if msg == "new-window" {
+                    tracing::info!("single-instance: new-window request received");
+                    let _ = tx.send(());
+                }
+            });
+        });
+    }
+
+    // Set the Wayland app_id / X11 WM_CLASS *before* the window is created so
+    // the Linux desktop shell can match the running window to the installed
+    // `meatshell.desktop` entry and show our icon in the dock/taskbar.  (On
+    // Windows the icon comes from the embedded .ico, so this is a no-op there.)
+    let _ = slint::set_xdg_app_id("meatshell");
+
+    // Taskbar jump list ("新建窗口") on Windows: register before the first
+    // window shows so the entry is available immediately. Failure is
+    // warn-only and never blocks startup.
+    #[cfg(windows)]
+    crate::app::jump_list::register_new_window_task();
+
+    // macOS Dock menu ("新建窗口"): install the new-window hook first so a
+    // Dock click can never race ahead of it. The NSApplication patching
+    // itself happens after the first window below, because AppKit asks the
+    // winit delegate for the Dock menu and that delegate only exists once
+    // the backend has built a window. Failures are warn-only and never
+    // block startup (see dock_menu.rs).
+    #[cfg(target_os = "macos")]
+    {
+        let core = core.clone();
+        set_new_window_hook(Rc::new(move || {
+            if let Err(e) = open_window(core.clone(), true, None) {
+                tracing::warn!("failed to open new window: {e:#}");
+            }
+        }));
+    }
+
+    open_window(core.clone(), false, None)?;
+
+    #[cfg(target_os = "macos")]
+    crate::app::dock_menu::install_dock_menu();
+
+    // UI-thread drain for forwarded new-window requests: the IPC listener
+    // above sends one () per request; this repeating timer picks them up on
+    // the Slint thread where open_window() may run. Each message is an
+    // explicit user action ("新建窗口"), so every pending message opens its
+    // own cascaded window rather than coalescing the batch. `ipc_timer` is
+    // a plain local binding: Slint timers stop when dropped, and run()
+    // blocks on run_event_loop below, so this keeps it alive for exactly the
+    // event loop's lifetime — no leaking needed.
+    let ipc_timer = {
+        let core = core.clone();
+        let timer = slint::Timer::default();
+        timer.start(
+            slint::TimerMode::Repeated,
+            std::time::Duration::from_millis(250),
+            move || {
+                while rx.try_recv().is_ok() {
+                    if let Err(e) = open_window(core.clone(), true, None) {
+                        tracing::warn!("failed to open forwarded window: {e:#}");
+                    }
+                }
+            },
+        );
+        timer
+    };
+
+    // Global loop: window.run() returns when *its* window closes, which is
+    // wrong once several windows share the loop.
+    slint::run_event_loop().context("event loop exited with error")?;
+    drop(ipc_timer);
+    Ok(())
+}
+
+/// Build and wire one application window. Called for the first window by
+/// `run()` and for every subsequent window by the new-window entry points.
+/// `at` pins the window to a physical screen position (tab detach); without
+/// it the window cascades from the newest one or centers.
+/// Returns the registry id used to unregister on close.
+fn open_window(
+    core: Rc<AppCore>,
+    cascade: bool,
+    at: Option<slint::PhysicalPosition>,
+) -> Result<u64> {
+    let runtime = core.runtime.clone();
+    let store = core.store.clone();
+    let registry = core.registry.clone();
 
     // Per-tab SSH handles (shell only; lives on Slint thread via Rc).
     let handles: Rc<RefCell<HashMap<String, SessionHandle>>> =
@@ -409,12 +605,12 @@ pub fn run() -> Result<()> {
     let last_term_size: Arc<Mutex<(u32, u32)>> = Arc::new(Mutex::new((80, 24)));
 
     // --- Build window + models ------------------------------------------
-    // Set the Wayland app_id / X11 WM_CLASS *before* the window is created so
-    // the Linux desktop shell can match the running window to the installed
-    // `meatshell.desktop` entry and show our icon in the dock/taskbar.  (On
-    // Windows the icon comes from the embedded .ico, so this is a no-op there.)
-    let _ = slint::set_xdg_app_id("meatshell");
     let window = AppWindow::new().context("failed to build Slint window")?;
+    // Cascade origin must be captured *before* registering: once registered,
+    // registry.newest() is this window itself. Registration itself is deferred
+    // until after the last fallible construction below, so a failed monitor
+    // window never leaves a stale registry entry.
+    let cascade_origin = if cascade { registry.newest() } else { None };
     // Slint applies preferred-width/height while the native window is being
     // created. Do not treat those startup Resized events as user adjustments;
     // otherwise they overwrite the persisted size before restoration (#278).
@@ -469,6 +665,9 @@ pub fn run() -> Result<()> {
     proc_win.set_custom_titlebar(cfg!(not(target_os = "macos")));
     proc_win.set_proc_list(ModelRc::from(proc_rows_model.clone()));
     let sys_win = SystemInfoWindow::new().context("failed to build system info window")?;
+    // Every fallible construction has now succeeded — register the window.
+    // (cascade_origin above was captured before this point, as required.)
+    let window_id = registry.register(window.as_weak());
     sys_win.set_custom_titlebar(cfg!(not(target_os = "macos")));
     sys_win.set_metrics(ModelRc::from(sys_metrics_model.clone()));
     sys_win.set_nets(ModelRc::from(sys_net_rows_model.clone()));
@@ -1169,6 +1368,30 @@ pub fn run() -> Result<()> {
         });
     }
     {
+        // Font zoom shortcuts (Ctrl+= / Ctrl+- / Ctrl+0). direction:
+        // +1 larger, -1 smaller, 0 = reset to the 13px default. Reuses the
+        // settings stepper's persist path; the Theme.term-font-size change
+        // re-measures the cell grid and triggers the PTY resize on its own.
+        let weak = window.as_weak();
+        let store = store.clone();
+        window.on_zoom_term_font(move |direction: i32| {
+            let next = {
+                let mut s = store.borrow_mut();
+                let next = if direction == 0 {
+                    13
+                } else {
+                    s.font_size() as i32 + direction
+                };
+                s.set_font_size(next.clamp(8, 32) as u32);
+                let _ = s.save();
+                s.font_size()
+            };
+            if let Some(w) = weak.upgrade() {
+                w.set_term_font_size(next as f32);
+            }
+        });
+    }
+    {
         let store = store.clone();
         window.on_persist_sftp_tree_width(move |width| {
             let mut s = store.borrow_mut();
@@ -1260,6 +1483,7 @@ pub fn run() -> Result<()> {
         let store = store.clone();
         let bufs_wp = bufs.clone();
         let proc_weak = proc_win.as_weak();
+        let registry = registry.clone();
         window.on_set_wallpaper(move |id: SharedString| {
             let id = id.to_string();
             let mut selected_builtin_theme = None;
@@ -1273,15 +1497,22 @@ pub fn run() -> Result<()> {
                     sync_proc_theme(&w, &p);
                 }
             }
-            let mut s = store.borrow_mut();
-            s.set_wallpaper(id);
-            // Choosing a built-in wallpaper applies its recommended palette once;
-            // persist that result so it too survives the next launch. A later
-            // manual theme toggle will overwrite this preference as expected.
-            if let Some(dark) = selected_builtin_theme {
-                s.set_theme_pref(if dark { "dark" } else { "light" }.to_string());
+            {
+                let mut s = store.borrow_mut();
+                s.set_wallpaper(id);
+                // Choosing a built-in wallpaper applies its recommended palette once;
+                // persist that result so it too survives the next launch. A later
+                // manual theme toggle will overwrite this preference as expected.
+                if let Some(dark) = selected_builtin_theme {
+                    s.set_theme_pref(if dark { "dark" } else { "light" }.to_string());
+                }
+                let _ = s.save();
             }
-            let _ = s.save();
+            // Only the theme flip needs cross-window propagation; the wallpaper
+            // image itself is not synced to other windows (YAGNI).
+            if selected_builtin_theme.is_some() {
+                registry.broadcast_config_changed();
+            }
         });
     }
     {
@@ -1313,6 +1544,25 @@ pub fn run() -> Result<()> {
     window.set_sessions(ModelRc::from(sessions_model.clone()));
     sync_sessions_to_model(&store.borrow(), &sessions_model);
     window.set_wsl_profiles(wsl_profile_model(&store.borrow()));
+    // Cross-window propagation: when another window persists sessions / theme /
+    // language it broadcasts; re-sync what this window shows. The listener only
+    // READS the store and updates this window's models (never saves), so a
+    // broadcast can never re-enter the broadcast path.
+    {
+        let weak = window.as_weak();
+        let store = store.clone();
+        let sessions_model = sessions_model.clone();
+        let bufs = bufs.clone();
+        registry.add_config_listener(window_id, Rc::new(move || {
+            let Some(w) = weak.upgrade() else { return };
+            // Rebuild the list with the window's current search filter.
+            sync_sessions_for_window(&weak, &store.borrow(), &sessions_model);
+            // Re-apply the theme to the chrome AND every open terminal buffer.
+            apply_dark_mode(&w, &bufs, theme_pref_is_dark(&store.borrow()));
+            // Language translations are process-global; refresh our flag only.
+            w.set_lang_en(crate::i18n::is_en());
+        }));
+    }
     {
         let weak = window.as_weak();
         window.on_pick_wsl_directory(move || {
@@ -1327,38 +1577,47 @@ pub fn run() -> Result<()> {
         let weak = window.as_weak();
         let store = store.clone();
         let sessions_model = sessions_model.clone();
+        let registry = registry.clone();
         window.on_add_wsl_profile(move |name, distribution, directory| {
-            let mut s = store.borrow_mut();
-            s.add_wsl_profile(
-                name.to_string(),
-                distribution.to_string(),
-                directory.to_string(),
-            );
-            let _ = s.save();
-            if let Some(w) = weak.upgrade() {
-                w.set_wsl_profiles(wsl_profile_model(&s));
-                sync_sessions_for_window(&weak, &s, &sessions_model);
+            {
+                let mut s = store.borrow_mut();
+                s.add_wsl_profile(
+                    name.to_string(),
+                    distribution.to_string(),
+                    directory.to_string(),
+                );
+                let _ = s.save();
+                if let Some(w) = weak.upgrade() {
+                    w.set_wsl_profiles(wsl_profile_model(&s));
+                    sync_sessions_for_window(&weak, &s, &sessions_model);
+                }
             }
+            registry.broadcast_config_changed();
         });
     }
     {
         let weak = window.as_weak();
         let store = store.clone();
         let sessions_model = sessions_model.clone();
+        let registry = registry.clone();
         window.on_remove_wsl_profile(move |id| {
-            let mut s = store.borrow_mut();
-            s.remove_wsl_profile(id.as_str());
-            let _ = s.save();
-            if let Some(w) = weak.upgrade() {
-                w.set_wsl_profiles(wsl_profile_model(&s));
-                sync_sessions_for_window(&weak, &s, &sessions_model);
+            {
+                let mut s = store.borrow_mut();
+                s.remove_wsl_profile(id.as_str());
+                let _ = s.save();
+                if let Some(w) = weak.upgrade() {
+                    w.set_wsl_profiles(wsl_profile_model(&s));
+                    sync_sessions_for_window(&weak, &s, &sessions_model);
+                }
             }
+            registry.broadcast_config_changed();
         });
     }
     {
         let weak = window.as_weak();
         let store = store.clone();
         let sessions_model = sessions_model.clone();
+        let registry = registry.clone();
         window.on_webdav_download(move || {
             let Some(w) = weak.upgrade() else { return };
             let enabled = w.get_webdav_enabled();
@@ -1394,6 +1653,7 @@ pub fn run() -> Result<()> {
             let msg = match res {
                 Ok((added, skipped)) => {
                     sync_sessions_for_window(&weak, &store.borrow(), &sessions_model);
+                    registry.broadcast_config_changed();
                     format!(
                         "{} {}, {} {}",
                         t("已导入", "imported"),
@@ -1566,6 +1826,32 @@ pub fn run() -> Result<()> {
     let local_snap: LocalSnap = Arc::new(Mutex::new(SystemSnapshot::default()));
     let local_net_hist: NetHist = Arc::new(Mutex::new(vec![0.0; NET_HISTORY_LEN]));
 
+    // Expose this window's state to the rest of the process so tabs can be
+    // dragged out into a new window or merged into another one (#tab-detach).
+    core.window_states.borrow_mut().insert(
+        window_id,
+        WindowState {
+            weak: window.as_weak(),
+            handles: handles.clone(),
+            bufs: bufs.clone(),
+            gates: render_gates.clone(),
+            statuses: tab_statuses.clone(),
+            sftp_handles: sftp_handles.clone(),
+            sftp_last_cwd: sftp_last_cwd.clone(),
+            local_snap: local_snap.clone(),
+            net_hist: local_net_hist.clone(),
+            follow_cd: sftp_follow_cd.clone(),
+            layout: layout.clone(),
+            tabs_model: tabs_model.clone(),
+            terminals_model: terminals_model.clone(),
+            panes_model: panes_model.clone(),
+            splitters_model: splitters_model.clone(),
+            content_size: content_size.clone(),
+            proc_weak: proc_win.as_weak(),
+            sys_weak: sys_win.as_weak(),
+        },
+    );
+
     {
         let proc_weak = proc_win.as_weak();
         let handles = handles.clone();
@@ -1650,7 +1936,9 @@ pub fn run() -> Result<()> {
     // --- Wire callbacks --------------------------------------------------
     wire_session_callbacks(
         &window,
+        window_id,
         store.clone(),
+        registry.clone(),
         sessions_model.clone(),
         tabs_model.clone(),
         terminals_model.clone(),
@@ -1669,6 +1957,7 @@ pub fn run() -> Result<()> {
         local_snap.clone(),
         local_net_hist.clone(),
         sftp_follow_cd.clone(),
+        core.tab_routes.clone(),
     );
 
     // Recompute the sidebar whenever the active tab changes (fired from Slint's
@@ -1692,6 +1981,7 @@ pub fn run() -> Result<()> {
         let weak = window.as_weak();
         let store = store.clone();
         let tabs_model = tabs_model.clone();
+        let registry = registry.clone();
         window.on_set_language(move |code| {
             crate::i18n::set_language(&code.to_string());
             {
@@ -1699,6 +1989,7 @@ pub fn run() -> Result<()> {
                 s.set_language(crate::i18n::current_code().to_string());
                 let _ = s.save();
             }
+            registry.broadcast_config_changed();
             // Re-translate the welcome tab's dynamic title.
             for i in 0..tabs_model.row_count() {
                 if let Some(mut row) = tabs_model.row_data(i) {
@@ -1724,6 +2015,7 @@ pub fn run() -> Result<()> {
         let store = store.clone();
         let bufs_theme = bufs.clone();
         let proc_weak = proc_win.as_weak();
+        let registry = registry.clone();
         window.on_toggle_theme(move || {
             let Some(w) = weak.upgrade() else { return };
             let next_dark = !w.get_dark_mode();
@@ -1735,20 +2027,23 @@ pub fn run() -> Result<()> {
                 sync_proc_theme(&w, &p);
             }
             let pref = if next_dark { "dark" } else { "light" };
-            let mut s = store.borrow_mut();
-            s.set_theme_pref(pref.to_string());
-            let _ = s.save();
+            {
+                let mut s = store.borrow_mut();
+                s.set_theme_pref(pref.to_string());
+                let _ = s.save();
+            }
+            registry.broadcast_config_changed();
         });
     }
 
     // Host-key confirmation dialog (#109-5): the user trusts or rejects the
     // presented server key; the decision fans back out to the blocked SSH/SFTP
-    // handler(s) and the next queued prompt (if any) is shown.
+    // handler(s) and the next queued prompt for THIS window (if any) is shown.
     {
         let weak = window.as_weak();
         window.on_hostkey_accept(move || {
             if let Some(w) = weak.upgrade() {
-                resolve_front_hostkey(&w, true);
+                resolve_front_hostkey(&w, window_id, true);
             }
         });
     }
@@ -1756,7 +2051,7 @@ pub fn run() -> Result<()> {
         let weak = window.as_weak();
         window.on_hostkey_reject(move || {
             if let Some(w) = weak.upgrade() {
-                resolve_front_hostkey(&w, false);
+                resolve_front_hostkey(&w, window_id, false);
             }
         });
     }
@@ -1765,9 +2060,17 @@ pub fn run() -> Result<()> {
     // username/password (or cancels); the answer unblocks the SSH/SFTP auth.
     {
         let weak = window.as_weak();
+        let registry = registry.clone();
         window.on_cred_accept(move || {
             if let Some(w) = weak.upgrade() {
-                resolve_front_cred(&w, true);
+                let remember = w.get_cred_remember();
+                resolve_front_cred(&w, window_id, true);
+                // "Remember" persisted new credentials onto the saved session
+                // (auth_dialogs::persist_credentials); the registry is not
+                // reachable there, so broadcast from this owning callback.
+                if remember {
+                    registry.broadcast_config_changed();
+                }
             }
         });
     }
@@ -1775,7 +2078,7 @@ pub fn run() -> Result<()> {
         let weak = window.as_weak();
         window.on_cred_reject(move || {
             if let Some(w) = weak.upgrade() {
-                resolve_front_cred(&w, false);
+                resolve_front_cred(&w, window_id, false);
             }
         });
     }
@@ -1786,7 +2089,7 @@ pub fn run() -> Result<()> {
         let weak = window.as_weak();
         window.on_mfa_submit(move || {
             if let Some(w) = weak.upgrade() {
-                resolve_front_mfa(&w, true);
+                resolve_front_mfa(&w, window_id, true);
             }
         });
     }
@@ -1794,7 +2097,7 @@ pub fn run() -> Result<()> {
         let weak = window.as_weak();
         window.on_mfa_cancel(move || {
             if let Some(w) = weak.upgrade() {
-                resolve_front_mfa(&w, false);
+                resolve_front_mfa(&w, window_id, false);
             }
         });
     }
@@ -1890,8 +2193,14 @@ pub fn run() -> Result<()> {
     // Query the GitHub releases API on a background thread; if a newer version
     // exists, flip the banner on. Best-effort: any network/parse error is
     // silently ignored and the app keeps working on the current version.
-    // Skipped entirely when the user turned the check off (#184).
-    if store.borrow().update_check_enabled() {
+    // Skipped entirely when the user turned the check off (#184). Runs only
+    // for the first window of the process: the old `registry.count() == 1`
+    // guard re-fired the check whenever the count returned to 1 after a
+    // close-then-open. The flag is set regardless of the enabled setting, so
+    // a disabled check is never deferred to a later window either.
+    let first_window = !core.first_window_done.get();
+    core.first_window_done.set(true);
+    if first_window && store.borrow().update_check_enabled() {
         let weak = window.as_weak();
         std::thread::spawn(move || {
             let body =
@@ -2001,8 +2310,23 @@ pub fn run() -> Result<()> {
         window.set_about_libs(ModelRc::from(Rc::new(VecModel::from(libs))));
     }
 
+    // New-window entry points: the TabBar button and the Ctrl+Shift+N /
+    // ⌘⇧N shortcut both route here. Runs on the UI thread (Slint callback),
+    // so open_window can build the window directly. A failed open must not
+    // be silent — the click/keystroke already consumed (#multi-window).
+    {
+        let core = core.clone();
+        window.on_new_window_clicked(move || {
+            if let Err(e) = open_window(core.clone(), true, None) {
+                tracing::warn!("failed to open new window: {e:#}");
+            }
+        });
+    }
+
     wire_tab_callbacks(
         &window,
+        window_id,
+        core.clone(),
         tabs_model.clone(),
         terminals_model.clone(),
         layout.clone(),
@@ -2024,6 +2348,7 @@ pub fn run() -> Result<()> {
         store.clone(),
         ConnectCtx {
             weak: window.as_weak(),
+            window_id,
             runtime: runtime.clone(),
             handles: handles.clone(),
             sftp_handles: sftp_handles.clone(),
@@ -2036,6 +2361,7 @@ pub fn run() -> Result<()> {
             last_term_size: last_term_size.clone(),
             sftp_follow_cd: sftp_follow_cd.clone(),
             store: store.clone(),
+            tab_routes: core.tab_routes.clone(),
         },
     );
 
@@ -2120,9 +2446,14 @@ pub fn run() -> Result<()> {
         let sh = sftp_handles.clone();
         let wheel_bufs = bufs.clone();
         let close_handles = handles.clone();
+        let close_sftp_handles = sftp_handles.clone();
+        let ev_proc_weak = proc_win.as_weak();
+        let ev_sys_weak = sys_win.as_weak();
         let ev_store = store.clone();
         let ev_activity = activity.clone();
         let ev_exit_confirmed = exit_confirmed.clone();
+        let ev_registry = registry.clone();
+        let ev_core = core.clone();
         let ev_window_size_tracking_ready = window_size_tracking_ready.clone();
         let ev_pending_window_size_restore = pending_window_size_restore.clone();
         let mut last_cursor_logical: Option<(f32, f32)> = None;
@@ -2421,6 +2752,22 @@ pub fn run() -> Result<()> {
                         if let Some(win) = weak.upgrade() {
                             save_layout(&win, &ev_store);
                         }
+                        // The event is not prevented, so Slint will destroy this
+                        // window. Mirror the confirmed custom-close path: tear down
+                        // this window's workers and unregister it, quitting the
+                        // shared event loop if it was the last one — otherwise a
+                        // stale registry entry blocks the quit of a later window.
+                        teardown_window(
+                            window_id,
+                            &close_handles,
+                            &close_sftp_handles,
+                            &ev_proc_weak,
+                            &ev_sys_weak,
+                        );
+                        if ev_registry.unregister(window_id) {
+                            let _ = slint::quit_event_loop();
+                        }
+                        forget_window_state(&ev_core, window_id);
                     }
                     _ => {}
                 }
@@ -2436,6 +2783,8 @@ pub fn run() -> Result<()> {
         let close_handles = handles.clone();
         let close_sftp_handles = sftp_handles.clone();
         let close_exit_confirmed = exit_confirmed.clone();
+        let close_registry = registry.clone();
+        let close_core = core.clone();
         window.on_confirm_close_yes(move || {
             // Guard against a double click and against another close request
             // arriving from Windows Installer while shutdown is in progress.
@@ -2447,29 +2796,21 @@ pub fn run() -> Result<()> {
                 save_layout(&w, &cc_store);
                 let _ = w.hide();
             }
-            if let Some(w) = proc_weak.upgrade() {
-                let _ = w.hide();
-            }
-            if let Some(w) = sys_weak.upgrade() {
-                let _ = w.hide();
-            }
             // Ask every worker to stop before the runtime/event loop is torn
-            // down. Clearing the maps also makes any repeated close request see
-            // no live sessions and pass through immediately.
-            {
-                let mut sessions = close_handles.borrow_mut();
-                for handle in sessions.values() {
-                    handle.close();
-                }
-                sessions.clear();
+            // down, and hide the detachable monitor windows. Clearing the maps
+            // also makes any repeated close request see no live sessions and
+            // pass through immediately.
+            teardown_window(
+                window_id,
+                &close_handles,
+                &close_sftp_handles,
+                &proc_weak,
+                &sys_weak,
+            );
+            if close_registry.unregister(window_id) {
+                let _ = slint::quit_event_loop();
             }
-            if let Ok(mut sftp) = close_sftp_handles.lock() {
-                for handle in sftp.values() {
-                    handle.close();
-                }
-                sftp.clear();
-            }
-            let _ = slint::quit_event_loop();
+            forget_window_state(&close_core, window_id);
         });
     }
 
@@ -2500,8 +2841,13 @@ pub fn run() -> Result<()> {
     {
         let weak = window.as_weak();
         let close_handles = handles.clone();
+        let close_sftp_handles = sftp_handles.clone();
+        let wc_proc_weak = proc_win.as_weak();
+        let wc_sys_weak = sys_win.as_weak();
         let wc_store = store.clone();
         let wc_exit_confirmed = exit_confirmed.clone();
+        let wc_registry = registry.clone();
+        let wc_core = core.clone();
         window.on_win_close(move || {
             if let Some(w) = weak.upgrade() {
                 // Mirror the native-X behaviour: confirm if sessions are open.
@@ -2509,7 +2855,20 @@ pub fn run() -> Result<()> {
                 {
                     wc_exit_confirmed.set(true);
                     save_layout(&w, &wc_store);
-                    let _ = slint::quit_event_loop();
+                    // Tear down this window's workers and hide its monitor
+                    // windows; quit only if it was the last one.
+                    teardown_window(
+                        window_id,
+                        &close_handles,
+                        &close_sftp_handles,
+                        &wc_proc_weak,
+                        &wc_sys_weak,
+                    );
+                    let _ = w.hide();
+                    if wc_registry.unregister(window_id) {
+                        let _ = slint::quit_event_loop();
+                    }
+                    forget_window_state(&wc_core, window_id);
                 } else {
                     w.set_confirm_close_open(true);
                 }
@@ -2550,19 +2909,41 @@ pub fn run() -> Result<()> {
         });
     }
 
-    // Center the window on the primary monitor once it's shown (size is only
-    // known after the first frame, so defer via a single-shot timer).
+    // Position once shown (size is only known after the first frame). The
+    // first window centers on the primary monitor; later windows cascade
+    // ~40 px from the newest existing window instead of stacking exactly on
+    // top of it. The origin was captured above, before this window was
+    // registered (registry.newest() would return this window itself).
     {
         let weak = window.as_weak();
+        let origin = cascade_origin
+            .and_then(|w| w.upgrade())
+            .map(|w| w.window().position());
         slint::Timer::single_shot(std::time::Duration::from_millis(30), move || {
-            if let Some(w) = weak.upgrade() {
-                center_window(&w);
+            let Some(w) = weak.upgrade() else { return };
+            if let Some(pos) = at {
+                // Tab detach pinned the window under the cursor (#tab-detach).
+                w.window().set_position(pos);
+                return;
+            }
+            match origin {
+                Some(pos) => {
+                    w.window().set_position(slint::PhysicalPosition::new(
+                        pos.x + 40,
+                        pos.y + 40,
+                    ));
+                }
+                None => center_window(&w),
             }
         });
     }
 
-    window.run().context("event loop exited with error")?;
-    Ok(())
+    // The old entry point was window.run(), which shows the window before
+    // spinning the loop. run_event_loop() does not, so display it here —
+    // without this the app starts but no window ever appears (#multi-window).
+    window.show().context("failed to show window")?;
+
+    Ok(window_id)
 }
 
 /// Center the window on the primary monitor's work area (Windows).
@@ -2999,7 +3380,11 @@ fn sync_sessions_for_window(
 /// `host|port|username|password|name` is skipped. Dedup happens at the call site.
 fn wire_session_callbacks(
     window: &AppWindow,
+    // Registry id of `window`; connect-time prompts are tagged with it so
+    // their dialogs open (and abort on close) in this window (#multi-window).
+    window_id: u64,
     store: Rc<RefCell<ConfigStore>>,
+    registry: Rc<WindowRegistry<slint::Weak<AppWindow>>>,
     sessions_model: Rc<VecModel<SessionInfo>>,
     tabs_model: Rc<VecModel<TabInfo>>,
     terminals_model: Rc<VecModel<TerminalState>>,
@@ -3018,6 +3403,7 @@ fn wire_session_callbacks(
     local_snap: LocalSnap,
     local_net_hist: NetHist,
     sftp_follow_cd: Arc<std::sync::atomic::AtomicBool>,
+    tab_routes: TabRoutes,
 ) {
     // Working set of port forwards (#56) for the session being created/edited.
     // The forward add/delete callbacks mutate it; saving reads it into
@@ -3098,6 +3484,7 @@ fn wire_session_callbacks(
         let weak = window.as_weak();
         let store = store.clone();
         let sessions_model = sessions_model.clone();
+        let registry = registry.clone();
         window.on_import_ssh_config(move || {
             let hosts = crate::ssh::ssh_config::parse_default();
             let mut added = 0usize;
@@ -3146,6 +3533,9 @@ fn wire_session_callbacks(
                 }
             }
             sync_sessions_for_window(&weak, &store.borrow(), &sessions_model);
+            if added > 0 {
+                registry.broadcast_config_changed();
+            }
             if let Some(w) = weak.upgrade() {
                 let hint = if added > 0 {
                     format!("{} {}", t("已导入", "imported"), added)
@@ -3186,6 +3576,7 @@ fn wire_session_callbacks(
         let weak = window.as_weak();
         let store = store.clone();
         let sessions_model = sessions_model.clone();
+        let registry = registry.clone();
         window.on_batch_import_confirm(move |text: SharedString| {
             let parsed = parse_batch_import(text.as_str());
             let total = parsed.len();
@@ -3209,6 +3600,9 @@ fn wire_session_callbacks(
                 }
             }
             sync_sessions_for_window(&weak, &store.borrow(), &sessions_model);
+            if added > 0 {
+                registry.broadcast_config_changed();
+            }
             if let Some(w) = weak.upgrade() {
                 let hint = if total == 0 {
                     t("没有可导入的连接", "nothing to import").to_string()
@@ -3227,6 +3621,7 @@ fn wire_session_callbacks(
         let weak = window.as_weak();
         let store = store.clone();
         let sessions_model = sessions_model.clone();
+        let registry = registry.clone();
         window.on_import_sessions(move || {
             if let Some(path) = rfd::FileDialog::new()
                 .add_filter("JSON", &["json"])
@@ -3237,6 +3632,7 @@ fn wire_session_callbacks(
                     let hint = match res {
                         Ok((added, skipped)) => {
                             sync_sessions_for_window(&weak, &store.borrow(), &sessions_model);
+                            registry.broadcast_config_changed();
                             format!(
                                 "{} {} / {} {}",
                                 t("已导入", "imported"),
@@ -3314,6 +3710,7 @@ fn wire_session_callbacks(
         let weak = window.as_weak();
         let store = store.clone();
         let sessions_model = sessions_model.clone();
+        let registry = registry.clone();
         window.on_remove_session(move |id: SharedString| {
             {
                 let mut s = store.borrow_mut();
@@ -3323,6 +3720,7 @@ fn wire_session_callbacks(
                 }
             }
             sync_sessions_for_window(&weak, &store.borrow(), &sessions_model);
+            registry.broadcast_config_changed();
             if let Some(w) = weak.upgrade() {
                 // Touch a property so the list re-renders reliably.
                 let _ = w.get_sessions();
@@ -3335,7 +3733,9 @@ fn wire_session_callbacks(
         let weak = window.as_weak();
         let store = store.clone();
         let sessions_model = sessions_model.clone();
+        let registry = registry.clone();
         window.on_duplicate_session(move |id: SharedString| {
+            let mut duplicated = false;
             {
                 let mut s = store.borrow_mut();
                 if let Some(orig) = s.get(&id.to_string()).cloned() {
@@ -3347,9 +3747,13 @@ fn wire_session_callbacks(
                     if let Err(err) = s.save() {
                         tracing::warn!("failed to save config: {err:#}");
                     }
+                    duplicated = true;
                 }
             }
             sync_sessions_for_window(&weak, &store.borrow(), &sessions_model);
+            if duplicated {
+                registry.broadcast_config_changed();
+            }
             if let Some(w) = weak.upgrade() {
                 let _ = w.get_sessions();
             }
@@ -3361,13 +3765,15 @@ fn wire_session_callbacks(
         let weak = window.as_weak();
         let store = store.clone();
         let sessions_model = sessions_model.clone();
+        let registry = registry.clone();
         window.on_move_session(move |id: SharedString, group: SharedString| {
+            let mut moved = false;
             {
                 let mut s = store.borrow_mut();
                 if let Some(orig) = s.get(&id.to_string()).cloned() {
-                    let mut moved = orig;
+                    let mut target = orig;
                     // "default" is the display label for ungrouped → store empty.
-                    moved.group = if group.as_str().eq_ignore_ascii_case("default") {
+                    target.group = if group.as_str().eq_ignore_ascii_case("default") {
                         String::new()
                     } else if is_reserved_session_group(group.as_str().trim()) {
                         // `system` belongs exclusively to built-in local shells.
@@ -3375,13 +3781,17 @@ fn wire_session_callbacks(
                     } else {
                         group.to_string()
                     };
-                    s.upsert(moved);
+                    s.upsert(target);
                     if let Err(err) = s.save() {
                         tracing::warn!("failed to save config: {err:#}");
                     }
+                    moved = true;
                 }
             }
             sync_sessions_for_window(&weak, &store.borrow(), &sessions_model);
+            if moved {
+                registry.broadcast_config_changed();
+            }
             if let Some(w) = weak.upgrade() {
                 let _ = w.get_sessions();
             }
@@ -3442,6 +3852,7 @@ fn wire_session_callbacks(
         let weak = window.as_weak();
         let store = store.clone();
         let sessions_model = sessions_model.clone();
+        let registry = registry.clone();
         window.on_submit_group(move |orig: SharedString, name: SharedString| {
             let trimmed = name.trim();
             let error = {
@@ -3473,6 +3884,7 @@ fn wire_session_callbacks(
                 }
             }
             sync_sessions_for_window(&weak, &store.borrow(), &sessions_model);
+            registry.broadcast_config_changed();
             if let Some(w) = weak.upgrade() {
                 let _ = w.get_sessions();
             }
@@ -3484,6 +3896,7 @@ fn wire_session_callbacks(
         let weak = window.as_weak();
         let store = store.clone();
         let sessions_model = sessions_model.clone();
+        let registry = registry.clone();
         window.on_delete_group(move |name: SharedString| {
             {
                 let mut s = store.borrow_mut();
@@ -3493,6 +3906,7 @@ fn wire_session_callbacks(
                 }
             }
             sync_sessions_for_window(&weak, &store.borrow(), &sessions_model);
+            registry.broadcast_config_changed();
             if let Some(w) = weak.upgrade() {
                 let _ = w.get_sessions();
             }
@@ -3505,6 +3919,7 @@ fn wire_session_callbacks(
         let store = store.clone();
         let sessions_model = sessions_model.clone();
         let edit_forwards = edit_forwards.clone();
+        let registry = registry.clone();
         window.on_session_dialog_submit(move |draft: SessionDraft| {
             let id = draft.id.to_string();
             let forwards = match validated_port_forwards(&edit_forwards.borrow()) {
@@ -3611,6 +4026,7 @@ fn wire_session_callbacks(
                 }
             }
             sync_sessions_for_window(&weak, &store.borrow(), &sessions_model);
+            registry.broadcast_config_changed();
             if let Some(w) = weak.upgrade() {
                 w.set_dialog_open(false);
             }
@@ -3698,6 +4114,7 @@ fn wire_session_callbacks(
                                                 responder,
                                             } => enqueue_hostkey_prompt(
                                                 &w,
+                                                window_id,
                                                 host,
                                                 port,
                                                 key_type,
@@ -3714,6 +4131,7 @@ fn wire_session_callbacks(
                                                 responder,
                                             } => enqueue_cred_prompt(
                                                 &w,
+                                                window_id,
                                                 session_id,
                                                 host,
                                                 user,
@@ -3729,6 +4147,7 @@ fn wire_session_callbacks(
                                                 responder,
                                             } => enqueue_mfa_prompt(
                                                 &w,
+                                                window_id,
                                                 session_id,
                                                 host,
                                                 prompt,
@@ -3884,6 +4303,7 @@ fn wire_session_callbacks(
         let local_snap = local_snap.clone();
         let local_net_hist = local_net_hist.clone();
         let sftp_follow_cd = sftp_follow_cd.clone();
+        let tab_routes = tab_routes.clone();
         window.on_connect_session(move |id: SharedString| {
             let id = id.to_string();
             let session = if id.starts_with("system:") {
@@ -4048,6 +4468,7 @@ fn wire_session_callbacks(
             // Shared with in-place reconnect (#79) via start_session_in_tab.
             let ctx = ConnectCtx {
                 weak: weak.clone(),
+                window_id,
                 runtime: runtime.clone(),
                 handles: handles.clone(),
                 sftp_handles: sftp_handles.clone(),
@@ -4060,6 +4481,7 @@ fn wire_session_callbacks(
                 last_term_size: last_term_size.clone(),
                 sftp_follow_cd: sftp_follow_cd.clone(),
                 store: store.clone(),
+                tab_routes: tab_routes.clone(),
             };
             start_session_in_tab(&tab_id, session, &ctx);
         });

--- a/src/app/auth_dialogs.rs
+++ b/src/app/auth_dialogs.rs
@@ -34,10 +34,14 @@ pub(super) fn hostkey_dialog_text(
 }
 
 /// Queue a host-key prompt: answer immediately if already decided this run,
-/// merge into an existing pending entry for the same host, otherwise enqueue
-/// (and show it now if nothing else is up).
+/// merge into an existing pending entry for the same host *in the same
+/// window*, otherwise enqueue (and show it in the owning window if that
+/// window has no other host-key dialog up). Prompts from different windows
+/// never merge — each window decides for itself (#multi-window).
+#[allow(clippy::too_many_arguments)] // window_id tags the owning window
 pub(super) fn enqueue_hostkey_prompt(
     win: &AppWindow,
+    window_id: u64,
     host: String,
     port: u16,
     key_type: String,
@@ -52,14 +56,21 @@ pub(super) fn enqueue_hostkey_prompt(
     }
     let show_now = HOSTKEY_QUEUE.with(|q| {
         let mut q = q.borrow_mut();
-        if let Some(p) = q.iter_mut().find(|p| p.host == host && p.port == port) {
+        if let Some(p) = q
+            .iter_mut()
+            .find(|p| p.window_id == window_id && p.host == host && p.port == port)
+        {
             p.responders.push(responder);
             return false;
         }
-        let was_empty = q.is_empty();
+        // Show only if this window has no other queued prompt of this type:
+        // each window's oldest queued entry is the one displayed in its
+        // dialog, so a second prompt must wait its turn in *that* window.
+        let show_now = !q.iter().any(|p| p.window_id == window_id);
         let (title, message, detail, confirm_label) =
             hostkey_dialog_text(&host, port, &key_type, &fingerprint, changed);
         q.push_back(PendingHostKey {
+            window_id,
             host,
             port,
             changed,
@@ -69,17 +80,18 @@ pub(super) fn enqueue_hostkey_prompt(
             confirm_label,
             responders: vec![responder],
         });
-        was_empty
+        show_now
     });
     if show_now {
-        show_front_hostkey(win);
+        show_front_hostkey(win, window_id);
     }
 }
 
-/// Push the front pending prompt's details into the window and open the dialog.
-pub(super) fn show_front_hostkey(win: &AppWindow) {
+/// Push this window's oldest pending prompt's details into the window and
+/// open the dialog.
+pub(super) fn show_front_hostkey(win: &AppWindow, window_id: u64) {
     HOSTKEY_QUEUE.with(|q| {
-        if let Some(p) = q.borrow().front() {
+        if let Some(p) = q.borrow().iter().find(|p| p.window_id == window_id) {
             win.set_hostkey_changed(p.changed);
             win.set_hostkey_title(p.title.clone().into());
             win.set_hostkey_message(p.message.clone().into());
@@ -90,12 +102,13 @@ pub(super) fn show_front_hostkey(win: &AppWindow) {
     });
 }
 
-/// Apply the user's decision to the front prompt, then show the next one (or
-/// close the dialog if the queue is now empty).
-pub(super) fn resolve_front_hostkey(win: &AppWindow, accept: bool) {
+/// Apply the user's decision to this window's oldest pending prompt, then
+/// show that window's next prompt (or close the dialog if it has none left).
+pub(super) fn resolve_front_hostkey(win: &AppWindow, window_id: u64, accept: bool) {
     let has_next = HOSTKEY_QUEUE.with(|q| {
         let mut q = q.borrow_mut();
-        if let Some(p) = q.pop_front() {
+        if let Some(pos) = q.iter().position(|p| p.window_id == window_id) {
+            let p = q.remove(pos).expect("position checked above");
             // Only remember an *accept* for this run (so a slightly-later SFTP
             // prompt for the same host is answered without a second dialog). We
             // must NOT cache a reject: a single dismissal — e.g. an accidental
@@ -113,13 +126,61 @@ pub(super) fn resolve_front_hostkey(win: &AppWindow, accept: bool) {
                 r.respond(accept);
             }
         }
-        !q.is_empty()
+        q.iter().any(|p| p.window_id == window_id)
     });
     if has_next {
-        show_front_hostkey(win);
+        show_front_hostkey(win, window_id);
     } else {
         win.set_hostkey_prompt_open(false);
     }
+}
+
+/// Abort every queued prompt owned by `window_id` (called when that window
+/// closes): answer each with reject/cancel so the blocked connection attempts
+/// fail cleanly instead of hanging forever on a dialog that will never show.
+pub(super) fn abort_window_prompts(window_id: u64) {
+    HOSTKEY_QUEUE.with(|q| {
+        let mut q = q.borrow_mut();
+        let mut i = 0;
+        while i < q.len() {
+            if q[i].window_id == window_id {
+                let p = q.remove(i).expect("index checked above");
+                for r in &p.responders {
+                    r.respond(false);
+                }
+            } else {
+                i += 1;
+            }
+        }
+    });
+    CRED_QUEUE.with(|q| {
+        let mut q = q.borrow_mut();
+        let mut i = 0;
+        while i < q.len() {
+            if q[i].window_id == window_id {
+                let p = q.remove(i).expect("index checked above");
+                for r in &p.responders {
+                    r.respond(None);
+                }
+            } else {
+                i += 1;
+            }
+        }
+    });
+    MFA_QUEUE.with(|q| {
+        let mut q = q.borrow_mut();
+        let mut i = 0;
+        while i < q.len() {
+            if q[i].window_id == window_id {
+                let p = q.remove(i).expect("index checked above");
+                for r in &p.responders {
+                    r.respond(None);
+                }
+            } else {
+                i += 1;
+            }
+        }
+    });
 }
 
 // ---------------------------------------------------------------------------
@@ -135,10 +196,13 @@ thread_local! {
 }
 
 /// Queue a credential prompt: answer immediately if already decided this run,
-/// merge into an existing pending entry for the same session, otherwise enqueue
-/// (and show it now if nothing else is up).
+/// merge into an existing pending entry for the same session *in the same
+/// window*, otherwise enqueue (and show it in the owning window if that
+/// window has no other credential dialog up) (#multi-window).
+#[allow(clippy::too_many_arguments)] // window_id tags the owning window
 pub(super) fn enqueue_cred_prompt(
     win: &AppWindow,
+    window_id: u64,
     session_id: String,
     host: String,
     user: String,
@@ -152,12 +216,18 @@ pub(super) fn enqueue_cred_prompt(
     }
     let show_now = CRED_QUEUE.with(|q| {
         let mut q = q.borrow_mut();
-        if let Some(p) = q.iter_mut().find(|p| p.session_id == session_id) {
+        if let Some(p) = q
+            .iter_mut()
+            .find(|p| p.window_id == window_id && p.session_id == session_id)
+        {
             p.responders.push(responder);
             return false;
         }
-        let was_empty = q.is_empty();
+        // Per-window turn: show only if this window has no other queued
+        // credential prompt (its oldest entry is the one on screen).
+        let show_now = !q.iter().any(|p| p.window_id == window_id);
         q.push_back(PendingCred {
+            window_id,
             session_id,
             host,
             user,
@@ -165,17 +235,18 @@ pub(super) fn enqueue_cred_prompt(
             need_password,
             responders: vec![responder],
         });
-        was_empty
+        show_now
     });
     if show_now {
-        show_front_cred(win);
+        show_front_cred(win, window_id);
     }
 }
 
-/// Populate the credential dialog from the front prompt and open it.
-pub(super) fn show_front_cred(win: &AppWindow) {
+/// Populate the credential dialog from this window's oldest pending prompt and
+/// open it.
+pub(super) fn show_front_cred(win: &AppWindow, window_id: u64) {
     CRED_QUEUE.with(|q| {
-        if let Some(p) = q.borrow().front() {
+        if let Some(p) = q.borrow().iter().find(|p| p.window_id == window_id) {
             win.set_cred_host(p.host.clone().into());
             win.set_cred_need_user(p.need_user);
             win.set_cred_need_password(p.need_password);
@@ -187,9 +258,10 @@ pub(super) fn show_front_cred(win: &AppWindow) {
     });
 }
 
-/// Apply the user's answer to the front credential prompt (or cancel), persist
-/// it when "remember" is checked, then show the next prompt or close.
-pub(super) fn resolve_front_cred(win: &AppWindow, accept: bool) {
+/// Apply the user's answer to this window's oldest credential prompt (or
+/// cancel), persist it when "remember" is checked, then show that window's
+/// next prompt or close its dialog.
+pub(super) fn resolve_front_cred(win: &AppWindow, window_id: u64, accept: bool) {
     let reply: Option<crate::ssh::CredentialReply> = if accept {
         Some((
             win.get_cred_user().to_string(),
@@ -201,7 +273,8 @@ pub(super) fn resolve_front_cred(win: &AppWindow, accept: bool) {
     };
     let has_next = CRED_QUEUE.with(|q| {
         let mut q = q.borrow_mut();
-        if let Some(p) = q.pop_front() {
+        if let Some(pos) = q.iter().position(|p| p.window_id == window_id) {
+            let p = q.remove(pos).expect("position checked above");
             CRED_DECIDED.with(|d| {
                 d.borrow_mut().insert(p.session_id.clone(), reply.clone());
             });
@@ -212,12 +285,12 @@ pub(super) fn resolve_front_cred(win: &AppWindow, accept: bool) {
                 r.respond(reply.clone());
             }
         }
-        !q.is_empty()
+        q.iter().any(|p| p.window_id == window_id)
     });
     // Don't leave the typed password lingering in the UI property.
     win.set_cred_password("".into());
     if has_next {
-        show_front_cred(win);
+        show_front_cred(win, window_id);
     } else {
         win.set_cred_prompt_open(false);
     }
@@ -256,13 +329,16 @@ thread_local! {
     static MFA_QUEUE: RefCell<VecDeque<PendingMfa>> = RefCell::new(VecDeque::new());
 }
 
-/// Queue an MFA prompt: a concurrent connection for the same session (the shell
-/// and its SFTP channel both hitting the prompt at once) merges into the open
-/// dialog so the code is only typed once; otherwise enqueue (and show it now if
-/// nothing else is up). We deliberately do NOT cache answers across attempts —
-/// a wrong code must re-prompt on reconnect, not be silently replayed.
+/// Queue an MFA prompt: a concurrent connection for the same session *in the
+/// same window* (the shell and its SFTP channel both hitting the prompt at
+/// once) merges into the open dialog so the code is only typed once; otherwise
+/// enqueue (and show it in the owning window if that window has no other MFA
+/// dialog up). We deliberately do NOT cache answers across attempts — a wrong
+/// code must re-prompt on reconnect, not be silently replayed. Cross-window
+/// prompts never merge — each window types its own code (#multi-window).
 pub(super) fn enqueue_mfa_prompt(
     win: &AppWindow,
+    window_id: u64,
     session_id: String,
     host: String,
     prompt: String,
@@ -271,29 +347,36 @@ pub(super) fn enqueue_mfa_prompt(
 ) {
     let show_now = MFA_QUEUE.with(|q| {
         let mut q = q.borrow_mut();
-        if let Some(p) = q.iter_mut().find(|p| p.session_id == session_id) {
+        if let Some(p) = q
+            .iter_mut()
+            .find(|p| p.window_id == window_id && p.session_id == session_id)
+        {
             p.responders.push(responder);
             return false;
         }
-        let was_empty = q.is_empty();
+        // Per-window turn: show only if this window has no other queued MFA
+        // prompt (its oldest entry is the one on screen).
+        let show_now = !q.iter().any(|p| p.window_id == window_id);
         q.push_back(PendingMfa {
+            window_id,
             session_id,
             host,
             prompt,
             echo,
             responders: vec![responder],
         });
-        was_empty
+        show_now
     });
     if show_now {
-        show_front_mfa(win);
+        show_front_mfa(win, window_id);
     }
 }
 
-/// Populate the MFA dialog from the front prompt and open it.
-pub(super) fn show_front_mfa(win: &AppWindow) {
+/// Populate the MFA dialog from this window's oldest pending prompt and open
+/// it.
+pub(super) fn show_front_mfa(win: &AppWindow, window_id: u64) {
     MFA_QUEUE.with(|q| {
-        if let Some(p) = q.borrow().front() {
+        if let Some(p) = q.borrow().iter().find(|p| p.window_id == window_id) {
             win.set_mfa_host(p.host.clone().into());
             win.set_mfa_prompt(p.prompt.clone().into());
             win.set_mfa_echo(p.echo);
@@ -303,9 +386,9 @@ pub(super) fn show_front_mfa(win: &AppWindow) {
     });
 }
 
-/// Apply the user's answer to the front MFA prompt (or cancel), then show the
-/// next prompt or close.
-pub(super) fn resolve_front_mfa(win: &AppWindow, accept: bool) {
+/// Apply the user's answer to this window's oldest MFA prompt (or cancel),
+/// then show that window's next prompt or close its dialog.
+pub(super) fn resolve_front_mfa(win: &AppWindow, window_id: u64, accept: bool) {
     let answer: Option<String> = if accept {
         Some(win.get_mfa_answer().to_string())
     } else {
@@ -313,17 +396,18 @@ pub(super) fn resolve_front_mfa(win: &AppWindow, accept: bool) {
     };
     let has_next = MFA_QUEUE.with(|q| {
         let mut q = q.borrow_mut();
-        if let Some(p) = q.pop_front() {
+        if let Some(pos) = q.iter().position(|p| p.window_id == window_id) {
+            let p = q.remove(pos).expect("position checked above");
             for r in &p.responders {
                 r.respond(answer.clone());
             }
         }
-        !q.is_empty()
+        q.iter().any(|p| p.window_id == window_id)
     });
     // Don't leave the typed code lingering in the UI property.
     win.set_mfa_answer("".into());
     if has_next {
-        show_front_mfa(win);
+        show_front_mfa(win, window_id);
     } else {
         win.set_mfa_prompt_open(false);
     }

--- a/src/app/core.rs
+++ b/src/app/core.rs
@@ -1,0 +1,161 @@
+// Process-global core shared by every window. Slint is single-threaded:
+// all windows live on the same UI thread, so the Rc<RefCell<>> members are
+// only ever touched from that thread (the listener registry is written once
+// per window construction, also on the UI thread).
+
+use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
+use std::rc::Rc;
+use std::sync::{Arc, Mutex};
+
+use tokio::runtime::Runtime;
+
+use crate::config::ConfigStore;
+use crate::resource::{LocalSnap, NetHist, TabStatuses};
+use crate::sftp::{SftpHandles, SftpLastCwd};
+use crate::ssh::SessionHandle;
+use crate::terminal::{RenderGates, TermBuffers};
+use crate::ui::{
+    AppWindow, PaneInfo, ProcWindow, SplitterInfo, SystemInfoWindow, TabInfo, TerminalState,
+};
+
+/// Where a tab's session events are currently delivered. Session pump
+/// threads hold an `Arc<Mutex<TabRoute>>` per tab and re-read it on every
+/// batch, so moving a tab to another window is just rewriting this struct —
+/// the pumps keep running and immediately target the new window.
+///
+/// Every field is thread-safe (the pumps run off the UI thread).
+#[derive(Clone)]
+pub struct TabRoute {
+    pub window: slint::Weak<AppWindow>,
+    pub window_id: u64,
+    pub bufs: TermBuffers,
+    pub gates: RenderGates,
+    pub statuses: TabStatuses,
+    pub local_snap: LocalSnap,
+    pub net_hist: NetHist,
+    pub sftp_handles: SftpHandles,
+    pub sftp_last_cwd: SftpLastCwd,
+    pub follow_cd: Arc<std::sync::atomic::AtomicBool>,
+}
+
+/// Tab id → its current delivery route. Shared with the pump threads.
+pub type TabRoutes = Arc<Mutex<HashMap<String, Arc<Mutex<TabRoute>>>>>;
+
+/// Everything another window (or a tab transfer) needs to reach into one
+/// open window. UI-thread-only: every Rc<RefCell> here is borrowed on the
+/// Slint thread exclusively.
+#[derive(Clone)]
+pub struct WindowState {
+    pub weak: slint::Weak<AppWindow>,
+    pub handles: Rc<RefCell<HashMap<String, SessionHandle>>>,
+    pub bufs: TermBuffers,
+    pub gates: RenderGates,
+    pub statuses: TabStatuses,
+    pub sftp_handles: SftpHandles,
+    pub sftp_last_cwd: SftpLastCwd,
+    pub local_snap: LocalSnap,
+    pub net_hist: NetHist,
+    pub follow_cd: Arc<std::sync::atomic::AtomicBool>,
+    pub layout: Rc<RefCell<crate::layout::Layout>>,
+    pub tabs_model: Rc<slint::VecModel<TabInfo>>,
+    pub terminals_model: Rc<slint::VecModel<TerminalState>>,
+    pub panes_model: Rc<slint::VecModel<PaneInfo>>,
+    pub splitters_model: Rc<slint::VecModel<SplitterInfo>>,
+    pub content_size: Rc<Cell<(f32, f32)>>,
+    pub proc_weak: slint::Weak<ProcWindow>,
+    pub sys_weak: slint::Weak<SystemInfoWindow>,
+}
+
+/// Open-window registry, generic over the window handle so it can be unit
+/// tested without constructing Slint components. Production instantiates
+/// `WindowRegistry<slint::Weak<AppWindow>>`.
+#[derive(Default)]
+pub struct WindowRegistry<H> {
+    next_id: RefCell<u64>,
+    windows: RefCell<HashMap<u64, H>>,
+    /// Config listeners keyed by window id, so `unregister` can drop the
+    /// closing window's closure (it captures that window's sessions model
+    /// and terminal buffers — leaving it behind would leak them until exit).
+    listeners: RefCell<HashMap<u64, Rc<dyn Fn()>>>,
+}
+
+impl<H: Clone> WindowRegistry<H> {
+    pub fn register(&self, handle: H) -> u64 {
+        let mut next = self.next_id.borrow_mut();
+        *next += 1;
+        let id = *next;
+        self.windows.borrow_mut().insert(id, handle);
+        id
+    }
+
+    /// Remove a window (and its config listener); returns true when the
+    /// registry became empty (the caller must then quit the event loop).
+    pub fn unregister(&self, id: u64) -> bool {
+        self.windows.borrow_mut().remove(&id);
+        self.listeners.borrow_mut().remove(&id);
+        self.windows.borrow().is_empty()
+    }
+
+    #[cfg(test)]
+    pub fn is_empty(&self) -> bool {
+        self.windows.borrow().is_empty()
+    }
+
+    #[cfg(test)]
+    pub fn count(&self) -> usize {
+        self.windows.borrow().len()
+    }
+
+    #[cfg(test)]
+    pub fn for_each<F: FnMut(&H)>(&self, mut f: F) {
+        for h in self.windows.borrow().values() {
+            f(h);
+        }
+    }
+
+    /// A handle of the most recently registered window (used as cascade /
+    /// position origin for the next one).
+    pub fn newest(&self) -> Option<H> {
+        self.windows
+            .borrow()
+            .iter()
+            .max_by_key(|(id, _)| *id)
+            .map(|(_, h)| h.clone())
+    }
+
+    pub fn add_config_listener(&self, id: u64, f: Rc<dyn Fn()>) {
+        self.listeners.borrow_mut().insert(id, f);
+    }
+
+    /// Config (sessions / theme / language …) changed in one window; every
+    /// window refreshes its derived UI state.
+    pub fn broadcast_config_changed(&self) {
+        for l in self.listeners.borrow().values() {
+            l();
+        }
+    }
+}
+
+pub struct AppCore {
+    pub runtime: Arc<Runtime>,
+    /// Shared among all windows; touched only on the Slint UI thread.
+    pub store: Rc<RefCell<ConfigStore>>,
+    /// Live windows; the last one closing quits the shared event loop.
+    pub registry: Rc<WindowRegistry<slint::Weak<AppWindow>>>,
+    /// Per-window state reachable across windows (tab detach/merge), keyed
+    /// by the same id the registry hands out. UI-thread-only.
+    pub window_states: Rc<RefCell<HashMap<u64, WindowState>>>,
+    /// Tab id → delivery route, shared with the session pump threads so a
+    /// tab can be retargeted at another window while its pumps keep running.
+    pub tab_routes: TabRoutes,
+    /// Set once the first window of the process lifetime finishes opening.
+    /// The in-app update check runs only for that window — keying it off
+    /// `registry.count() == 1` would re-fire after close-then-open.
+    /// UI-thread-only, like the rest of this struct.
+    pub first_window_done: Cell<bool>,
+}
+
+#[cfg(test)]
+#[path = "../../tests/app/window_management/registry.rs"]
+mod registry_tests;

--- a/src/app/core.rs
+++ b/src/app/core.rs
@@ -62,7 +62,17 @@ pub struct WindowState {
     pub terminals_model: Rc<slint::VecModel<TerminalState>>,
     pub panes_model: Rc<slint::VecModel<PaneInfo>>,
     pub splitters_model: Rc<slint::VecModel<SplitterInfo>>,
+    /// Repeated Slint timers owned by this window (e.g. the 1 Hz system
+    /// sampler). Dropping the state on close drops these, which stops them —
+    /// otherwise they keep firing for the whole process lifetime.
+    pub timers: Rc<RefCell<Vec<slint::Timer>>>,
     pub content_size: Rc<Cell<(f32, f32)>>,
+    /// Strong handles: both windows start hidden, and the Slint backend only
+    /// keeps a component alive while its window is visible — without these
+    /// they'd be destroyed as soon as `open_window` returns. Released when
+    /// `forget_window_state` drops this entry on close.
+    pub proc_win: Rc<ProcWindow>,
+    pub sys_win: Rc<SystemInfoWindow>,
     pub proc_weak: slint::Weak<ProcWindow>,
     pub sys_weak: slint::Weak<SystemInfoWindow>,
 }

--- a/src/app/dock_menu.rs
+++ b/src/app/dock_menu.rs
@@ -1,0 +1,138 @@
+//! macOS Dock menu: right-click the Dock icon → "新建窗口".
+//!
+//! AppKit asks the application delegate for `applicationDockMenu:`; while
+//! winit's delegate is installed it does not fall back to `NSApplication`
+//! itself (verified on macOS — patching `NSApplication` left the Dock menu
+//! default). We therefore add two methods to the delegate's class at
+//! runtime with `class_addMethod` (falling back to the `NSApplication`
+//! class only when no delegate exists yet):
+//!
+//! * `applicationDockMenu:` — builds and returns the Dock menu (a single
+//!   "新建窗口" entry). The menu is constructed fresh on every request and
+//!   autoreleased, matching AppKit's expectation that the returned menu is
+//!   not owned by the Dock.
+//! * `meatshellNewWindow:` — the menu item's action (target = the receiver
+//!   of `applicationDockMenu:`, i.e. the same object whose class we
+//!   patched). It routes into `crate::app::request_new_window()`, which
+//!   opens a new window through the hook `run()` installs.
+//!
+//! Threading: the Dock menu is only requested on the main thread, which is
+//! also Slint's UI thread in this app, so the action handler can open the
+//! window directly without `invoke_from_event_loop`.
+
+use std::ffi::c_char;
+
+use objc2::ffi::class_addMethod;
+use objc2::rc::Retained;
+use objc2::runtime::{AnyClass, AnyObject, Imp, Sel};
+use objc2::{msg_send, sel, ClassType, MainThreadMarker, MainThreadOnly};
+use objc2_app_kit::{NSApplication, NSMenu, NSMenuItem};
+use objc2_foundation::NSString;
+
+/// `applicationDockMenu:` implementation: `fn(id self, SEL _cmd, id sender) -> NSMenu *`.
+type DockMenuFn = unsafe extern "C-unwind" fn(&AnyObject, Sel, &AnyObject) -> *mut NSMenu;
+/// `meatshellNewWindow:` implementation: `fn(id self, SEL _cmd, id sender) -> void`.
+type NewWindowFn = unsafe extern "C-unwind" fn(&AnyObject, Sel, &AnyObject);
+
+/// Add `applicationDockMenu:` and `meatshellNewWindow:` where AppKit will
+/// actually look for them. AppKit asks the application DELEGATE for
+/// `applicationDockMenu:` first, and while winit's delegate is installed it
+/// never falls back to the `NSApplication` class (verified on macOS:
+/// patching `NSApplication` left the Dock menu default). So patch the
+/// delegate's class; only if no delegate exists yet fall back to
+/// `NSApplication`. Call this after the first window is created, which is
+/// when winit has set up the delegate. Failures are logged and swallowed —
+/// a missing Dock entry must never keep the app from starting.
+pub fn install_dock_menu() {
+    // Defensive: class patching happens once at startup on the main thread,
+    // where `run()` executes. Bail out instead of touching AppKit off-main.
+    let Some(mtm) = MainThreadMarker::new() else {
+        tracing::warn!("dock menu install skipped: not on the main thread");
+        return;
+    };
+
+    unsafe {
+        let app = NSApplication::sharedApplication(mtm);
+        // Raw runtime lookup: AppKit's -[NSApplication delegate], then the
+        // delegate instance's class. Going through msg_send sidesteps the
+        // ProtocolObject type gymnastics entirely.
+        let delegate: *mut AnyObject = msg_send![&app, delegate];
+        let cls: *mut AnyClass = if delegate.is_null() {
+            (NSApplication::class() as *const AnyClass).cast_mut()
+        } else {
+            msg_send![delegate, class]
+        };
+
+        // SAFETY: `Imp` is an argument-less `unsafe extern "C-unwind" fn()`;
+        // the runtime passes self/_cmd/sender per the type encoding given to
+        // `class_addMethod`, which matches each implementation's real
+        // signature (see the type aliases above). Transmuting between
+        // same-ABI function pointers is the standard way to register IMPs.
+        let dock_imp: Imp = std::mem::transmute::<DockMenuFn, Imp>(dock_menu_impl);
+        let action_imp: Imp = std::mem::transmute::<NewWindowFn, Imp>(new_window_impl);
+
+        // - (NSMenu *)applicationDockMenu:(id)sender;  → "@@:@"
+        let dock_ok = class_addMethod(
+            cls,
+            sel!(applicationDockMenu:),
+            dock_imp,
+            b"@@:@\0".as_ptr().cast::<c_char>(),
+        );
+        // - (void)meatshellNewWindow:(id)sender;  → "v@@:@"
+        let action_ok = class_addMethod(
+            cls,
+            sel!(meatshellNewWindow:),
+            action_imp,
+            b"v@@:@\0".as_ptr().cast::<c_char>(),
+        );
+        if !dock_ok.as_bool() || !action_ok.as_bool() {
+            tracing::warn!(
+                dock = dock_ok.as_bool(),
+                action = action_ok.as_bool(),
+                "dock menu install: class_addMethod failed"
+            );
+        }
+    }
+}
+
+/// `applicationDockMenu:` — build the menu fresh on every request and hand
+/// AppKit an autoreleased (non-owned) reference. Dock menu requests are rare
+/// (one per right-click), so rebuilding avoids keeping a menu alive in a
+/// static and any ownership puzzles.
+///
+/// # Safety
+///
+/// Invoked by AppKit via the Objective-C runtime on the main thread with a
+/// valid `NSApplication` receiver and selector.
+unsafe extern "C-unwind" fn dock_menu_impl(
+    this: &AnyObject,
+    _cmd: Sel,
+    _sender: &AnyObject,
+) -> *mut NSMenu {
+    let Some(mtm) = MainThreadMarker::new() else {
+        return std::ptr::null_mut();
+    };
+
+    let menu = NSMenu::new(mtm);
+    let item = NSMenuItem::initWithTitle_action_keyEquivalent(
+        NSMenuItem::alloc(mtm),
+        &NSString::from_str("新建窗口"),
+        Some(sel!(meatshellNewWindow:)),
+        &NSString::new(),
+    );
+    // Target the NSApplication instance that received applicationDockMenu:.
+    item.setTarget(Some(this));
+    menu.addItem(&item);
+
+    Retained::autorelease_ptr(menu)
+}
+
+/// `meatshellNewWindow:` — the menu item action. Runs on the main thread, so
+/// it can open the window directly through the hook installed by `run()`.
+///
+/// # Safety
+///
+/// Invoked by AppKit via the Objective-C runtime on the main thread.
+unsafe extern "C-unwind" fn new_window_impl(_this: &AnyObject, _cmd: Sel, _sender: &AnyObject) {
+    crate::app::request_new_window();
+}

--- a/src/app/jump_list.rs
+++ b/src/app/jump_list.rs
@@ -1,0 +1,118 @@
+//! Windows taskbar jump list: right-click the taskbar icon → "新建窗口",
+//! launching `meatshell --new-window`. The launch is forwarded to the
+//! running primary instance over the single-instance IPC socket (see
+//! `single_instance.rs`), so the entry behaves like Chrome's "new window"
+//! task instead of spawning a second process.
+//!
+//! Registration runs at startup, before the first window is shown, and must
+//! never block or fail startup: every error path degrades to a tracing warn.
+
+use windows::core::{w, Interface, HRESULT, HSTRING, PROPVARIANT};
+use windows::Win32::Storage::EnhancedStorage::{PKEY_AppUserModel_ID, PKEY_Title};
+use windows::Win32::System::Com::{
+    CoCreateInstance, CoInitializeEx, CLSCTX_ALL, COINIT_APARTMENTTHREADED,
+};
+use windows::Win32::UI::Shell::Common::{IObjectArray, IObjectCollection};
+use windows::Win32::UI::Shell::{
+    DestinationList, EnumerableObjectCollection, ICustomDestinationList, IShellLinkW,
+    PropertiesSystem::IPropertyStore, SetCurrentProcessExplicitAppUserModelID, ShellLink,
+};
+
+/// AppUserModelID used to attach the jump list to this application.
+/// Must stay in sync with the identity Explorer uses for meatshell.
+const APP_ID: &str = "meatshell";
+
+/// Register the "新建窗口" user task on the taskbar jump list.
+///
+/// Failures are logged and swallowed — a missing jump list entry must never
+/// keep the app from starting.
+pub fn register_new_window_task() {
+    set_app_user_model_id();
+    if let Err(e) = register_inner() {
+        tracing::warn!("jump list registration failed: {e}");
+    }
+}
+
+/// Declare the process AppUserModelID so Explorer associates this process
+/// with the jump list published under `APP_ID` (taskbar grouping and the
+/// custom destination list). Without it the shell derives an ID from the
+/// exe path and may silently ignore our list.
+///
+/// The `w!` literal must equal `APP_ID` (the macro needs a string literal).
+/// Failure is warn-only, like everything else in this module.
+pub fn set_app_user_model_id() {
+    if let Err(e) = unsafe { SetCurrentProcessExplicitAppUserModelID(w!("meatshell")) } {
+        tracing::warn!("SetCurrentProcessExplicitAppUserModelID failed: {e}");
+    }
+}
+
+fn register_inner() -> windows::core::Result<()> {
+    unsafe {
+        // The main thread has no COM apartment yet at this point in startup;
+        // ignore S_FALSE (already initialized) and RPC_E_CHANGED_MODE (some
+        // shell component initialized it differently) — either way COM is
+        // usable from here.
+        let _ = CoInitializeEx(None, COINIT_APARTMENTTHREADED);
+
+        // current_exe() also works when launched as a portable/AppImage-style
+        // bare binary, so the jump list keeps pointing at the running image.
+        let exe = std::env::current_exe().map_err(|e| {
+            windows::core::Error::new(
+                HRESULT(e.raw_os_error().unwrap_or(0)),
+                format!("current_exe: {e}"),
+            )
+        })?;
+
+        // Shell link: target = this exe, args = --new-window.
+        let exe_h = HSTRING::from(exe.as_path());
+        let link: IShellLinkW = CoCreateInstance(&ShellLink, None, CLSCTX_ALL)
+            .map_err(step("CoCreateInstance(ShellLink)"))?;
+        link.SetPath(&exe_h).map_err(step("SetPath"))?;
+        link.SetArguments(w!("--new-window"))
+            .map_err(step("SetArguments"))?;
+        link.SetDescription(w!("新建窗口"))
+            .map_err(step("SetDescription"))?;
+        link.SetIconLocation(&exe_h, 0)
+            .map_err(step("SetIconLocation"))?;
+
+        // Windows 11 validates user-task links strictly: without an explicit
+        // PKEY_Title the shell rejects the task with E_INVALIDARG from
+        // AddUserTasks (SetDescription does not count as a display name).
+        // AppUserModelID keeps the task grouped with our jump list.
+        let store: IPropertyStore = link.cast().map_err(step("cast IPropertyStore"))?;
+        store
+            .SetValue(&PKEY_Title, &PROPVARIANT::from("新建窗口"))
+            .map_err(step("SetValue(Title)"))?;
+        store
+            .SetValue(&PKEY_AppUserModel_ID, &PROPVARIANT::from(APP_ID))
+            .map_err(step("SetValue(AppUserModelID)"))?;
+        store.Commit().map_err(step("PropertyStore.Commit"))?;
+
+        // User tasks collection holding the single link.
+        let collection: IObjectCollection =
+            CoCreateInstance(&EnumerableObjectCollection, None, CLSCTX_ALL)
+                .map_err(step("CoCreateInstance(EnumerableObjectCollection)"))?;
+        collection.AddObject(&link).map_err(step("AddObject"))?;
+
+        // Custom destination list: publish the task under our AppUserModelID.
+        let list: ICustomDestinationList = CoCreateInstance(&DestinationList, None, CLSCTX_ALL)
+            .map_err(step("CoCreateInstance(DestinationList)"))?;
+        let _ = list.SetAppID(&HSTRING::from(APP_ID));
+        let mut slots = 0u32;
+        let _removed: IObjectArray = list.BeginList(&mut slots).map_err(step("BeginList"))?;
+        list.AddUserTasks(&collection)
+            .map_err(step("AddUserTasks"))?;
+        list.CommitList().map_err(step("CommitList"))?;
+        Ok(())
+    }
+}
+
+/// Tag a COM failure with the failing step so the log names the exact call.
+fn step(name: &'static str) -> impl FnOnce(windows::core::Error) -> windows::core::Error {
+    move |e| {
+        windows::core::Error::new(
+            e.code(),
+            format!("{name}: {e} (0x{:08X})", e.code().0 as u32),
+        )
+    }
+}

--- a/src/app/launch.rs
+++ b/src/app/launch.rs
@@ -1,0 +1,18 @@
+#[cfg(test)]
+#[path = "../../tests/app/window_management/launch_intent.rs"]
+mod launch_intent_tests;
+
+/// What this process launch is supposed to do, parsed from argv before any
+/// window exists. `--new-window` is issued by the OS entry points (Windows
+/// jump list, macOS dock menu, Linux desktop action); when an instance is
+/// already running it is forwarded over the single-instance socket instead
+/// of opening a second process.
+pub struct LaunchIntent {
+    pub new_window: bool,
+}
+
+pub fn parse(args: &[String]) -> LaunchIntent {
+    LaunchIntent {
+        new_window: args.iter().any(|a| a == "--new-window"),
+    }
+}

--- a/src/app/session_event.rs
+++ b/src/app/session_event.rs
@@ -2,6 +2,7 @@ use super::*;
 
 pub(super) fn apply_session_event_to_window(
     win: &AppWindow,
+    window_id: u64,
     tab_id: &str,
     event: SessionEvent,
     bufs: &TermBuffers,
@@ -96,6 +97,7 @@ pub(super) fn apply_session_event_to_window(
             // synthetic Output event so it reuses the normal render path (#79).
             apply_session_event_to_window(
                 win,
+                window_id,
                 tab_id,
                 SessionEvent::Output(format!(
                     "\r\n\x1b[31m{}\x1b[0m\r\n",
@@ -274,6 +276,7 @@ pub(super) fn apply_session_event_to_window(
                 // into the terminal via a synthetic Output event (#70).
                 apply_session_event_to_window(
                     win,
+                    window_id,
                     tab_id,
                     SessionEvent::Output(format!(
                         "\r\n[meatshell] {} {}: {}\r\n",
@@ -378,7 +381,16 @@ pub(super) fn apply_session_event_to_window(
             changed,
             responder,
         } => {
-            enqueue_hostkey_prompt(win, host, port, key_type, fingerprint, changed, responder);
+            enqueue_hostkey_prompt(
+                win,
+                window_id,
+                host,
+                port,
+                key_type,
+                fingerprint,
+                changed,
+                responder,
+            );
         }
         SessionEvent::CredentialPrompt {
             session_id,
@@ -390,6 +402,7 @@ pub(super) fn apply_session_event_to_window(
         } => {
             enqueue_cred_prompt(
                 win,
+                window_id,
                 session_id,
                 host,
                 user,
@@ -405,7 +418,7 @@ pub(super) fn apply_session_event_to_window(
             echo,
             responder,
         } => {
-            enqueue_mfa_prompt(win, session_id, host, prompt, echo, responder);
+            enqueue_mfa_prompt(win, window_id, session_id, host, prompt, echo, responder);
         }
         SessionEvent::CommandRan(cmd) => {
             // A command typed directly in the terminal, captured via the shell

--- a/src/app/session_models.rs
+++ b/src/app/session_models.rs
@@ -310,12 +310,14 @@ pub(super) fn sync_sessions_to_model_with_filter(
 /// Same rows as `sync_sessions_to_model_with_filter`, but when the row count
 /// is unchanged the rows are written with `set_row_data` instead of `set_vec`:
 /// the `for` loop keeps its elements (and a drag's pointer grab) alive. Used
-/// for per-hop updates during drag-to-reorder.
+/// for per-hop updates during drag-to-reorder. Returns false when the row
+/// count changed and a full `set_vec` rebuild was required — that recreates
+/// the rows and drops the dragging row's pointer grab.
 pub(super) fn refresh_session_rows_in_place(
     store: &ConfigStore,
     model: &VecModel<SessionInfo>,
     query: &str,
-) {
+) -> bool {
     use slint::Model as _;
     let builtin_sessions = builtin_local_sessions(store.wsl_profiles());
     let rows = build_session_rows(
@@ -329,8 +331,10 @@ pub(super) fn refresh_session_rows_in_place(
         for (i, row) in rows.into_iter().enumerate() {
             model.set_row_data(i, row);
         }
+        true
     } else {
         model.set_vec(rows);
+        false
     }
 }
 

--- a/src/app/session_models.rs
+++ b/src/app/session_models.rs
@@ -244,7 +244,7 @@ fn build_session_rows(
         });
     }
     for group in &display_groups {
-        let mut gs: Vec<&Session> = if group == "default" {
+        let gs: Vec<&Session> = if group == "default" {
             sessions
                 .iter()
                 .filter(|session| {
@@ -258,8 +258,9 @@ fn build_session_rows(
                 .filter(|session| &session.group == group && matches(session))
                 .collect()
         };
-        gs.sort_by_key(|s| s.name.to_lowercase());
-
+        // No alphabetical sort: the stored Vec order is the user's manual
+        // order, maintained by drag-to-reorder (same convention as quick
+        // commands). New sessions land at the end of their group.
         if gs.is_empty() && !searching {
             rows.push(blank(group));
         } else {
@@ -306,13 +307,38 @@ pub(super) fn sync_sessions_to_model_with_filter(
     ));
 }
 
+/// Same rows as `sync_sessions_to_model_with_filter`, but when the row count
+/// is unchanged the rows are written with `set_row_data` instead of `set_vec`:
+/// the `for` loop keeps its elements (and a drag's pointer grab) alive. Used
+/// for per-hop updates during drag-to-reorder.
+pub(super) fn refresh_session_rows_in_place(
+    store: &ConfigStore,
+    model: &VecModel<SessionInfo>,
+    query: &str,
+) {
+    use slint::Model as _;
+    let builtin_sessions = builtin_local_sessions(store.wsl_profiles());
+    let rows = build_session_rows(
+        store.sessions(),
+        store.groups(),
+        store.collapsed_session_groups(),
+        &builtin_sessions,
+        query,
+    );
+    if rows.len() == model.row_count() {
+        for (i, row) in rows.into_iter().enumerate() {
+            model.set_row_data(i, row);
+        }
+    } else {
+        model.set_vec(rows);
+    }
+}
+
 pub(super) fn sync_sessions_to_model(store: &ConfigStore, model: &VecModel<SessionInfo>) {
     sync_sessions_to_model_with_filter(store, model, "");
 }
 
-pub(super) fn builtin_local_sessions(
-    wsl_profiles: &[crate::config::WslProfile],
-) -> Vec<Session> {
+pub(super) fn builtin_local_sessions(wsl_profiles: &[crate::config::WslProfile]) -> Vec<Session> {
     let mut out = Vec::new();
     #[cfg(windows)]
     {

--- a/src/app/session_models.rs
+++ b/src/app/session_models.rs
@@ -66,21 +66,7 @@ pub(super) fn parse_batch_import(text: &str) -> Vec<Session> {
 /// dropdown (#179). Ungrouped ("") is excluded; the dialog leaves the field blank
 /// for that case.
 pub(super) fn session_groups_model(store: &ConfigStore) -> ModelRc<SharedString> {
-    let sessions = store.sessions();
-    let mut named: Vec<String> = store
-        .groups()
-        .iter()
-        .filter(|group| !is_reserved_session_group(group.trim()))
-        .cloned()
-        .chain(
-            sessions
-                .iter()
-                .filter(|s| !s.group.is_empty() && !is_reserved_session_group(s.group.trim()))
-                .map(|s| s.group.clone()),
-        )
-        .collect();
-    named.sort_by_key(|g| g.to_lowercase());
-    named.dedup();
+    let named = named_display_groups(store.groups(), store.sessions());
     ModelRc::from(Rc::new(VecModel::from(
         named
             .into_iter()
@@ -183,20 +169,7 @@ fn build_session_rows(
             .map(|session| session.group.clone())
             .collect()
     } else {
-        explicit_groups
-            .iter()
-            .filter(|group| !is_reserved_session_group(group.trim()))
-            .cloned()
-            .chain(
-                sessions
-                    .iter()
-                    .filter(|session| {
-                        !session.group.is_empty()
-                            && !is_reserved_session_group(session.group.trim())
-                    })
-                    .map(|session| session.group.clone()),
-            )
-            .collect()
+        named_display_groups(explicit_groups, sessions)
     };
     named.sort_by_key(|g| g.to_lowercase());
     named.dedup();

--- a/src/app/session_runtime.rs
+++ b/src/app/session_runtime.rs
@@ -57,6 +57,25 @@ pub(super) fn start_session_in_tab(tab_id: &str, session: Session, ctx: &Connect
     handle.set_resource_monitoring(monitoring_enabled);
     ctx.handles.borrow_mut().insert(tab_id.to_string(), handle);
 
+    // Delivery route for this tab. Both pump threads hold the Arc and
+    // re-read it on every batch, so a later detach/merge only rewrites the
+    // route — the pumps keep running and target the new window (#tab-detach).
+    let route = Arc::new(Mutex::new(TabRoute {
+        window: ctx.weak.clone(),
+        window_id: ctx.window_id,
+        bufs: ctx.bufs.clone(),
+        gates: ctx.render_gates.clone(),
+        statuses: ctx.tab_statuses.clone(),
+        local_snap: ctx.local_snap.clone(),
+        net_hist: ctx.local_net_hist.clone(),
+        sftp_handles: ctx.sftp_handles.clone(),
+        sftp_last_cwd: ctx.sftp_last_cwd.clone(),
+        follow_cd: ctx.sftp_follow_cd.clone(),
+    }));
+    if let Ok(mut routes) = ctx.tab_routes.lock() {
+        routes.insert(tab_id.to_string(), route.clone());
+    }
+
     // Separate SFTP connection for the same session (SSH only). It waits for
     // the interactive PTY to report Connected so a second SSH handshake cannot
     // contend with terminal startup on the same host/network path.
@@ -84,17 +103,9 @@ pub(super) fn start_session_in_tab(tab_id: &str, session: Session, ctx: &Connect
 
     // --- Shell event pump (dedicated thread) ---
     {
-        let weak_inner = ctx.weak.clone();
-        let bufs_thread = ctx.bufs.clone();
-        let sftp_handles_pump = ctx.sftp_handles.clone();
-        let sftp_last_cwd_pump = ctx.sftp_last_cwd.clone();
+        let route_pump = route.clone();
         let rt_pump = ctx.runtime.clone();
         let tab_id_pump = tab_id.to_string();
-        let statuses_pump = ctx.tab_statuses.clone();
-        let local_pump = ctx.local_snap.clone();
-        let net_pump = ctx.local_net_hist.clone();
-        let follow_cd_pump = ctx.sftp_follow_cd.clone();
-        let render_gates_pump = ctx.render_gates.clone();
         std::thread::spawn(move || {
             let mut shell_rx = rx;
             let mut sftp_ready_tx = sftp_ready_tx;
@@ -124,6 +135,13 @@ pub(super) fn start_session_in_tab(tab_id: &str, session: Session, ctx: &Connect
                     }
                 }
 
+                // Resolve the current delivery route once per batch: a tab that
+                // was detached/merged mid-stream simply delivers this batch
+                // to its new window (#tab-detach).
+                let Ok(rt) = route_pump.lock().map(|g| g.clone()) else {
+                    continue;
+                };
+
                 // Run CwdChanged side-effects here (off the UI thread), drop the
                 // swallowed ones, and concatenate runs of Output into a single chunk
                 // so the UI parses + renders the whole burst once.
@@ -142,7 +160,7 @@ pub(super) fn start_session_in_tab(tab_id: &str, session: Session, ctx: &Connect
                             // OSC 7, same directory or not, snaps the panel back to
                             // the shell's cwd. Unchanged repeats (every prompt
                             // re-emits OSC 7) are ignored (#59).
-                            let changed = match sftp_last_cwd_pump.lock() {
+                            let changed = match rt.sftp_last_cwd.lock() {
                                 Ok(mut m) => {
                                     m.insert(tab_id_pump.clone(), cwd.clone()).as_deref()
                                         != Some(cwd.as_str())
@@ -153,7 +171,7 @@ pub(super) fn start_session_in_tab(tab_id: &str, session: Session, ctx: &Connect
                             // sftp_loading without any ListDir to clear it (the #59
                             // stuck-"loading" trap).
                             if !changed
-                                || !follow_cd_pump.load(std::sync::atomic::Ordering::Relaxed)
+                                || !rt.follow_cd.load(std::sync::atomic::Ordering::Relaxed)
                             {
                                 continue;
                             }
@@ -161,7 +179,7 @@ pub(super) fn start_session_in_tab(tab_id: &str, session: Session, ctx: &Connect
                                 prev.abort();
                             }
                             let cwd_spawn = cwd.clone();
-                            let sftp_h = sftp_handles_pump.clone();
+                            let sftp_h = rt.sftp_handles.clone();
                             let tid = tab_id_pump.clone();
                             cwd_debounce = Some(rt_pump.spawn(async move {
                                 tokio::time::sleep(std::time::Duration::from_millis(500)).await;
@@ -216,7 +234,7 @@ pub(super) fn start_session_in_tab(tab_id: &str, session: Session, ctx: &Connect
                         SessionEvent::Output(chunk) => {
                             let chunk_len = chunk.len();
                             let reply = ingest_terminal_output(
-                                &bufs_thread,
+                                &rt.bufs,
                                 &tab_id_pump,
                                 chunk.as_bytes(),
                             );
@@ -229,10 +247,10 @@ pub(super) fn start_session_in_tab(tab_id: &str, session: Session, ctx: &Connect
 
                             if record_ingested_chunk(chunk_len, &mut ingested_since_checkpoint) {
                                 let ticket = request_tab_render(
-                                    weak_inner.clone(),
+                                    rt.window.clone(),
                                     &tab_id_pump,
-                                    &bufs_thread,
-                                    &render_gates_pump,
+                                    &rt.bufs,
+                                    &rt.gates,
                                 );
                                 dirty_since_request = false;
 
@@ -255,10 +273,10 @@ pub(super) fn start_session_in_tab(tab_id: &str, session: Session, ctx: &Connect
 
                 if dirty_since_request {
                     let _ = request_tab_render(
-                        weak_inner.clone(),
+                        rt.window.clone(),
                         &tab_id_pump,
-                        &bufs_thread,
-                        &render_gates_pump,
+                        &rt.bufs,
+                        &rt.gates,
                     );
                 }
 
@@ -266,18 +284,21 @@ pub(super) fn start_session_in_tab(tab_id: &str, session: Session, ctx: &Connect
                     continue;
                 }
 
-                let weak_evt = weak_inner.clone();
+                let rt_evt = rt.clone();
                 let tid = tab_id_pump.clone();
-                let bufs_evt = bufs_thread.clone();
-                let st_evt = statuses_pump.clone();
-                let lc_evt = local_pump.clone();
-                let nh_evt = net_pump.clone();
-                let gates_evt = render_gates_pump.clone();
                 let _ = slint::invoke_from_event_loop(move || {
-                    if let Some(win) = weak_evt.upgrade() {
+                    if let Some(win) = rt_evt.window.upgrade() {
                         for evt in ui_only {
                             apply_session_event_to_window(
-                                &win, &tid, evt, &bufs_evt, &gates_evt, &st_evt, &lc_evt, &nh_evt,
+                                &win,
+                                rt_evt.window_id,
+                                &tid,
+                                evt,
+                                &rt_evt.bufs,
+                                &rt_evt.gates,
+                                &rt_evt.statuses,
+                                &rt_evt.local_snap,
+                                &rt_evt.net_hist,
                             );
                         }
                     }
@@ -288,13 +309,8 @@ pub(super) fn start_session_in_tab(tab_id: &str, session: Session, ctx: &Connect
 
     // --- SFTP event pump (separate thread, SSH only) ---
     if let Some(sftp_evt_tx) = sftp_evt_tx {
-        let weak_sftp = ctx.weak.clone();
-        let bufs_sftp = ctx.bufs.clone();
+        let route_sftp = route.clone();
         let tab_id_sftp = tab_id.to_string();
-        let statuses_sftp = ctx.tab_statuses.clone();
-        let local_sftp = ctx.local_snap.clone();
-        let net_sftp = ctx.local_net_hist.clone();
-        let gates_sftp = ctx.render_gates.clone();
         std::thread::spawn(move || {
             let mut sftp_rx = sftp_evt_tx;
             let mut drained: Vec<SessionEvent> = Vec::new();
@@ -314,18 +330,23 @@ pub(super) fn start_session_in_tab(tab_id: &str, session: Session, ctx: &Connect
                 if ui_batch.is_empty() {
                     continue;
                 }
-                let weak_s = weak_sftp.clone();
+                let Ok(rt_s) = route_sftp.lock().map(|g| g.clone()) else {
+                    continue;
+                };
                 let tid = tab_id_sftp.clone();
-                let bufs_s = bufs_sftp.clone();
-                let st_s = statuses_sftp.clone();
-                let lc_s = local_sftp.clone();
-                let nh_s = net_sftp.clone();
-                let gates_s = gates_sftp.clone();
                 let _ = slint::invoke_from_event_loop(move || {
-                    if let Some(win) = weak_s.upgrade() {
+                    if let Some(win) = rt_s.window.upgrade() {
                         for sftp_evt in ui_batch {
                             apply_session_event_to_window(
-                                &win, &tid, sftp_evt, &bufs_s, &gates_s, &st_s, &lc_s, &nh_s,
+                                &win,
+                                rt_s.window_id,
+                                &tid,
+                                sftp_evt,
+                                &rt_s.bufs,
+                                &rt_s.gates,
+                                &rt_s.statuses,
+                                &rt_s.local_snap,
+                                &rt_s.net_hist,
                             );
                         }
                     }

--- a/src/app/session_runtime.rs
+++ b/src/app/session_runtime.rs
@@ -84,16 +84,31 @@ pub(super) fn start_session_in_tab(tab_id: &str, session: Session, ctx: &Connect
         let (ready_tx, ready_rx) = tokio::sync::oneshot::channel::<()>();
         let sftp_runtime = ctx.runtime.clone();
         let sftp_task_runtime = sftp_runtime.clone();
-        let sftp_handles = ctx.sftp_handles.clone();
+        // Read the handle map through the route at insertion time: if the tab
+        // is dragged to another window while we connect, the route already
+        // points at the destination and the handle must land there.
+        let sftp_route = route.clone();
         let sftp_tab_id = tab_id.to_string();
         sftp_runtime.spawn(async move {
-            if ready_rx.await.is_err() {
+            // The interactive PTY may never report Connected (stalled
+            // handshake); bound the wait so this bootstrap task cannot
+            // outlive the tab forever.
+            if !matches!(
+                tokio::time::timeout(std::time::Duration::from_secs(30), ready_rx).await,
+                Ok(Ok(()))
+            ) {
                 return;
             }
             tokio::task::yield_now().await;
             let sftp_handle = spawn_sftp(sftp_task_runtime.handle(), session, jump, sftp_tx);
-            if let Ok(mut handles) = sftp_handles.lock() {
-                handles.insert(sftp_tab_id, sftp_handle);
+            let handles = sftp_route
+                .lock()
+                .ok()
+                .map(|r| r.sftp_handles.clone());
+            if let Some(handles) = handles {
+                if let Ok(mut handles) = handles.lock() {
+                    handles.insert(sftp_tab_id, sftp_handle);
+                }
             }
         });
         (Some(sftp_rx), Some(ready_tx))

--- a/src/app/sftp_ui.rs
+++ b/src/app/sftp_ui.rs
@@ -132,8 +132,7 @@ pub(super) fn natural_ascii_cmp(a: &str, b: &str) -> std::cmp::Ordering {
     ab.len().cmp(&bb.len())
 }
 
-/// Push a value into a fixed-length ring buffer (newest at the end).
-
+/// Collect the remote paths currently selected in an SFTP tab's file list.
 pub(super) fn collect_sftp_selected(
     terminals: &VecModel<TerminalState>,
     tab_id: &str,

--- a/src/app/single_instance.rs
+++ b/src/app/single_instance.rs
@@ -1,0 +1,182 @@
+// Single-instance coordination. All OS entry points (Windows jump list,
+// macOS dock menu, Linux desktop action) launch `meatshell --new-window`.
+// The first running instance owns a local endpoint under the data dir; later
+// `--new-window` launches connect, send "new-window\n" and exit, and the
+// primary opens the new window in-process (Chrome-style). Plain relaunches
+// never forward: if the endpoint is taken they run as an independent second
+// instance.
+//
+// Transport split: unix uses a unix-domain socket (`ipc.sock`); Windows uses
+// a TCP loopback listener on 127.0.0.1 whose port is published in a port
+// file (`ipc.port`), because std's Windows unix-socket support is unstable
+// (nightly-only, rust-lang/rust#150487). On Windows every `socket_path`
+// argument is therefore reinterpreted as the port-file path.
+
+#[cfg(windows)]
+use std::net::{SocketAddr, TcpListener, TcpStream};
+#[cfg(unix)]
+use std::os::unix::net::{UnixListener, UnixStream};
+
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+const MSG_NEW_WINDOW: &str = "new-window";
+
+#[derive(Debug)]
+pub enum Instance {
+    /// This process owns the endpoint. `listen` accepts forwarded requests.
+    Primary { listen: Listener },
+    /// Another instance is running; the new-window request was forwarded and
+    /// this process should exit with success.
+    Forwarded,
+}
+
+/// Try to become the primary instance. With `forward`, a live primary
+/// receives a new-window request and `Forwarded` is returned; without it a
+/// live primary is reported as an error so a plain relaunch runs as its own
+/// instance instead of opening a bonus window in the first one. Never
+/// panics on IO trouble — callers treat errors as "just run normally".
+#[cfg(unix)]
+pub fn acquire(socket_path: &Path, forward: bool) -> std::io::Result<Instance> {
+    if let Ok(listener) = UnixListener::bind(socket_path) {
+        return Ok(Instance::Primary {
+            listen: Listener { listener },
+        });
+    }
+    // Bind failed: either a live primary owns the socket, or the file is
+    // stale (the previous primary exited without unlinking it). Probe with
+    // a connect, mirroring the stale port-file logic on Windows.
+    match UnixStream::connect(socket_path) {
+        Ok(mut stream) => {
+            if !forward {
+                // A plain launch must not forward: report the live primary
+                // and let run() fall back to a normal second instance.
+                return Err(std::io::Error::other(
+                    "single-instance primary already running",
+                ));
+            }
+            stream.write_all(format!("{MSG_NEW_WINDOW}\n").as_bytes())?;
+            stream.flush()?;
+            Ok(Instance::Forwarded)
+        }
+        Err(_) => {
+            // Nothing is listening, so the file is stale. Remove it and
+            // retry the bind once. Shutdown-time unlinking is deliberately
+            // not attempted: it cannot run for a killed process, so this
+            // retry is the robust recovery.
+            let _ = std::fs::remove_file(socket_path);
+            let listener = UnixListener::bind(socket_path)?;
+            Ok(Instance::Primary {
+                listen: Listener { listener },
+            })
+        }
+    }
+}
+
+/// `socket_path` is the port-file path here (see module docs).
+#[cfg(windows)]
+pub fn acquire(socket_path: &Path, forward: bool) -> std::io::Result<Instance> {
+    let port_file = socket_path;
+    // A live primary? Connect with a short timeout; a stale port file
+    // (parse error, refused/timeout connection) is treated as "no primary".
+    if let Some(port) = read_port_file(port_file) {
+        if forward {
+            if forward_tcp(port).is_ok() {
+                return Ok(Instance::Forwarded);
+            }
+        } else if connect_tcp(port).is_ok() {
+            // A plain launch must not forward (and must not steal the port
+            // file): report the live primary and let run() fall back to a
+            // normal second instance.
+            return Err(std::io::Error::other(
+                "single-instance primary already running",
+            ));
+        }
+    }
+    // No live primary: start one on an ephemeral loopback port.
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    let port = listener.local_addr()?.port();
+    // Without the port file nobody can find us; let the caller fall back
+    // to a normal launch.
+    std::fs::write(port_file, port.to_string())?;
+    // Two processes can both see "no primary" and both reach this point.
+    // Whoever wrote the port file last wins; re-check and defer if we lost.
+    if read_port_file(port_file) != Some(port) {
+        drop(listener);
+        if forward {
+            if let Some(winner) = read_port_file(port_file) {
+                if forward_tcp(winner).is_ok() {
+                    return Ok(Instance::Forwarded);
+                }
+            }
+        }
+        // Degradation: the race-loser could not reach the winner, so a
+        // `--new-window` launch falls back to a second instance; rare and
+        // acceptable.
+        return Err(std::io::Error::other("lost single-instance race"));
+    }
+    Ok(Instance::Primary {
+        listen: Listener { listener },
+    })
+}
+
+#[cfg(windows)]
+fn connect_tcp(port: u16) -> std::io::Result<TcpStream> {
+    let addr = SocketAddr::from(([127, 0, 0, 1], port));
+    TcpStream::connect_timeout(&addr, Duration::from_millis(300))
+}
+
+#[cfg(windows)]
+fn forward_tcp(port: u16) -> std::io::Result<Instance> {
+    let mut stream = connect_tcp(port)?;
+    stream.write_all(format!("{MSG_NEW_WINDOW}\n").as_bytes())?;
+    stream.flush()?;
+    Ok(Instance::Forwarded)
+}
+
+#[cfg(windows)]
+fn read_port_file(port_file: &Path) -> Option<u16> {
+    std::fs::read_to_string(port_file).ok()?.trim().parse().ok()
+}
+
+/// Endpoint path inside the per-user data dir: the unix socket on unix, the
+/// TCP port file on Windows (see module docs).
+pub fn socket_path() -> PathBuf {
+    #[cfg(windows)]
+    {
+        crate::config::data_dir().join("ipc.port")
+    }
+    #[cfg(not(windows))]
+    {
+        crate::config::data_dir().join("ipc.sock")
+    }
+}
+
+#[derive(Debug)]
+pub struct Listener {
+    #[cfg(unix)]
+    listener: UnixListener,
+    #[cfg(windows)]
+    listener: TcpListener,
+}
+
+impl Listener {
+    /// Blocks forever, invoking `on_msg` for every complete line received.
+    /// Spawn this on its own thread.
+    pub fn spawn<F: FnMut(String) + Send + 'static>(self, mut on_msg: F) {
+        for stream in self.listener.incoming().flatten() {
+            // One silent client must not wedge every later forward: bound
+            // the wait for the first line and skip the connection if it
+            // times out.
+            let _ = stream.set_read_timeout(Some(Duration::from_secs(2)));
+            if let Some(Ok(line)) = BufReader::new(stream).lines().next() {
+                on_msg(line);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "../../tests/app/window_management/single_instance.rs"]
+mod single_instance_tests;

--- a/src/app/single_instance.rs
+++ b/src/app/single_instance.rs
@@ -132,7 +132,14 @@ fn forward_tcp(port: u16) -> std::io::Result<Instance> {
     let mut stream = connect_tcp(port)?;
     stream.write_all(format!("{MSG_NEW_WINDOW}\n").as_bytes())?;
     stream.flush()?;
-    Ok(Instance::Forwarded)
+    // Whoever holds the port must ack: a stale port file can point at an
+    // unrelated listener, and treating that as Forwarded would exit without
+    // any window ever opening.
+    stream.set_read_timeout(Some(Duration::from_secs(2)))?;
+    match BufReader::new(&stream).lines().next() {
+        Some(Ok(line)) if line == "ack" => Ok(Instance::Forwarded),
+        _ => Err(std::io::Error::other("no ack from single-instance primary")),
+    }
 }
 
 #[cfg(windows)]
@@ -163,14 +170,19 @@ pub struct Listener {
 
 impl Listener {
     /// Blocks forever, invoking `on_msg` for every complete line received.
-    /// Spawn this on its own thread.
+    /// Spawn this on its own thread. Every accepted line is acked before
+    /// dispatch so forwarders can verify they reached the real primary —
+    /// on Windows the port file may stale and point at an unrelated
+    /// listener, which would never ack.
     pub fn spawn<F: FnMut(String) + Send + 'static>(self, mut on_msg: F) {
-        for stream in self.listener.incoming().flatten() {
+        for mut stream in self.listener.incoming().flatten() {
             // One silent client must not wedge every later forward: bound
             // the wait for the first line and skip the connection if it
             // times out.
             let _ = stream.set_read_timeout(Some(Duration::from_secs(2)));
-            if let Some(Ok(line)) = BufReader::new(stream).lines().next() {
+            if let Some(Ok(line)) = BufReader::new(&stream).lines().next() {
+                let _ = stream.write_all(b"ack\n");
+                let _ = stream.flush();
                 on_msg(line);
             }
         }

--- a/src/app/tab_callbacks.rs
+++ b/src/app/tab_callbacks.rs
@@ -142,6 +142,7 @@ pub(super) fn wire_tab_callbacks(
         let panes_model = panes_model.clone();
         let splitters_model = splitters_model.clone();
         let tab_titles = tab_titles.clone();
+        let tab_routes = core.tab_routes.clone();
         window.on_pane_tab_closed(move |_pane_id: i32, id: SharedString| {
             let id = id.to_string();
             if id == "welcome" {
@@ -159,6 +160,9 @@ pub(super) fn wire_tab_callbacks(
                 gate.close();
             }
             bufs.lock().unwrap().remove(&id);
+            if let Ok(mut routes) = tab_routes.lock() {
+                routes.remove(&id);
+            }
 
             // Remove from tabs + terminals models.
             let mut idx = None;

--- a/src/app/tab_callbacks.rs
+++ b/src/app/tab_callbacks.rs
@@ -15,6 +15,7 @@ pub(super) fn wire_tab_callbacks(
     render_gates: RenderGates,
     sftp_handles: SftpHandles,
     sftp_last_cwd: SftpLastCwd,
+    tab_titles: Rc<RefCell<HashMap<String, String>>>,
 ) {
     // Ctrl+Tab / Ctrl+Shift+Tab cycle within the currently focused pane (#294).
     {
@@ -140,11 +141,13 @@ pub(super) fn wire_tab_callbacks(
         let sftp_last_cwd = sftp_last_cwd.clone();
         let panes_model = panes_model.clone();
         let splitters_model = splitters_model.clone();
+        let tab_titles = tab_titles.clone();
         window.on_pane_tab_closed(move |_pane_id: i32, id: SharedString| {
             let id = id.to_string();
             if id == "welcome" {
                 return;
             }
+            tab_titles.borrow_mut().remove(&id);
             if let Some(handle) = handles.borrow_mut().remove(&id) {
                 handle.close();
             }

--- a/src/app/tab_callbacks.rs
+++ b/src/app/tab_callbacks.rs
@@ -2,6 +2,8 @@ use super::*;
 
 pub(super) fn wire_tab_callbacks(
     window: &AppWindow,
+    window_id: u64,
+    core: Rc<AppCore>,
     tabs_model: Rc<VecModel<TabInfo>>,
     terminals_model: Rc<VecModel<TerminalState>>,
     layout: Rc<RefCell<crate::layout::Layout>>,
@@ -388,7 +390,15 @@ pub(super) fn wire_tab_callbacks(
         let weak = window.as_weak();
         let layout = layout.clone();
         let content_size = content_size.clone();
-        window.on_tab_drag_move(move |_tab_id: SharedString, x: f32, y: f32| {
+        let core = core.clone();
+        window.on_tab_drag_move(move |tab_id: SharedString, x: f32, y: f32| {
+            let tab_id = tab_id.to_string();
+            // Cross-window detach/merge owns the feedback once the cursor
+            // leaves the window (the torn-off window follows the pointer,
+            // the window under the cursor lights up) (#tab-detach).
+            if handle_global_tab_drag_move(&core, window_id, &tab_id, x, y) {
+                return;
+            }
             if let Some(w) = weak.upgrade() {
                 match drag_target(&layout.borrow(), content_size.get(), x, y) {
                     Some((_, _, (hx, hy, hw, hh))) => {
@@ -416,6 +426,12 @@ pub(super) fn wire_tab_callbacks(
         let splitters_model = splitters_model.clone();
         window.on_tab_drag_drop(move |tab_id: SharedString, x: f32, y: f32| {
             let tab_id = tab_id.to_string();
+            // A cross-window drag (torn-off window following the cursor) is
+            // settled here: merged into the window under the pointer, or
+            // kept where it is (#tab-detach).
+            if handle_global_tab_drag_drop(&core, window_id, &tab_id, x, y) {
+                return;
+            }
             let target = drag_target(&layout.borrow(), content_size.get(), x, y);
             if let Some((pane, zone, _)) = target {
                 let mut lay = layout.borrow_mut();

--- a/src/app/tab_transfer.rs
+++ b/src/app/tab_transfer.rs
@@ -1,0 +1,514 @@
+//! Tab detach / merge (#tab-detach).
+//!
+//! Interaction: while a tab is dragged, the source window keeps the tab —
+//! the gesture must survive until the pointer is released. Cross-window
+//! feedback is live: whichever window sits under the cursor lights up as
+//! the merge target and is raised to the front. The actual move happens on
+//! DROP:
+//!
+//! * over another window  → the tab merges into it;
+//! * back over the source → the usual pane split/move logic applies;
+//! * over empty desktop   → the tab tears off into a new window created at
+//!   the drop point (clamped onto the monitor so it never opens half
+//!   off-screen), and a source window left without tabs closes itself.
+//!
+//! Session pumps are retargeted through the per-tab `TabRoute` (see
+//! `core.rs`), so a moved tab keeps its live connection.
+
+use super::*;
+
+/// One window's rectangle in global logical coordinates.
+struct WinGeo {
+    x: f32,
+    y: f32,
+    w: f32,
+    h: f32,
+}
+
+fn win_geo(win: &AppWindow) -> WinGeo {
+    let scale = win.window().scale_factor().max(0.01);
+    let pos = win.window().position();
+    let size = win.window().size();
+    WinGeo {
+        x: pos.x as f32 / scale,
+        y: pos.y as f32 / scale,
+        w: size.width as f32 / scale,
+        h: size.height as f32 / scale,
+    }
+}
+
+fn contains(g: &WinGeo, x: f32, y: f32) -> bool {
+    x >= g.x && x < g.x + g.w && y >= g.y && y < g.y + g.h
+}
+
+/// Pane-area-relative point → global logical coordinates.
+fn global_point(core: &Rc<AppCore>, window_id: u64, x: f32, y: f32) -> Option<(f32, f32)> {
+    let st = core.window_states.borrow().get(&window_id).cloned()?;
+    let win = st.weak.upgrade()?;
+    let g = win_geo(&win);
+    Some((
+        g.x + win.get_content_origin_x() + x,
+        g.y + win.get_content_origin_y() + y,
+    ))
+}
+
+/// The other window under the point, if any.
+fn window_over(core: &Rc<AppCore>, exclude: u64, gx: f32, gy: f32) -> Option<u64> {
+    let states = core.window_states.borrow();
+    for (id, st) in states.iter() {
+        if *id == exclude {
+            continue;
+        }
+        let Some(win) = st.weak.upgrade() else {
+            continue;
+        };
+        let g = win_geo(&win);
+        if contains(&g, gx, gy) {
+            return Some(*id);
+        }
+    }
+    None
+}
+
+fn find_tab_row(st: &WindowState, tab_id: &str) -> Option<TabInfo> {
+    use slint::Model as _;
+    st.tabs_model.iter().find(|t| t.id.to_string() == tab_id)
+}
+
+/// Can this tab be moved? Any terminal tab that owns a session handle, in
+/// any connection state: connected tabs keep their live connection,
+/// disconnected tabs (state 2) reconnect in the new window (Enter-to-
+/// reconnect, #79), and mid-connect tabs keep connecting because every
+/// event (including auth prompts) is delivered through the per-tab
+/// `TabRoute`, which the move retargets at the new window. Excluded: the
+/// welcome tab (no session).
+fn movable(core: &Rc<AppCore>, window_id: u64, tab_id: &str) -> bool {
+    let states = core.window_states.borrow();
+    let Some(st) = states.get(&window_id) else {
+        return false;
+    };
+    let Some(row) = find_tab_row(st, tab_id) else {
+        return false;
+    };
+    row.kind.to_string() == "terminal" && st.handles.borrow().contains_key(tab_id)
+}
+
+/// Highlight a window's content area as a merge target.
+fn highlight_window(core: &Rc<AppCore>, window_id: u64) {
+    let states = core.window_states.borrow();
+    let Some(st) = states.get(&window_id) else {
+        return;
+    };
+    let Some(win) = st.weak.upgrade() else {
+        return;
+    };
+    let g = win_geo(&win);
+    let ox = win.get_content_origin_x();
+    let oy = win.get_content_origin_y();
+    win.set_drag_active(true);
+    win.set_drag_hl_x(-ox);
+    win.set_drag_hl_y(-oy);
+    win.set_drag_hl_w(g.w);
+    win.set_drag_hl_h(g.h);
+}
+
+fn clear_highlight(core: &Rc<AppCore>, window_id: u64) {
+    if let Some(st) = core.window_states.borrow().get(&window_id).cloned() {
+        if let Some(w) = st.weak.upgrade() {
+            w.set_drag_active(false);
+        }
+    }
+}
+
+fn clear_all_highlights(core: &Rc<AppCore>) {
+    let ids: Vec<u64> = core.window_states.borrow().keys().copied().collect();
+    for id in ids {
+        clear_highlight(core, id);
+    }
+}
+
+thread_local! {
+    /// Window highlighted on the previous move event (raise-on-hover only
+    /// fires when the hover target changes).
+    static LAST_TARGET: std::cell::Cell<Option<u64>> = const { std::cell::Cell::new(None) };
+}
+
+/// Per-move cross-window handling. Returns true when the cursor is outside
+/// the source window (caller then skips the in-window pane highlight).
+pub(super) fn handle_global_tab_drag_move(
+    core: &Rc<AppCore>,
+    window_id: u64,
+    tab_id: &str,
+    x: f32,
+    y: f32,
+) -> bool {
+    let Some((gx, gy)) = global_point(core, window_id, x, y) else {
+        return false;
+    };
+    let over_src = {
+        let states = core.window_states.borrow();
+        states
+            .get(&window_id)
+            .and_then(|st| st.weak.upgrade())
+            .map(|w| contains(&win_geo(&w), gx, gy))
+            .unwrap_or(true)
+    };
+    if over_src {
+        LAST_TARGET.with(|t| t.set(None));
+        clear_all_highlights(core);
+        return false; // plain in-window drag: pane highlight logic applies
+    }
+
+    // Cross-window: nothing is moved until the drop. Light up (and raise)
+    // whichever window would receive the tab; a non-movable tab gets no
+    // merge preview.
+    let target = if movable(core, window_id, tab_id) {
+        window_over(core, window_id, gx, gy)
+    } else {
+        None
+    };
+    if let Some(t) = target {
+        highlight_window(core, t);
+        let changed = LAST_TARGET.with(|c| {
+            let prev = c.get();
+            c.set(Some(t));
+            prev != Some(t)
+        });
+        if changed {
+            // Bring the hovered window to the front so the user sees where
+            // the tab would land (Chrome-style drag).
+            if let Some(st) = core.window_states.borrow().get(&t).cloned() {
+                if let Some(w) = st.weak.upgrade() {
+                    w.window().with_winit_window(|ww| ww.focus_window());
+                }
+            }
+        }
+    } else {
+        LAST_TARGET.with(|t| t.set(None));
+        clear_all_highlights(core);
+    }
+    clear_highlight(core, window_id);
+    true
+}
+
+/// Drop handling. Returns true when the drop was consumed here (caller skips
+/// the in-window split logic).
+pub(super) fn handle_global_tab_drag_drop(
+    core: &Rc<AppCore>,
+    window_id: u64,
+    tab_id: &str,
+    x: f32,
+    y: f32,
+) -> bool {
+    LAST_TARGET.with(|t| t.set(None));
+    clear_all_highlights(core);
+
+    let Some((gx, gy)) = global_point(core, window_id, x, y) else {
+        tracing::warn!("tab-drop: global_point failed (window {window_id}, local {x},{y})");
+        return false;
+    };
+    let over_src = {
+        let states = core.window_states.borrow();
+        states
+            .get(&window_id)
+            .and_then(|st| st.weak.upgrade())
+            .map(|w| contains(&win_geo(&w), gx, gy))
+            .unwrap_or(true)
+    };
+    tracing::warn!(
+        "tab-drop: tab={tab_id} global=({gx},{gy}) over_src={over_src} movable={}",
+        movable(core, window_id, tab_id)
+    );
+
+    // A drop inside the source window always keeps the in-window pane
+    // split/move logic, even if another window's rect overlaps underneath
+    // (maximized or stacked windows share the same pixels).
+    if over_src {
+        return false;
+    }
+    // Merge into whichever other window received the drop.
+    if let Some(dst) = window_over(core, window_id, gx, gy) {
+        tracing::warn!("tab-drop: merge into window {dst}");
+        if movable(core, window_id, tab_id) {
+            let moved = move_tab_between_windows(core, window_id, dst, tab_id);
+            // A window emptied by the merge closes itself, exactly like the
+            // desktop-detach path below.
+            if moved && window_tab_count(core, window_id) == 0 {
+                close_window_now(core, window_id);
+            }
+        }
+        return true;
+    }
+    // Empty desktop: tear off into a new window at the drop point.
+    if !movable(core, window_id, tab_id) {
+        tracing::warn!("tab-drop: not movable, detach skipped");
+        return true;
+    }
+    let Some(src_win) = core
+        .window_states
+        .borrow()
+        .get(&window_id)
+        .and_then(|st| st.weak.upgrade())
+    else {
+        tracing::warn!("tab-drop: source window gone");
+        return true;
+    };
+    let at = clamped_detach_position(&src_win, gx, gy);
+    match open_window(core.clone(), false, Some(at)) {
+        Ok(new_id) => {
+            tracing::warn!("tab-drop: detach into new window {new_id}");
+            {
+                // The fresh window opens with a welcome tab; the detached
+                // session takes its place.
+                {
+                    let states = core.window_states.borrow();
+                    if let Some(st) = states.get(&new_id) {
+                        use slint::Model as _;
+                        if let Some(i) = st
+                            .tabs_model
+                            .iter()
+                            .position(|t| t.id.to_string() == "welcome")
+                        {
+                            st.tabs_model.remove(i);
+                        }
+                        st.layout.borrow_mut().remove_tab("welcome");
+                    }
+                }
+                let moved = move_tab_between_windows(core, window_id, new_id, tab_id);
+                let left = window_tab_count(core, window_id);
+                tracing::warn!("tab-drop: moved={moved} source tabs left={left}");
+                if moved && left == 0 {
+                    close_window_now(core, window_id);
+                }
+            }
+        }
+        Err(err) => {
+            tracing::warn!("tab-drop: open_window failed: {err:#}");
+        }
+    }
+    true
+}
+
+/// Drop point → top-left for the torn-off window, clamped so the window
+/// lands fully on the source window's monitor (a window created half
+/// off-screen renders with a missing strip on some systems).
+fn clamped_detach_position(src_win: &AppWindow, gx: f32, gy: f32) -> slint::PhysicalPosition {
+    let scale = src_win.window().scale_factor().max(0.01);
+    let src_geo = win_geo(src_win);
+    // Estimate the new window's size with the source window's size.
+    let (est_w, est_h) = (src_geo.w, src_geo.h);
+    let mut left = gx - 24.0;
+    let mut top = gy - 8.0;
+    let clamped = src_win.window().with_winit_window(|ww| {
+        let Some(monitor) = ww.current_monitor().or_else(|| ww.primary_monitor()) else {
+            return None;
+        };
+        let mscale = monitor.scale_factor().max(0.01);
+        let mx = monitor.position().x as f32 / mscale as f32;
+        let my = monitor.position().y as f32 / mscale as f32;
+        let mw = monitor.size().width as f32 / mscale as f32;
+        let mh = monitor.size().height as f32 / mscale as f32;
+        Some((mx, my, mw, mh))
+    });
+    if let Some(Some((mx, my, mw, mh))) = clamped {
+        left = left.clamp(mx + 8.0, (mx + mw - est_w - 8.0).max(mx + 8.0));
+        top = top.clamp(my + 8.0, (my + mh - est_h - 8.0).max(my + 8.0));
+    }
+    slint::PhysicalPosition::new((left * scale) as i32, (top * scale) as i32)
+}
+
+/// Terminal-tab count of a window (welcome tab excluded): a window torn empty
+/// by a tab detach should close even though its welcome tab remains.
+fn window_tab_count(core: &Rc<AppCore>, window_id: u64) -> usize {
+    use slint::Model as _;
+    core.window_states
+        .borrow()
+        .get(&window_id)
+        .map(|st| {
+            st.tabs_model
+                .iter()
+                .filter(|t| t.id.as_str() != "welcome")
+                .count()
+        })
+        .unwrap_or(0)
+}
+
+/// Move one connected tab (session, buffers, layout membership, UI rows)
+/// from window `src_id` to window `dst_id` and retarget its pumps.
+pub(super) fn move_tab_between_windows(
+    core: &Rc<AppCore>,
+    src_id: u64,
+    dst_id: u64,
+    tab_id: &str,
+) -> bool {
+    use slint::Model as _;
+    let (src, dst) = {
+        let states = core.window_states.borrow();
+        let Some(src) = states.get(&src_id).cloned() else {
+            return false;
+        };
+        let Some(dst) = states.get(&dst_id).cloned() else {
+            return false;
+        };
+        let Some(row) = find_tab_row(&src, tab_id) else {
+            return false;
+        };
+        if row.kind.to_string() != "terminal" || !src.handles.borrow().contains_key(tab_id) {
+            return false;
+        }
+        (src, dst)
+    };
+
+    // UI rows travel with the tab.
+    let Some(tab_i) = src
+        .tabs_model
+        .iter()
+        .position(|t| t.id.to_string() == tab_id)
+    else {
+        return false;
+    };
+    let tab_row = src.tabs_model.row_data(tab_i).unwrap();
+    src.tabs_model.remove(tab_i);
+    let term_row = {
+        let mut row = None;
+        let mut idx = None;
+        for (i, r) in src.terminals_model.iter().enumerate() {
+            if r.id.to_string() == tab_id {
+                row = Some(r);
+                idx = Some(i);
+                break;
+            }
+        }
+        if let Some(i) = idx {
+            src.terminals_model.remove(i);
+        }
+        row
+    };
+
+    // Layout membership.
+    src.layout.borrow_mut().remove_tab(tab_id);
+    dst.layout.borrow_mut().add_tab(tab_id.to_string());
+
+    // Session worker + per-tab state maps move wholesale.
+    if let Some(h) = src.handles.borrow_mut().remove(tab_id) {
+        dst.handles.borrow_mut().insert(tab_id.to_string(), h);
+    }
+    if let Ok(mut m) = src.bufs.lock() {
+        if let Some(v) = m.remove(tab_id) {
+            if let Ok(mut d) = dst.bufs.lock() {
+                d.insert(tab_id.to_string(), v);
+            }
+        }
+    }
+    if let Ok(mut m) = src.gates.lock() {
+        if let Some(v) = m.remove(tab_id) {
+            if let Ok(mut d) = dst.gates.lock() {
+                d.insert(tab_id.to_string(), v);
+            }
+        }
+    }
+    if let Ok(mut m) = src.statuses.lock() {
+        if let Some(v) = m.remove(tab_id) {
+            if let Ok(mut d) = dst.statuses.lock() {
+                d.insert(tab_id.to_string(), v);
+            }
+        }
+    }
+    if let Ok(mut m) = src.sftp_handles.lock() {
+        if let Some(v) = m.remove(tab_id) {
+            if let Ok(mut d) = dst.sftp_handles.lock() {
+                d.insert(tab_id.to_string(), v);
+            }
+        }
+    }
+    if let Ok(mut m) = src.sftp_last_cwd.lock() {
+        m.remove(tab_id);
+    }
+
+    // Retarget the running pumps at the new window.
+    if let Ok(routes) = core.tab_routes.lock() {
+        if let Some(route) = routes.get(tab_id) {
+            if let Ok(mut r) = route.lock() {
+                *r = TabRoute {
+                    window: dst.weak.clone(),
+                    window_id: dst_id,
+                    bufs: dst.bufs.clone(),
+                    gates: dst.gates.clone(),
+                    statuses: dst.statuses.clone(),
+                    local_snap: dst.local_snap.clone(),
+                    net_hist: dst.net_hist.clone(),
+                    sftp_handles: dst.sftp_handles.clone(),
+                    sftp_last_cwd: dst.sftp_last_cwd.clone(),
+                    follow_cd: dst.follow_cd.clone(),
+                };
+            }
+        }
+    }
+
+    // Land the rows in the target window, select the tab, and paint the
+    // terminal immediately instead of waiting for the next output burst.
+    dst.tabs_model.push(tab_row);
+    if let Some(row) = term_row {
+        dst.terminals_model.push(row);
+    }
+    if let Some(w) = dst.weak.upgrade() {
+        refresh_panes(
+            &w,
+            &dst.layout.borrow(),
+            dst.content_size.get(),
+            &dst.tabs_model,
+            &dst.panes_model,
+            &dst.splitters_model,
+        );
+        rebuild_tab_display(&w, &dst.bufs, tab_id);
+    }
+    if let Some(w) = src.weak.upgrade() {
+        refresh_panes(
+            &w,
+            &src.layout.borrow(),
+            src.content_size.get(),
+            &src.tabs_model,
+            &src.panes_model,
+            &src.splitters_model,
+        );
+    }
+    true
+}
+
+/// Programmatic close for a window emptied by a tab detach. Mirrors the
+/// confirmed-close path: persist layout, tear workers down, unregister,
+/// quit when it was the last window.
+pub(super) fn close_window_now(core: &Rc<AppCore>, window_id: u64) {
+    let st = core.window_states.borrow().get(&window_id).cloned();
+    let Some(st) = st else {
+        return;
+    };
+    if let Some(win) = st.weak.upgrade() {
+        save_layout(&win, &core.store);
+        teardown_window(
+            window_id,
+            &st.handles,
+            &st.sftp_handles,
+            &st.proc_weak,
+            &st.sys_weak,
+        );
+        let _ = win.hide();
+    }
+    if core.registry.unregister(window_id) {
+        let _ = slint::quit_event_loop();
+    }
+    forget_window_state(core, window_id);
+}
+
+/// Drop a closed window's shared state and any routes still pointing at it.
+pub(super) fn forget_window_state(core: &Rc<AppCore>, window_id: u64) {
+    core.window_states.borrow_mut().remove(&window_id);
+    if let Ok(mut routes) = core.tab_routes.lock() {
+        routes.retain(|_, route| {
+            route
+                .lock()
+                .map(|r| r.window_id != window_id)
+                .unwrap_or(false)
+        });
+    }
+}

--- a/src/app/tab_transfer.rs
+++ b/src/app/tab_transfer.rs
@@ -17,6 +17,23 @@
 
 use super::*;
 
+/// Move one tab's entry from the source window's per-tab map into the
+/// destination's during a detach/merge. Poisoned locks are skipped, matching
+/// every other lock site in this module.
+fn move_locked_entry<V>(
+    src: &Arc<Mutex<HashMap<String, V>>>,
+    dst: &Arc<Mutex<HashMap<String, V>>>,
+    tab_id: &str,
+) {
+    if let Ok(mut m) = src.lock() {
+        if let Some(v) = m.remove(tab_id) {
+            if let Ok(mut d) = dst.lock() {
+                d.insert(tab_id.to_string(), v);
+            }
+        }
+    }
+}
+
 /// One window's rectangle in global logical coordinates.
 struct WinGeo {
     x: f32,
@@ -393,37 +410,11 @@ pub(super) fn move_tab_between_windows(
     if let Some(h) = src.handles.borrow_mut().remove(tab_id) {
         dst.handles.borrow_mut().insert(tab_id.to_string(), h);
     }
-    if let Ok(mut m) = src.bufs.lock() {
-        if let Some(v) = m.remove(tab_id) {
-            if let Ok(mut d) = dst.bufs.lock() {
-                d.insert(tab_id.to_string(), v);
-            }
-        }
-    }
-    if let Ok(mut m) = src.gates.lock() {
-        if let Some(v) = m.remove(tab_id) {
-            if let Ok(mut d) = dst.gates.lock() {
-                d.insert(tab_id.to_string(), v);
-            }
-        }
-    }
-    if let Ok(mut m) = src.statuses.lock() {
-        if let Some(v) = m.remove(tab_id) {
-            if let Ok(mut d) = dst.statuses.lock() {
-                d.insert(tab_id.to_string(), v);
-            }
-        }
-    }
-    if let Ok(mut m) = src.sftp_handles.lock() {
-        if let Some(v) = m.remove(tab_id) {
-            if let Ok(mut d) = dst.sftp_handles.lock() {
-                d.insert(tab_id.to_string(), v);
-            }
-        }
-    }
-    if let Ok(mut m) = src.sftp_last_cwd.lock() {
-        m.remove(tab_id);
-    }
+    move_locked_entry(&src.bufs, &dst.bufs, tab_id);
+    move_locked_entry(&src.gates, &dst.gates, tab_id);
+    move_locked_entry(&src.statuses, &dst.statuses, tab_id);
+    move_locked_entry(&src.sftp_handles, &dst.sftp_handles, tab_id);
+    move_locked_entry(&src.sftp_last_cwd, &dst.sftp_last_cwd, tab_id);
 
     // Retarget the running pumps at the new window.
     if let Ok(routes) = core.tab_routes.lock() {
@@ -503,7 +494,13 @@ pub(super) fn close_window_now(core: &Rc<AppCore>, window_id: u64) {
 
 /// Drop a closed window's shared state and any routes still pointing at it.
 pub(super) fn forget_window_state(core: &Rc<AppCore>, window_id: u64) {
-    core.window_states.borrow_mut().remove(&window_id);
+    if let Some(st) = core.window_states.borrow_mut().remove(&window_id) {
+        // Deterministic teardown: stop this window's repeated timers and hide
+        // its monitor windows now rather than relying on the handle drops.
+        st.timers.borrow_mut().clear();
+        let _ = st.proc_win.hide();
+        let _ = st.sys_win.hide();
+    }
     if let Ok(mut routes) = core.tab_routes.lock() {
         routes.retain(|_, route| {
             route

--- a/src/app/tab_transfer.rs
+++ b/src/app/tab_transfer.rs
@@ -485,6 +485,7 @@ pub(super) fn close_window_now(core: &Rc<AppCore>, window_id: u64) {
     };
     if let Some(win) = st.weak.upgrade() {
         save_layout(&win, &core.store);
+        clear_zen_on_close(&win, &core.store);
         teardown_window(
             window_id,
             &st.handles,

--- a/src/app/window.rs
+++ b/src/app/window.rs
@@ -32,14 +32,12 @@ pub(super) fn apply_window_chrome(window: &slint::Window) {
         };
         let hwnd = h.hwnd.get();
 
+        // Pointer-width param instead of *const c_void: keeps this FFI
+        // declaration free of core::ffi (a module older rustc releases
+        // lack) while remaining ABI-identical on every supported target.
         #[link(name = "dwmapi")]
         extern "system" {
-            fn DwmSetWindowAttribute(
-                hwnd: isize,
-                attr: u32,
-                pv: *const core::ffi::c_void,
-                cb: u32,
-            ) -> i32;
+            fn DwmSetWindowAttribute(hwnd: isize, attr: u32, pv: isize, cb: u32) -> i32;
         }
         // DWMWA_WINDOW_CORNER_PREFERENCE = 33, DWMWCP_ROUND = 2 (Windows 11+).
         const DWMWA_WINDOW_CORNER_PREFERENCE: u32 = 33;
@@ -49,7 +47,7 @@ pub(super) fn apply_window_chrome(window: &slint::Window) {
             let corner_hr = DwmSetWindowAttribute(
                 hwnd,
                 DWMWA_WINDOW_CORNER_PREFERENCE,
-                (&pref as *const u32).cast(),
+                &pref as *const u32 as isize,
                 4,
             );
             tracing::debug!("window chrome applied: hwnd={hwnd:#x} corner_hr={corner_hr:#x}");

--- a/src/config/impls/config.rs
+++ b/src/config/impls/config.rs
@@ -314,6 +314,31 @@ pub(crate) fn is_reserved_session_group(name: &str) -> bool {
     name.eq_ignore_ascii_case("default") || name.eq_ignore_ascii_case("system")
 }
 
+/// Named display groups: explicit folders ∪ the groups sessions are filed
+/// under, with reserved names and ungrouped excluded, de-duplicated and
+/// sorted case-insensitively. The single source of truth for group display
+/// order — shared by the welcome list, drag-reorder target finding and the
+/// group dropdown; if these ever drift, drop targets and rendered rows
+/// disagree (#41).
+pub(crate) fn named_display_groups(explicit: &[String], sessions: &[Session]) -> Vec<String> {
+    let mut named: Vec<String> = explicit
+        .iter()
+        .filter(|group| !is_reserved_session_group(group.trim()))
+        .cloned()
+        .chain(
+            sessions
+                .iter()
+                .filter(|session| {
+                    !session.group.is_empty() && !is_reserved_session_group(session.group.trim())
+                })
+                .map(|session| session.group.clone()),
+        )
+        .collect();
+    named.sort_by_key(|group| group.to_lowercase());
+    named.dedup();
+    named
+}
+
 /// Repair configurations created before #316/#324, when the Move-to menu exposed
 /// the built-in `system` group as a destination for saved server sessions.
 fn normalize_reserved_session_groups(cfg: &mut ConfigFile) -> bool {
@@ -573,23 +598,10 @@ impl ConfigStore {
         {
             display.push("default".to_string());
         }
-        let mut named: Vec<String> = self
-            .cache
-            .groups
-            .iter()
-            .filter(|g| !is_reserved_session_group(g.trim()))
-            .cloned()
-            .chain(
-                self.cache
-                    .sessions
-                    .iter()
-                    .map(display_group)
-                    .filter(|g| g != "default"),
-            )
-            .collect();
-        named.sort_by_key(|g| g.to_lowercase());
-        named.dedup();
-        display.extend(named);
+        display.extend(named_display_groups(
+            &self.cache.groups,
+            &self.cache.sessions,
+        ));
 
         let Some(pos) = display.iter().position(|g| g == &group) else {
             return false;
@@ -632,12 +644,14 @@ impl ConfigStore {
 
         // A named source group that just lost its last member would vanish
         // from the list (changing the row count mid-drag, which drops the
-        // dragging row's pointer grab); keep it as an empty folder.
+        // dragging row's pointer grab); keep it as an empty folder. Register
+        // it in `groups` directly rather than via add_group: the folder was
+        // visibly expanded during the drag, and add_group would collapse it.
         if group != "default"
             && !self.cache.sessions.iter().any(|s| s.group == source_group)
             && !self.cache.groups.iter().any(|g| g == &source_group)
         {
-            self.add_group(source_group);
+            self.cache.groups.push(source_group);
         }
         true
     }

--- a/src/config/impls/config.rs
+++ b/src/config/impls/config.rs
@@ -513,27 +513,133 @@ impl ConfigStore {
         &self.cache.sessions
     }
 
-    /// Drag-to-reorder a saved session among its same-group siblings
-    /// (`dir < 0` = up). The stored Vec order is the display order, same
-    /// convention as quick commands. Returns whether the order changed.
+    /// Drag-to-reorder a saved session (`dir < 0` = up). The stored Vec order
+    /// is the display order within a group (same convention as quick commands).
+    /// Same-group hops swap neighbours; when there is no same-group neighbour
+    /// the hop crosses the group boundary instead: the session moves into the
+    /// nearest visible display group along `dir`, landing at that group's
+    /// boundary (first member moving down, last moving up). Returns whether
+    /// anything changed.
     pub fn reorder_session(&mut self, id: &str, dir: isize) -> bool {
-        let sessions = &mut self.cache.sessions;
-        let Some(idx) = sessions.iter().position(|s| s.id == id) else {
+        // Display group of a session: ungrouped (and reserved names) render
+        // under "default"; everything else under its own group. Mirrors
+        // build_session_rows in src/app/session_models.rs.
+        fn display_group(session: &Session) -> String {
+            if session.group.is_empty() || is_reserved_session_group(session.group.trim()) {
+                "default".to_string()
+            } else {
+                session.group.clone()
+            }
+        }
+
+        let Some(idx) = self.cache.sessions.iter().position(|s| s.id == id) else {
             return false;
         };
-        let group = sessions[idx].group.clone();
-        let target = if dir < 0 {
-            (0..idx).rev().find(|&i| sessions[i].group == group)
-        } else {
-            (idx + 1..sessions.len()).find(|&i| sessions[i].group == group)
-        };
-        match target {
-            Some(target) => {
-                sessions.swap(idx, target);
-                true
+        let group = display_group(&self.cache.sessions[idx]);
+
+        // Same-group neighbour in stored (= display) order → plain swap.
+        let same_group_target = {
+            let sessions = &self.cache.sessions;
+            if dir < 0 {
+                (0..idx)
+                    .rev()
+                    .find(|&i| display_group(&sessions[i]) == group)
+            } else {
+                (idx + 1..sessions.len()).find(|&i| display_group(&sessions[i]) == group)
             }
-            None => false,
+        };
+        if let Some(target) = same_group_target {
+            self.cache.sessions.swap(idx, target);
+            return true;
         }
+
+        // Cross-group hop. Display order: "default" first (only when ungrouped
+        // sessions exist), then named groups — explicit folders ∪ sessions'
+        // groups — alphabetically. Collapsed groups are skipped: their rows
+        // are hidden, so a card must never land inside one.
+        let Some(collapsed_groups) = self.cache.collapsed_session_groups.clone() else {
+            // Mirrors build_session_rows: no collapse list = everything
+            // collapsed, so no visible target group can exist.
+            return false;
+        };
+        let is_collapsed = |name: &str| collapsed_groups.iter().any(|g| g == name);
+
+        let mut display: Vec<String> = Vec::new();
+        if self
+            .cache
+            .sessions
+            .iter()
+            .any(|s| display_group(s) == "default")
+        {
+            display.push("default".to_string());
+        }
+        let mut named: Vec<String> = self
+            .cache
+            .groups
+            .iter()
+            .filter(|g| !is_reserved_session_group(g.trim()))
+            .cloned()
+            .chain(
+                self.cache
+                    .sessions
+                    .iter()
+                    .map(display_group)
+                    .filter(|g| g != "default"),
+            )
+            .collect();
+        named.sort_by_key(|g| g.to_lowercase());
+        named.dedup();
+        display.extend(named);
+
+        let Some(pos) = display.iter().position(|g| g == &group) else {
+            return false;
+        };
+        let target_group = if dir < 0 {
+            (0..pos).rev().find(|&i| !is_collapsed(&display[i]))
+        } else {
+            (pos + 1..display.len()).find(|&i| !is_collapsed(&display[i]))
+        }
+        .map(|i| display[i].clone());
+        let Some(target_group) = target_group else {
+            return false;
+        };
+
+        let source_group = self.cache.sessions[idx].group.clone();
+        let mut moved = self.cache.sessions.remove(idx);
+        moved.group = if target_group == "default" {
+            String::new()
+        } else {
+            target_group.clone()
+        };
+        let insert_at = {
+            let members: Vec<usize> = self
+                .cache
+                .sessions
+                .iter()
+                .enumerate()
+                .filter(|(_, s)| display_group(s) == target_group)
+                .map(|(i, _)| i)
+                .collect();
+            if members.is_empty() {
+                idx.min(self.cache.sessions.len())
+            } else if dir < 0 {
+                members[members.len() - 1] + 1
+            } else {
+                members[0]
+            }
+        };
+        self.cache.sessions.insert(insert_at, moved);
+
+        // A named source group that just lost its last member would vanish
+        // from the list (changing the row count mid-drag, which drops the
+        // dragging row's pointer grab); keep it as an empty folder.
+        if group != "default"
+            && !self.cache.sessions.iter().any(|s| s.group == source_group)
+            && !self.cache.groups.iter().any(|g| g == &source_group)
+        {
+            self.add_group(source_group);
+        }
+        true
     }
 
     pub fn upsert(&mut self, mut session: Session) {
@@ -1731,6 +1837,147 @@ mod tests {
             .unwrap()
             .iter()
             .any(|group| group == "production"));
+    }
+
+    /// Display order for these tests: default(d1, d2), alpha(a1), beta(b1, b2)
+    /// — "default" first, named groups alphabetically, stored Vec order
+    /// matching display order.
+    fn reorder_store() -> ConfigStore {
+        let mut store = temp_store();
+        store.cache.sessions = vec![
+            sample_session("d1"),
+            sample_session("d2"),
+            Session {
+                group: "alpha".into(),
+                ..sample_session("a1")
+            },
+            Session {
+                group: "beta".into(),
+                ..sample_session("b1")
+            },
+            Session {
+                group: "beta".into(),
+                ..sample_session("b2")
+            },
+        ];
+        // Empty collapse list = every group expanded.
+        store.cache.collapsed_session_groups = Some(Vec::new());
+        store
+    }
+
+    fn id_of(store: &ConfigStore, name: &str) -> String {
+        store
+            .sessions()
+            .iter()
+            .find(|s| s.name == name)
+            .expect("session present")
+            .id
+            .clone()
+    }
+
+    fn order_of(store: &ConfigStore) -> Vec<(String, String)> {
+        store
+            .sessions()
+            .iter()
+            .map(|s| (s.name.clone(), s.group.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn reorder_session_swaps_same_group_neighbours() {
+        let mut store = reorder_store();
+        assert!(store.reorder_session(&id_of(&store, "d1"), 1));
+        assert_eq!(
+            order_of(&store)[..2],
+            [("d2".into(), "".into()), ("d1".into(), "".into())]
+        );
+    }
+
+    #[test]
+    fn reorder_session_hops_down_into_next_group_at_its_top() {
+        let mut store = reorder_store();
+        assert!(store.reorder_session(&id_of(&store, "d2"), 1));
+        assert_eq!(
+            order_of(&store)[1..4],
+            [
+                ("d2".into(), "alpha".into()),
+                ("a1".into(), "alpha".into()),
+                ("b1".into(), "beta".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn reorder_session_hops_up_into_previous_group_at_its_bottom() {
+        let mut store = reorder_store();
+        assert!(store.reorder_session(&id_of(&store, "a1"), -1));
+        assert_eq!(
+            order_of(&store)[..3],
+            [
+                ("d1".into(), "".into()),
+                ("d2".into(), "".into()),
+                ("a1".into(), "".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn reorder_session_skips_collapsed_groups() {
+        let mut store = reorder_store();
+        store.set_session_group_collapsed("alpha", true);
+        assert!(store.reorder_session(&id_of(&store, "d2"), 1));
+        assert_eq!(
+            order_of(&store)[1..4],
+            [
+                ("a1".into(), "alpha".into()),
+                ("d2".into(), "beta".into()),
+                ("b1".into(), "beta".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn reorder_session_lands_in_empty_explicit_folder() {
+        let mut store = reorder_store();
+        store.cache.groups.push("gamma".into());
+        assert!(store.reorder_session(&id_of(&store, "b2"), 1));
+        let last = store.sessions().iter().find(|s| s.name == "b2").unwrap();
+        assert_eq!(last.group, "gamma");
+    }
+
+    #[test]
+    fn reorder_session_keeps_emptied_implicit_group_as_folder() {
+        let mut store = reorder_store();
+        assert!(store.reorder_session(&id_of(&store, "a1"), 1));
+        assert_eq!(
+            store
+                .sessions()
+                .iter()
+                .find(|s| s.name == "a1")
+                .unwrap()
+                .group,
+            "beta"
+        );
+        assert!(store.groups().iter().any(|g| g == "alpha"));
+    }
+
+    #[test]
+    fn reorder_session_no_op_at_list_edges() {
+        let mut store = reorder_store();
+        assert!(!store.reorder_session(&id_of(&store, "d1"), -1));
+        assert!(!store.reorder_session(&id_of(&store, "b2"), 1));
+        assert_eq!(order_of(&store).len(), 5);
+    }
+
+    #[test]
+    fn reorder_session_cross_group_needs_a_collapse_list() {
+        let mut store = reorder_store();
+        store.cache.collapsed_session_groups = None;
+        // Same-group hops still work ...
+        assert!(store.reorder_session(&id_of(&store, "d1"), 1));
+        // ... but crossing a boundary does not: no list means every group
+        // renders collapsed (mirrors build_session_rows).
+        assert!(!store.reorder_session(&id_of(&store, "b2"), 1));
     }
 
     #[test]

--- a/src/config/impls/config.rs
+++ b/src/config/impls/config.rs
@@ -513,9 +513,27 @@ impl ConfigStore {
         &self.cache.sessions
     }
 
-    #[allow(dead_code)] // reserved for an upcoming reorder/drag-drop feature
-    pub fn sessions_mut(&mut self) -> &mut Vec<Session> {
-        &mut self.cache.sessions
+    /// Drag-to-reorder a saved session among its same-group siblings
+    /// (`dir < 0` = up). The stored Vec order is the display order, same
+    /// convention as quick commands. Returns whether the order changed.
+    pub fn reorder_session(&mut self, id: &str, dir: isize) -> bool {
+        let sessions = &mut self.cache.sessions;
+        let Some(idx) = sessions.iter().position(|s| s.id == id) else {
+            return false;
+        };
+        let group = sessions[idx].group.clone();
+        let target = if dir < 0 {
+            (0..idx).rev().find(|&i| sessions[i].group == group)
+        } else {
+            (idx + 1..sessions.len()).find(|&i| sessions[i].group == group)
+        };
+        match target {
+            Some(target) => {
+                sessions.swap(idx, target);
+                true
+            }
+            None => false,
+        }
     }
 
     pub fn upsert(&mut self, mut session: Session) {
@@ -2087,5 +2105,34 @@ mod tests {
         assert!(!store.paste_confirm_enabled());
         assert!(!store.extra_paste_shortcuts_enabled());
         assert!(store.zen_mode());
+    }
+
+    #[test]
+    fn reorder_session_swaps_same_group_siblings_only() {
+        let mut store = temp_store();
+        let mk = |id: &str, group: &str| Session {
+            id: id.into(),
+            name: id.into(),
+            group: group.into(),
+            ..Session::new_empty()
+        };
+        store.cache.sessions = vec![mk("a", ""), mk("x", "ops"), mk("b", ""), mk("c", "")];
+
+        // Moving "c" up swaps it with the nearest ungrouped sibling ("b"),
+        // leaving the grouped session in between untouched.
+        assert!(store.reorder_session("c", -1));
+        assert_eq!(
+            store
+                .sessions()
+                .iter()
+                .map(|s| s.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["a", "x", "c", "b"]
+        );
+        // "a" is already the first ungrouped session; "x" is alone in its
+        // group; unknown ids are no-ops.
+        assert!(!store.reorder_session("a", -1));
+        assert!(!store.reorder_session("x", 1));
+        assert!(!store.reorder_session("nope", 1));
     }
 }

--- a/src/config/impls/config.rs
+++ b/src/config/impls/config.rs
@@ -810,6 +810,15 @@ impl ConfigStore {
         self.cache.sftp_no_follow_cd = !follow;
     }
 
+    /// Whether the quick-command bar under the terminal is hidden.
+    pub fn cmd_bar_hidden(&self) -> bool {
+        self.cache.hide_cmd_bar
+    }
+
+    pub fn set_cmd_bar_hidden(&mut self, hidden: bool) {
+        self.cache.hide_cmd_bar = hidden;
+    }
+
     /// Saved quick commands (#55).
     pub fn quick_commands(&self) -> &[QuickCommand] {
         &self.cache.quick_commands

--- a/src/config/struct/config_file.rs
+++ b/src/config/struct/config_file.rs
@@ -148,6 +148,9 @@ pub struct ConfigFile {
     /// preset download dir. Defaults to false (#87).
     #[serde(default)]
     pub download_always_ask: bool,
+    /// Hide the quick-command bar under the terminal. Defaults to false.
+    #[serde(default)]
+    pub hide_cmd_bar: bool,
     /// Stored inverted so multiline paste confirmation remains enabled for
     /// existing configurations unless the user explicitly disables it (#300).
     #[serde(default)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,7 +85,8 @@ fn main() -> anyhow::Result<()> {
             // forwarded to the PTY via the `edited` callback.  The vim/Shift side-effects
             // are handled instead by the C0-marker + 3-layer Backspace filters in
             // `app::on_send_key`, so we no longer need (and must not use) ImmDisableIME.
-            app::run()
+            let intent = app::launch::parse(&args);
+            app::run(intent)
         }
         StartMode::Version => unreachable!("handled above"),
     }

--- a/src/session/struct/prompts.rs
+++ b/src/session/struct/prompts.rs
@@ -16,6 +16,11 @@ use crate::ui::AppWindow;
 /// Shared dependencies for starting or reconnecting a session tab.
 pub(crate) struct ConnectCtx {
     pub(crate) weak: slint::Weak<AppWindow>,
+    /// Registry id of the window this session belongs to, so connect-time
+    /// prompts (host key / credentials / MFA) open their dialog in the
+    /// owning window rather than whichever window happens to resolve the
+    /// global queue front first (#multi-window).
+    pub(crate) window_id: u64,
     pub(crate) runtime: Arc<Runtime>,
     pub(crate) handles: Rc<RefCell<HashMap<String, SessionHandle>>>,
     pub(crate) sftp_handles: SftpHandles,
@@ -28,9 +33,16 @@ pub(crate) struct ConnectCtx {
     pub(crate) last_term_size: Arc<Mutex<(u32, u32)>>,
     pub(crate) sftp_follow_cd: Arc<AtomicBool>,
     pub(crate) store: Rc<RefCell<ConfigStore>>,
+    /// Process-wide tab delivery routes. Starting a session registers its
+    /// route here so a later detach/merge can retarget the running pumps
+    /// at another window without respawning them (#tab-detach).
+    pub(crate) tab_routes: crate::app::core::TabRoutes,
 }
 
 pub(crate) struct PendingHostKey {
+    /// Registry id of the window that owns this prompt's session(s); the
+    /// dialog is shown there and the entry is aborted if that window closes.
+    pub(crate) window_id: u64,
     pub(crate) host: String,
     pub(crate) port: u16,
     pub(crate) changed: bool,
@@ -42,6 +54,8 @@ pub(crate) struct PendingHostKey {
 }
 
 pub(crate) struct PendingCred {
+    /// Owning window's registry id (see `PendingHostKey::window_id`).
+    pub(crate) window_id: u64,
     pub(crate) session_id: String,
     pub(crate) host: String,
     pub(crate) user: String,
@@ -51,6 +65,8 @@ pub(crate) struct PendingCred {
 }
 
 pub(crate) struct PendingMfa {
+    /// Owning window's registry id (see `PendingHostKey::window_id`).
+    pub(crate) window_id: u64,
     pub(crate) session_id: String,
     pub(crate) host: String,
     pub(crate) prompt: String,

--- a/src/terminal/impls/serial.rs
+++ b/src/terminal/impls/serial.rs
@@ -99,24 +99,34 @@ async fn run_serial(
         session.baud_rate
     )));
 
-    // Open on a blocking thread — serialport::open() can stall on a busy device.
+    // Open on a blocking thread — serialport::open() can stall on a busy
+    // device. The timeout bounds the stall: sans it, Close never reaches the
+    // command pump (open is awaited before the pump starts) and the task
+    // would wedge runtime shutdown forever.
     let open_name = port_name.clone();
     let baud = session.baud_rate;
     let data_bits = parse_data_bits(session.data_bits);
     let stop_bits = parse_stop_bits(session.stop_bits);
     let parity = parse_parity(&session.parity);
     let flow = parse_flow(&session.flow_control);
-    let port = tokio::task::spawn_blocking(move || {
-        serialport::new(&open_name, baud)
-            .data_bits(data_bits)
-            .stop_bits(stop_bits)
-            .parity(parity)
-            .flow_control(flow)
-            // Short read timeout so the reader thread can poll the stop flag.
-            .timeout(Duration::from_millis(50))
-            .open()
-    })
+    let port = tokio::time::timeout(
+        Duration::from_secs(15),
+        tokio::task::spawn_blocking(move || {
+            serialport::new(&open_name, baud)
+                .data_bits(data_bits)
+                .stop_bits(stop_bits)
+                .parity(parity)
+                .flow_control(flow)
+                // Short read timeout so the reader thread can poll the stop flag.
+                .timeout(Duration::from_millis(50))
+                .open()
+        }),
+    )
     .await
+    .context(t(
+        "打开串口超时",
+        "timed out opening the serial port",
+    ))?
     .context("serial open task panicked")?
     .with_context(|| {
         format!(
@@ -179,17 +189,38 @@ async fn run_serial(
                 // Never log keystroke bytes — they can be passwords (#15).
                 tracing::debug!("serial write len={} bytes", bytes.len());
                 let w = writer.clone();
-                let res = tokio::task::spawn_blocking(move || {
-                    let mut guard = w.lock().unwrap();
-                    guard.write_all(&bytes).and_then(|_| guard.flush())
-                })
+                // Hardware flow control with a stopped peer wedges write_all
+                // forever; the timeout keeps Close serviceable so the task
+                // can still finish on shutdown.
+                let res = tokio::time::timeout(
+                    Duration::from_secs(30),
+                    tokio::task::spawn_blocking(move || {
+                        let mut guard = w.lock().unwrap();
+                        guard.write_all(&bytes).and_then(|_| guard.flush())
+                    }),
+                )
                 .await;
-                if let Ok(Err(e)) = res {
-                    let _ = events.send(SessionEvent::Closed(format!(
-                        "{}: {e}",
-                        t("串口写入失败", "serial write failed")
-                    )));
-                    break;
+                match res {
+                    Ok(Ok(Ok(()))) => {}
+                    Ok(Ok(Err(e))) => {
+                        let _ = events.send(SessionEvent::Closed(format!(
+                            "{}: {e}",
+                            t("串口写入失败", "serial write failed")
+                        )));
+                        break;
+                    }
+                    Ok(Err(_)) => {
+                        let _ = events.send(SessionEvent::Closed(
+                            t("串口写入线程异常", "serial write thread panicked").into(),
+                        ));
+                        break;
+                    }
+                    Err(_) => {
+                        let _ = events.send(SessionEvent::Closed(
+                            t("串口写入超时", "serial write timed out").into(),
+                        ));
+                        break;
+                    }
                 }
             }
             // A serial line has no window size; nothing to propagate.

--- a/tests/app/window_management/launch_intent.rs
+++ b/tests/app/window_management/launch_intent.rs
@@ -1,0 +1,19 @@
+use crate::app::launch::parse;
+
+#[test]
+fn no_flags_means_plain_launch() {
+    let intent = parse(&["meatshell".to_string()]);
+    assert!(!intent.new_window);
+}
+
+#[test]
+fn new_window_flag_is_recognised() {
+    let intent = parse(&["meatshell".to_string(), "--new-window".to_string()]);
+    assert!(intent.new_window);
+}
+
+#[test]
+fn unrelated_args_do_not_trigger_new_window() {
+    let intent = parse(&["meatshell".to_string(), "--version".to_string()]);
+    assert!(!intent.new_window);
+}

--- a/tests/app/window_management/registry.rs
+++ b/tests/app/window_management/registry.rs
@@ -1,0 +1,64 @@
+use crate::app::core::WindowRegistry;
+use std::cell::Cell;
+use std::rc::Rc;
+
+#[test]
+fn register_unregister_tracks_count_and_empty_flag() {
+    let reg: WindowRegistry<u32> = WindowRegistry::default();
+    let a = reg.register(1u32);
+    let b = reg.register(2u32);
+    assert_eq!(reg.count(), 2);
+    assert!(!reg.is_empty());
+
+    assert!(!reg.unregister(a), "still one window left");
+    assert_eq!(reg.count(), 1);
+    assert!(reg.unregister(b), "registry now empty");
+    assert!(reg.is_empty());
+}
+
+#[test]
+fn unregister_of_unknown_id_is_harmless() {
+    let reg: WindowRegistry<u32> = WindowRegistry::default();
+    let _ = reg.register(7u32);
+    assert!(!reg.unregister(u64::MAX));
+    assert_eq!(reg.count(), 1);
+}
+
+#[test]
+fn for_each_visits_live_entries() {
+    let reg: WindowRegistry<u32> = WindowRegistry::default();
+    let _a = reg.register(10u32);
+    let b = reg.register(20u32);
+    reg.unregister(b);
+    let seen = Rc::new(Cell::new(0u32));
+    let seen2 = seen.clone();
+    reg.for_each(move |h| seen2.set(seen2.get() + *h));
+    assert_eq!(seen.get(), 10);
+}
+
+#[test]
+fn config_listeners_fire_on_broadcast() {
+    let reg: WindowRegistry<u32> = WindowRegistry::default();
+    let id = reg.register(1u32);
+    let hits = Rc::new(Cell::new(0));
+    let h1 = hits.clone();
+    reg.add_config_listener(id, Rc::new(move || h1.set(h1.get() + 1)));
+    reg.broadcast_config_changed();
+    reg.broadcast_config_changed();
+    assert_eq!(hits.get(), 2);
+}
+
+#[test]
+fn config_listener_stops_firing_after_window_unregisters() {
+    let reg: WindowRegistry<u32> = WindowRegistry::default();
+    let id = reg.register(1u32);
+    let hits = Rc::new(Cell::new(0));
+    let h1 = hits.clone();
+    reg.add_config_listener(id, Rc::new(move || h1.set(h1.get() + 1)));
+    reg.broadcast_config_changed();
+    assert_eq!(hits.get(), 1);
+
+    reg.unregister(id);
+    reg.broadcast_config_changed();
+    assert_eq!(hits.get(), 1, "closed window's listener must be pruned");
+}

--- a/tests/app/window_management/single_instance.rs
+++ b/tests/app/window_management/single_instance.rs
@@ -1,0 +1,107 @@
+use crate::app::single_instance::{acquire, Instance};
+use std::sync::mpsc;
+
+/// Per-pid dir, per-test endpoint filename. Cargo runs tests in the same
+/// process (separate threads), so a shared endpoint would let one test's
+/// primary answer another test's acquire; the distinct names keep each test
+/// deterministic. The pre-remove also guards against a stale file from an
+/// earlier run under a reused pid. This is a unix-socket path on unix and a
+/// TCP port-file path on Windows (see `single_instance` module docs).
+fn temp_socket_path(test_name: &str) -> std::path::PathBuf {
+    let n = std::process::id();
+    let dir = std::env::temp_dir().join(format!("meatshell-si-{n}"));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(format!("ipc-{test_name}.sock"));
+    let _ = std::fs::remove_file(&path);
+    path
+}
+
+#[test]
+fn first_acquire_becomes_primary_and_second_forwards() {
+    let path = temp_socket_path("first_acquire_becomes_primary_and_second_forwards");
+    let (tx, rx) = mpsc::channel();
+
+    // Plain launch: becomes the primary.
+    let instance = acquire(&path, false).expect("primary acquire");
+    let Instance::Primary { listen } = instance else {
+        panic!("first acquire must be primary");
+    };
+    std::thread::spawn(move || {
+        listen.spawn(move |msg| {
+            let _ = tx.send(msg);
+        });
+    });
+
+    // Give the accept loop a moment to start.
+    std::thread::sleep(std::time::Duration::from_millis(100));
+
+    // `--new-window` launch: forwards to the primary.
+    match acquire(&path, true).expect("forward acquire") {
+        Instance::Forwarded => {}
+        Instance::Primary { .. } => panic!("second acquire must forward"),
+    }
+
+    let msg = rx
+        .recv_timeout(std::time::Duration::from_secs(5))
+        .expect("primary should receive the message");
+    assert_eq!(msg, "new-window");
+}
+
+#[test]
+fn forwarding_without_primary_fails() {
+    let path = temp_socket_path("forwarding_without_primary_fails");
+    // No primary bound: acquire must become primary, not Forwarded.
+    match acquire(&path, true).expect("acquire") {
+        Instance::Primary { .. } => {}
+        Instance::Forwarded => panic!("no primary to forward to"),
+    }
+}
+
+/// A previous primary that exited without unlinking leaves a file behind.
+/// `UnixListener::bind` fails with EADDRINUSE for any existing file, so
+/// acquire must detect staleness via the failed connect probe, remove the
+/// file and take over the endpoint instead of erroring out.
+#[test]
+fn stale_socket_file_is_recovered() {
+    let path = temp_socket_path("stale_socket_file_is_recovered");
+    // A file with no listener behind it: stale endpoint.
+    std::fs::write(&path, b"stale").unwrap();
+    match acquire(&path, true).expect("acquire over a stale socket file") {
+        Instance::Primary { .. } => {}
+        Instance::Forwarded => panic!("nothing is listening behind a stale file"),
+    }
+}
+
+/// A plain second launch must not forward "new-window" to the primary
+/// (run() only honors `Forwarded` for `--new-window`, so forwarding would
+/// spawn a bonus window in the first instance while also starting a second
+/// one). acquire(forward=false) must therefore report the live primary as
+/// an error without sending anything.
+#[test]
+fn plain_acquire_does_not_forward_to_primary() {
+    let path = temp_socket_path("plain_acquire_does_not_forward_to_primary");
+    let (tx, rx) = mpsc::channel();
+
+    let instance = acquire(&path, false).expect("primary acquire");
+    let Instance::Primary { listen } = instance else {
+        panic!("first acquire must be primary");
+    };
+    std::thread::spawn(move || {
+        listen.spawn(move |msg| {
+            let _ = tx.send(msg);
+        });
+    });
+
+    // Give the accept loop a moment to start.
+    std::thread::sleep(std::time::Duration::from_millis(100));
+
+    // Bind fails, the probe finds a live primary, no message is sent.
+    acquire(&path, false).expect_err("plain acquire must not forward");
+
+    // The primary must not have received anything from the probe.
+    assert!(
+        rx.recv_timeout(std::time::Duration::from_millis(300))
+            .is_err(),
+        "plain launch must not deliver a message to the primary"
+    );
+}

--- a/ui/app.slint
+++ b/ui/app.slint
@@ -693,6 +693,11 @@ export component AppWindow inherits Window {
 
     // --- Session list ------------------------------------------------------
     in property <[SessionInfo]> sessions;
+    // Bumped by Rust whenever the sessions model is rebuilt wholesale
+    // (set_vec). A rebuild destroys the dragging row's pointer grab, so
+    // Welcome watches this to clear its shared drag state instead of
+    // leaving a card lifted forever.
+    in property <int> sessions-revision: 0;
     in-out property <string> host-search-query;
     callback host-search-changed(string);
 
@@ -765,7 +770,7 @@ export component AppWindow inherits Window {
     callback edit-session(string /* session-id */);
     callback duplicate-session(string /* session-id */);
     callback move-session(string /* session-id */, string /* group */);
-    callback reorder-session(string /* session-id */, int /* dir: -1 up, 1 down */);
+    callback reorder-session(string /* session-id */, int /* dir: -1 up, 1 down */) -> bool;
     callback reorder-session-end();
     callback toggle-group(string /* group */);
     callback remove-session(string /* session-id */);
@@ -1238,6 +1243,7 @@ export component AppWindow inherits Window {
                     sessions: root.sessions;
                     import-hint: root.ssh-import-hint;
                     search-query <=> root.host-search-query;
+                    sessions-revision: root.sessions-revision;
                     search-changed(query) => { root.host-search-changed(query); }
                     collapse => {
                         root.welcome-collapsed = true;
@@ -1268,7 +1274,7 @@ export component AppWindow inherits Window {
                     edit-session(id) => { root.edit-session(id); }
                     duplicate-session(id) => { root.duplicate-session(id); }
                     move-session(id, group) => { root.move-session(id, group); }
-                    reorder-session(id, dir) => { root.reorder-session(id, dir); }
+                    reorder-session(id, dir) => { return root.reorder-session(id, dir); }
                     reorder-end => { root.reorder-session-end(); }
                     toggle-group(group) => { root.toggle-group(group); }
                     new-group => {
@@ -1634,6 +1640,7 @@ export component AppWindow inherits Window {
                         sessions: root.sessions;
                         import-hint: root.ssh-import-hint;
                         search-query <=> root.host-search-query;
+                        sessions-revision: root.sessions-revision;
                         search-changed(query) => { root.host-search-changed(query); }
                         new-session => { root.new-session-clicked(); }
                         import-ssh-config => { root.import-ssh-config(); }
@@ -1641,7 +1648,7 @@ export component AppWindow inherits Window {
                         edit-session(id) => { root.edit-session(id); }
                         duplicate-session(id) => { root.duplicate-session(id); }
                         move-session(id, group) => { root.move-session(id, group); }
-                        reorder-session(id, dir) => { root.reorder-session(id, dir); }
+                        reorder-session(id, dir) => { return root.reorder-session(id, dir); }
                         reorder-end => { root.reorder-session-end(); }
                         toggle-group(group) => { root.toggle-group(group); }
                         new-group => {
@@ -3027,6 +3034,8 @@ export component AppWindow inherits Window {
                     text <=> root.tab-rename-value;
                     font-family: Theme.ui-font-family; // CJK-capable (#54)
                     placeholder-text: @tr("Session name");
+                    // Focus the text the moment the dialog opens.
+                    init => { tr-input.focus(); }
                     accepted => {
                         root.rename-tab(root.tab-rename-id, root.tab-rename-value);
                     }

--- a/ui/app.slint
+++ b/ui/app.slint
@@ -500,6 +500,7 @@ export component AppWindow inherits Window {
     }
     callback set-term-font(string);                // apply + persist font family
     callback set-term-font-size(int);              // apply + persist font size (px)
+    callback zoom-term-font(int);                  // Ctrl+=/-/0 zoom: +1 / -1 / reset
     callback set-terminal-line-spacing(float);
     callback set-term-font-bold(bool);             // apply + persist bold terminal text
     callback set-term-cursor-style(string);        // apply + persist cursor shape (#275)
@@ -771,6 +772,7 @@ export component AppWindow inherits Window {
     callback tab-selected(string);
     callback tab-closed(string);
     callback new-tab-clicked();
+    callback new-window-clicked();   // open another application window (#multi-window)
     callback tab-reorder(int /* from-index */, int /* dir: -1 left / +1 right */);
     // Per-pane tab actions (v0.5): the int is the pane (leaf) id.
     callback pane-tab-selected(int /* pane-id */, string /* tab-id */);
@@ -801,6 +803,10 @@ export component AppWindow inherits Window {
     // Reports the pane-area size to Rust so it can flatten the split tree into
     // absolute pane / splitter rects. Fired whenever the content area resizes.
     callback content-resized(length /* w */, length /* h */);
+    // pane-area origin in window coordinates; tab drag-out converts
+    // drop points to global screen coordinates with this (#tab-detach).
+    out property <length> content-origin-x: pane-area.absolute-position.x;
+    out property <length> content-origin-y: pane-area.absolute-position.y;
     // Asks Rust to recompute the sidebar (status + resources) for whatever tab
     // is now active.  Fired on every active-tab change, UI- or code-driven.
     callback refresh-sidebar();
@@ -890,627 +896,298 @@ export component AppWindow inherits Window {
         image-fit: cover;
     }
 
-    VerticalLayout {
-        spacing: 0;
-
-        // macOS immersive bar: a strip under the native traffic-light buttons.
-        // Frosted like the other panels (bg-panel) so it matches in both themes —
-        // a plain transparent strip would show the raw wallpaper here and look dark
-        // in light mode. Left as a plain reserve (no TouchArea) so macOS's own title
-        // bar keeps handling the window drag in this region.
-        if root.titlebar-inset > 0px : Rectangle {
-            height: root.titlebar-inset;
-            background: Theme.bg-panel;
-        }
-
-        // Immersive custom title bar (#119) — only on frameless platforms
-        // (Windows/Linux). App icon + name on the left, a draggable middle
-        // (move window / double-click to maximize), then the toolbar icons and
-        // window controls on the right. macOS keeps its native title bar and
-        // shows the toolbar icons via the overlay further below.
-        if root.custom-titlebar : Rectangle {
-            height: 38px;
-            background: Theme.bg-panel;
-            tb-drag := TouchArea {
-                pointer-event(e) => {
-                    if (e.kind == PointerEventKind.down && e.button == PointerEventButton.left) {
-                        root.win-drag();
-                    }
-                }
-                double-clicked => { root.win-maximize-toggle(); }
-            }
-            HorizontalLayout {
-                padding-left: 12px;
-                spacing: 8px;
-                // Vertical-centering wrappers so the icon and name line up (#119).
-                VerticalLayout {
-                    alignment: center;
-                    Image {
-                        source: @image-url("../assets/icon.png");
-                        width: 18px;
-                        height: 18px;
-                    }
-                }
-                VerticalLayout {
-                    alignment: center;
-                    Text {
-                        text: "meatshell";
-                        color: Theme.text-secondary;
-                        font-size: Theme.fs-sm;
-                    }
-                }
-                // Draggable spacer (no TouchArea → clicks fall to tb-drag).
-                Rectangle { horizontal-stretch: 1; }
-                // Window controls only — the app toolbar icons live in the tab
-                // row below, not here (#119).
-                WinBtn { icon: "\u{E15B}"; clicked => { root.win-minimize(); } }
-                WinBtn {
-                    icon: root.window-maximized ? "\u{E3E0}" : "\u{E835}";
-                    clicked => { root.win-maximize-toggle(); }
-                }
-                WinBtn { icon: "\u{E5CD}"; danger: true; clicked => { root.win-close(); } }
+    // Window-wide shortcut interceptor (#multi-window). Slint delivers a key
+    // to the focused item first and only bubbles it up the ancestor chain when
+    // it is rejected there; a Window itself cannot bind key-pressed. This
+    // passive FocusScope therefore wraps the whole main content and catches any
+    // shortcut no descendant consumed — so new-window works on the welcome page
+    // (where no TerminalView exists yet) and whenever focus is on a non-terminal
+    // widget. It never takes focus itself (focus-on-click / focus-on-tab-
+    // navigation are off), so it does not disturb the terminal IME anchor or any
+    // other widget. A focused terminal accepts ⌘⇧N / Ctrl+Shift+N on its own
+    // (terminal_view.slint), which stops propagation, so the two never
+    // double-fire.
+    FocusScope {
+        focus-on-click: false;
+        focus-on-tab-navigation: false;
+        key-pressed(e) => {
+            // New window: ⌘⇧N / Ctrl+Shift+N (#multi-window). On macOS Slint
+            // maps `control` to Cmd (#158), so this single condition yields ⌘⇧N
+            // there and Ctrl+Shift+N elsewhere — identical to the TerminalView
+            // branch. \u{000e} is the Ctrl-N control char some backends send.
+            if (e.modifiers.control && e.modifiers.shift
+                    && (e.text == "n" || e.text == "N"
+                        || e.text == "\u{000e}")) {
+                root.new-window-clicked();
+                accept
+            // Font zoom: Ctrl+= / Ctrl+- / Ctrl+0 (⌘ on macOS). Same keys as
+            // the focused-terminal branch (terminal_view.slint); a focused
+            // terminal consumes them itself, so no double-fire.
+            } else if (e.modifiers.control && (e.text == "=" || e.text == "+")) {
+                root.zoom-term-font(1);
+                accept
+            } else if (e.modifiers.control && e.text == "-") {
+                root.zoom-term-font(-1);
+                accept
+            } else if (e.modifiers.control && e.text == "0") {
+                root.zoom-term-font(0);
+                accept
+            } else {
+                reject
             }
         }
 
-        // Dock area — fills below the title bar. The resource sidebar and the
-        // central content are positioned by absolute geometry computed from
-        // `sidebar-dock`, so the sidebar can sit on any window edge (#dock).
-        dock-area := Rectangle {
-        vertical-stretch: 1;
-        // Left-edge layout (welcome-as-sidebar mode): a thin always-on icon strip
-        // (IDEA-style) + the welcome/session sidebar (0 when collapsed). The rest
-        // (resource panel + central terminal, which never collapses) sits to their
-        // right in `rest`.
-        // Collapsed-only (M5): the icon strip shows only while collapsed; the
-        // panel itself (welcome-w) only while expanded — one or the other.
-        property <bool> sidebar-strip-outside:
-            !root.zen-mode && root.welcome-as-sidebar && !root.welcome-collapsed
-            && root.sidebar-collapsed && root.sidebar-dock == root.welcome-sidebar-dock;
-        property <length> sidebar-outside-strip: dock-area.sidebar-strip-outside ? 36px : 0px;
-        property <length> welcome-strip: (!root.zen-mode && root.welcome-as-sidebar && root.welcome-collapsed) ? 36px : 0px;
-        property <length> welcome-size: (!root.zen-mode && root.welcome-as-sidebar && !root.welcome-collapsed) ? root.welcome-sidebar-width : 0px;
-        property <length> welcome-taken: welcome-strip + welcome-size + sidebar-outside-strip;
-        property <bool> welcome-horizontal: root.welcome-sidebar-horizontal;
-        property <bool> welcome-sidebar-dragging;
-        property <bool> combine-collapsed-tools:
-            root.welcome-as-sidebar && root.welcome-collapsed
-            && root.sidebar-collapsed && root.sidebar-dock == root.welcome-sidebar-dock;
-        // A collapsed quick-command sidebar joins an existing collapsed strip
-        // on the same edge. Only when no such strip exists does it reserve its
-        // own outermost 36px slot (#215).
-        property <bool> quick-merge-welcome:
-            root.quick-panel-open && root.quick-panel-collapsed
-            && root.welcome-as-sidebar && root.welcome-collapsed
-            && root.quick-panel-dock == root.welcome-sidebar-dock;
-        property <bool> quick-merge-sidebar:
-            root.quick-panel-open && root.quick-panel-collapsed
-            && !dock-area.quick-merge-welcome && root.sidebar-collapsed
-            && root.quick-panel-dock == root.sidebar-dock;
-        property <length> quick-outer-strip:
-            !root.zen-mode && root.quick-panel-open && root.quick-panel-collapsed
-                && !dock-area.quick-merge-welcome && !dock-area.quick-merge-sidebar
-                ? 36px : 0px;
-        property <bool> quick-outer-horizontal:
-            root.quick-panel-dock == "left" || root.quick-panel-dock == "right";
-        property <length> quick-left:
-            root.quick-panel-dock == "left" ? dock-area.quick-outer-strip : 0px;
-        property <length> quick-right:
-            root.quick-panel-dock == "right" ? dock-area.quick-outer-strip : 0px;
-        property <length> quick-top:
-            root.quick-panel-dock == "top" ? dock-area.quick-outer-strip : 0px;
-        property <length> quick-bottom:
-            root.quick-panel-dock == "bottom" ? dock-area.quick-outer-strip : 0px;
+        VerticalLayout {
+            spacing: 0;
 
-        if dock-area.quick-outer-strip > 0px : ToolStrip {
-            x: root.quick-panel-dock == "right" ? parent.width - parent.quick-outer-strip : 0px;
-            y: root.quick-panel-dock == "bottom" ? parent.height - parent.quick-outer-strip : 0px;
-            width: parent.quick-outer-horizontal ? parent.quick-outer-strip : parent.width;
-            height: parent.quick-outer-horizontal ? parent.height : parent.quick-outer-strip;
-            dock-edge: root.quick-panel-dock;
-            glyph: "\u{E3E7}";
-            tooltip: @tr("Quick commands");
-            expand => {
-                root.quick-panel-collapsed = false;
-                if (root.sidebar-dock == root.quick-panel-dock) {
-                    root.sidebar-collapsed = true;
-                    root.set-sidebar-collapsed(true);
-                }
-                if (root.welcome-as-sidebar
-                        && root.welcome-sidebar-dock == root.quick-panel-dock) {
-                    root.welcome-collapsed = true;
-                    root.set-welcome-collapsed(true);
-                }
+            // macOS immersive bar: a strip under the native traffic-light buttons.
+            // Frosted like the other panels (bg-panel) so it matches in both themes —
+            // a plain transparent strip would show the raw wallpaper here and look dark
+            // in light mode. Left as a plain reserve (no TouchArea) so macOS's own title
+            // bar keeps handling the window drag in this region.
+            if root.titlebar-inset > 0px : Rectangle {
+                height: root.titlebar-inset;
+                background: Theme.bg-panel;
             }
-        }
 
-        // Collapsed welcome → a thin left icon strip (click the icon to re-open).
-        if root.welcome-as-sidebar && root.welcome-collapsed : ToolStrip {
-            x: root.welcome-sidebar-dock == "right"
-                ? parent.width - parent.quick-right - parent.welcome-strip
-                : root.welcome-sidebar-dock == "left" ? parent.quick-left : parent.quick-left;
-            y: root.welcome-sidebar-dock == "bottom"
-                ? parent.height - parent.quick-bottom - parent.welcome-strip
-                : root.welcome-sidebar-dock == "top" ? parent.quick-top : parent.quick-top;
-            width: parent.welcome-horizontal ? parent.welcome-strip
-                : parent.width - parent.quick-left - parent.quick-right;
-            height: parent.welcome-horizontal
-                ? parent.height - parent.quick-top - parent.quick-bottom : parent.welcome-strip;
-            dock-edge: root.welcome-sidebar-dock;
-            glyph: "\u{E88A}";   // session list / welcome
-            show-second: parent.combine-collapsed-tools || parent.quick-merge-welcome;
-            second-glyph: parent.combine-collapsed-tools ? "\u{E871}" : "\u{E3E7}";
-            show-third: parent.combine-collapsed-tools && parent.quick-merge-welcome;
-            third-glyph: "\u{E3E7}";
-            expand => {
-                root.welcome-collapsed = false;
-                root.set-welcome-collapsed(false);
-                if (root.sidebar-dock == root.welcome-sidebar-dock) {
-                    root.sidebar-collapsed = true;
-                    root.set-sidebar-collapsed(true);
-                }
-                if (root.quick-panel-open
-                        && root.quick-panel-dock == root.welcome-sidebar-dock) {
-                    root.quick-panel-collapsed = true;
-                }
-            }
-            expand-second => {
-                if (parent.combine-collapsed-tools) {
-                    root.sidebar-collapsed = false;
-                    root.set-sidebar-collapsed(false);
-                    if (root.quick-panel-open && root.quick-panel-dock == root.sidebar-dock) {
-                        root.quick-panel-collapsed = true;
+            // Immersive custom title bar (#119) — only on frameless platforms
+            // (Windows/Linux). App icon + name on the left, a draggable middle
+            // (move window / double-click to maximize), then the toolbar icons and
+            // window controls on the right. macOS keeps its native title bar and
+            // shows the toolbar icons via the overlay further below.
+            if root.custom-titlebar : Rectangle {
+                height: 38px;
+                background: Theme.bg-panel;
+                tb-drag := TouchArea {
+                    pointer-event(e) => {
+                        if (e.kind == PointerEventKind.down && e.button == PointerEventButton.left) {
+                            root.win-drag();
+                        }
                     }
-                } else {
+                    double-clicked => { root.win-maximize-toggle(); }
+                }
+                HorizontalLayout {
+                    padding-left: 12px;
+                    spacing: 8px;
+                    // Vertical-centering wrappers so the icon and name line up (#119).
+                    VerticalLayout {
+                        alignment: center;
+                        Image {
+                            source: @image-url("../assets/icon.png");
+                            width: 18px;
+                            height: 18px;
+                        }
+                    }
+                    VerticalLayout {
+                        alignment: center;
+                        Text {
+                            text: "meatshell";
+                            color: Theme.text-secondary;
+                            font-size: Theme.fs-sm;
+                        }
+                    }
+                    // Draggable spacer (no TouchArea → clicks fall to tb-drag).
+                    Rectangle { horizontal-stretch: 1; }
+                    // Window controls only — the app toolbar icons live in the tab
+                    // row below, not here (#119).
+                    WinBtn { icon: "\u{E15B}"; clicked => { root.win-minimize(); } }
+                    WinBtn {
+                        icon: root.window-maximized ? "\u{E3E0}" : "\u{E835}";
+                        clicked => { root.win-maximize-toggle(); }
+                    }
+                    WinBtn { icon: "\u{E5CD}"; danger: true; clicked => { root.win-close(); } }
+                }
+            }
+
+            // Dock area — fills below the title bar. The resource sidebar and the
+            // central content are positioned by absolute geometry computed from
+            // `sidebar-dock`, so the sidebar can sit on any window edge (#dock).
+            dock-area := Rectangle {
+            vertical-stretch: 1;
+            // Left-edge layout (welcome-as-sidebar mode): a thin always-on icon strip
+            // (IDEA-style) + the welcome/session sidebar (0 when collapsed). The rest
+            // (resource panel + central terminal, which never collapses) sits to their
+            // right in `rest`.
+            // Collapsed-only (M5): the icon strip shows only while collapsed; the
+            // panel itself (welcome-w) only while expanded — one or the other.
+            property <bool> sidebar-strip-outside:
+                !root.zen-mode && root.welcome-as-sidebar && !root.welcome-collapsed
+                && root.sidebar-collapsed && root.sidebar-dock == root.welcome-sidebar-dock;
+            property <length> sidebar-outside-strip: dock-area.sidebar-strip-outside ? 36px : 0px;
+            property <length> welcome-strip: (!root.zen-mode && root.welcome-as-sidebar && root.welcome-collapsed) ? 36px : 0px;
+            property <length> welcome-size: (!root.zen-mode && root.welcome-as-sidebar && !root.welcome-collapsed) ? root.welcome-sidebar-width : 0px;
+            property <length> welcome-taken: welcome-strip + welcome-size + sidebar-outside-strip;
+            property <bool> welcome-horizontal: root.welcome-sidebar-horizontal;
+            property <bool> welcome-sidebar-dragging;
+            property <bool> combine-collapsed-tools:
+                root.welcome-as-sidebar && root.welcome-collapsed
+                && root.sidebar-collapsed && root.sidebar-dock == root.welcome-sidebar-dock;
+            // A collapsed quick-command sidebar joins an existing collapsed strip
+            // on the same edge. Only when no such strip exists does it reserve its
+            // own outermost 36px slot (#215).
+            property <bool> quick-merge-welcome:
+                root.quick-panel-open && root.quick-panel-collapsed
+                && root.welcome-as-sidebar && root.welcome-collapsed
+                && root.quick-panel-dock == root.welcome-sidebar-dock;
+            property <bool> quick-merge-sidebar:
+                root.quick-panel-open && root.quick-panel-collapsed
+                && !dock-area.quick-merge-welcome && root.sidebar-collapsed
+                && root.quick-panel-dock == root.sidebar-dock;
+            property <length> quick-outer-strip:
+                !root.zen-mode && root.quick-panel-open && root.quick-panel-collapsed
+                    && !dock-area.quick-merge-welcome && !dock-area.quick-merge-sidebar
+                    ? 36px : 0px;
+            property <bool> quick-outer-horizontal:
+                root.quick-panel-dock == "left" || root.quick-panel-dock == "right";
+            property <length> quick-left:
+                root.quick-panel-dock == "left" ? dock-area.quick-outer-strip : 0px;
+            property <length> quick-right:
+                root.quick-panel-dock == "right" ? dock-area.quick-outer-strip : 0px;
+            property <length> quick-top:
+                root.quick-panel-dock == "top" ? dock-area.quick-outer-strip : 0px;
+            property <length> quick-bottom:
+                root.quick-panel-dock == "bottom" ? dock-area.quick-outer-strip : 0px;
+
+            if dock-area.quick-outer-strip > 0px : ToolStrip {
+                x: root.quick-panel-dock == "right" ? parent.width - parent.quick-outer-strip : 0px;
+                y: root.quick-panel-dock == "bottom" ? parent.height - parent.quick-outer-strip : 0px;
+                width: parent.quick-outer-horizontal ? parent.quick-outer-strip : parent.width;
+                height: parent.quick-outer-horizontal ? parent.height : parent.quick-outer-strip;
+                dock-edge: root.quick-panel-dock;
+                glyph: "\u{E3E7}";
+                tooltip: @tr("Quick commands");
+                expand => {
                     root.quick-panel-collapsed = false;
-                }
-            }
-            expand-third => { root.quick-panel-collapsed = false; }
-        }
-
-        if dock-area.sidebar-strip-outside : ToolStrip {
-            x: root.welcome-sidebar-dock == "right"
-                ? parent.width - parent.quick-right - parent.sidebar-outside-strip
-                : root.welcome-sidebar-dock == "left" ? parent.quick-left : parent.quick-left;
-            y: root.welcome-sidebar-dock == "bottom"
-                ? parent.height - parent.quick-bottom - parent.sidebar-outside-strip
-                : root.welcome-sidebar-dock == "top" ? parent.quick-top : parent.quick-top;
-            width: parent.welcome-horizontal ? parent.sidebar-outside-strip
-                : parent.width - parent.quick-left - parent.quick-right;
-            height: parent.welcome-horizontal
-                ? parent.height - parent.quick-top - parent.quick-bottom : parent.sidebar-outside-strip;
-            dock-edge: root.welcome-sidebar-dock;
-            glyph: "\u{E871}";
-            show-second: parent.quick-merge-sidebar;
-            second-glyph: "\u{E3E7}";
-            expand => {
-                root.sidebar-collapsed = false;
-                root.set-sidebar-collapsed(false);
-                root.welcome-collapsed = true;
-                root.set-welcome-collapsed(true);
-                if (root.quick-panel-open && root.quick-panel-dock == root.sidebar-dock) {
-                    root.quick-panel-collapsed = true;
-                }
-            }
-            expand-second => { root.quick-panel-collapsed = false; }
-        }
-
-        // Welcome / session list, to the right of the icon strip. Hidden when
-        // collapsed — its icon stays in the strip; clicking it re-opens.
-        if root.welcome-as-sidebar && !root.welcome-collapsed : Rectangle {
-            x: root.welcome-sidebar-dock == "right" ? parent.width - parent.quick-right - parent.sidebar-outside-strip - parent.welcome-size
-             : root.welcome-sidebar-dock == "left" ? parent.quick-left + parent.sidebar-outside-strip
-             : parent.quick-left;
-            y: root.welcome-sidebar-dock == "bottom" ? parent.height - parent.quick-bottom - parent.sidebar-outside-strip - parent.welcome-size
-             : root.welcome-sidebar-dock == "top" ? parent.quick-top + parent.sidebar-outside-strip
-             : parent.quick-top;
-            width: parent.welcome-horizontal ? parent.welcome-size
-                : parent.width - parent.quick-left - parent.quick-right;
-            height: parent.welcome-horizontal
-                ? parent.height - parent.quick-top - parent.quick-bottom : parent.welcome-size;
-            background: Theme.bg-panel;
-            clip: true;
-            Welcome {
-                width: parent.width;
-                height: parent.height;
-                compact: true;
-                dock-edge: root.welcome-sidebar-dock;
-                sessions: root.sessions;
-                import-hint: root.ssh-import-hint;
-                search-query <=> root.host-search-query;
-                search-changed(query) => { root.host-search-changed(query); }
-                collapse => {
-                    root.welcome-collapsed = true;
-                    root.set-welcome-collapsed(true);
-                }
-                dock-drag-move(ax, ay) => {
-                    root.panel-dragging = true;
-                    root.drag-nx = (ax - dock-area.absolute-position.x) / dock-area.width;
-                    root.drag-ny = (ay - dock-area.absolute-position.y) / dock-area.height;
-                }
-                dock-drag-end() => {
-                    if (root.dock-target != "") {
-                        root.welcome-sidebar-dock = root.dock-target;
-                        if (root.sidebar-dock == root.dock-target) {
-                            root.sidebar-collapsed = true;
-                            root.set-sidebar-collapsed(true);
-                        }
-                        if (root.quick-panel-open && root.quick-panel-dock == root.dock-target) {
-                            root.quick-panel-collapsed = true;
-                        }
-                        root.persist-welcome-sidebar-dock(root.welcome-sidebar-dock);
+                    if (root.sidebar-dock == root.quick-panel-dock) {
+                        root.sidebar-collapsed = true;
+                        root.set-sidebar-collapsed(true);
                     }
-                    root.panel-dragging = false;
-                }
-                new-session => { root.new-session-clicked(); }
-                import-ssh-config => { root.import-ssh-config(); }
-                connect-session(id) => { root.connect-session(id); }
-                edit-session(id) => { root.edit-session(id); }
-                duplicate-session(id) => { root.duplicate-session(id); }
-                move-session(id, group) => { root.move-session(id, group); }
-                toggle-group(group) => { root.toggle-group(group); }
-                new-group => {
-                    root.group-dialog-orig = "";
-                    root.group-dialog-name = "";
-                    root.group-dialog-error = "";
-                    root.group-dialog-open = true;
-                }
-                edit-group(name) => {
-                    root.group-dialog-orig = name;
-                    root.group-dialog-name = name;
-                    root.group-dialog-error = "";
-                    root.group-dialog-open = true;
-                }
-                delete-group(name) => { root.delete-group(name); }
-                remove-session(id) => { root.remove-session(id); }
-            }
-            Rectangle {
-                x: root.welcome-sidebar-dock == "left" ? parent.width - 1px : 0px;
-                y: root.welcome-sidebar-dock == "top" ? parent.height - 1px : 0px;
-                width: root.welcome-sidebar-horizontal ? 1px : parent.width;
-                height: root.welcome-sidebar-horizontal ? parent.height : 1px;
-                background: Theme.border-subtle;
-            }
-        }
-
-        // Drag the welcome sidebar's right edge to resize it (v0.5 M3b).
-        if root.welcome-as-sidebar && !root.welcome-collapsed : Rectangle {
-            x: root.welcome-sidebar-dock == "left" ? parent.quick-left + parent.sidebar-outside-strip + parent.welcome-size - 2px
-             : root.welcome-sidebar-dock == "right" ? parent.width - parent.quick-right - parent.sidebar-outside-strip - parent.welcome-size - 2px
-             : parent.quick-left;
-            y: root.welcome-sidebar-dock == "top" ? parent.quick-top + parent.sidebar-outside-strip + parent.welcome-size - 2px
-             : root.welcome-sidebar-dock == "bottom" ? parent.height - parent.quick-bottom - parent.sidebar-outside-strip - parent.welcome-size - 2px
-             : parent.quick-top;
-            width: parent.welcome-horizontal ? 4px
-                : parent.width - parent.quick-left - parent.quick-right;
-            height: parent.welcome-horizontal
-                ? parent.height - parent.quick-top - parent.quick-bottom : 4px;
-            background: ws-split-ta.has-hover || dock-area.welcome-sidebar-dragging
-                ? Theme.accent : transparent;
-            ws-split-ta := TouchArea {
-                mouse-cursor: dock-area.welcome-horizontal ? ew-resize : ns-resize;
-                pointer-event(ev) => {
-                    if (ev.kind == PointerEventKind.down) {
-                        dock-area.welcome-sidebar-dragging = true;
-                    } else if (ev.kind == PointerEventKind.up) {
-                        dock-area.welcome-sidebar-dragging = false;
-                        root.persist-welcome-sidebar-width(root.welcome-sidebar-width / 1px);
-                    }
-                }
-                moved => {
-                    if (dock-area.welcome-sidebar-dragging) {
-                        if (dock-area.welcome-horizontal) {
-                            root.welcome-sidebar-width = clamp(
-                                root.welcome-sidebar-dock == "right"
-                                    ? dock-area.absolute-position.x + dock-area.width
-                                        - (self.absolute-position.x + self.mouse-x)
-                                    : self.absolute-position.x + self.mouse-x
-                                        - dock-area.absolute-position.x,
-                                160px, 480px);
-                        } else {
-                            root.welcome-sidebar-width = clamp(
-                                root.welcome-sidebar-dock == "bottom"
-                                    ? dock-area.absolute-position.y + dock-area.height
-                                        - (self.absolute-position.y + self.mouse-y)
-                                    : self.absolute-position.y + self.mouse-y
-                                        - dock-area.absolute-position.y,
-                                120px, 360px);
-                        }
-                    }
-                }
-            }
-        }
-
-        // Everything except the welcome strip/sidebar — the resource panel,
-        // splitter and the central tab/pane content — sits to the right of them.
-        rest := Rectangle {
-        x: (root.welcome-sidebar-dock == "left" ? parent.welcome-taken : 0px)
-            + parent.quick-left;
-        y: (root.welcome-sidebar-dock == "top" ? parent.welcome-taken : 0px)
-            + parent.quick-top;
-        width: parent.width
-            - (parent.welcome-horizontal ? parent.welcome-taken : 0px)
-            - parent.quick-left - parent.quick-right;
-        height: parent.height
-            - (!parent.welcome-horizontal ? parent.welcome-taken : 0px)
-            - parent.quick-top - parent.quick-bottom;
-        // A shared ToolStrip is already reserved outside `rest` while the
-        // welcome panel is expanded, or by the merged welcome strip while both
-        // panels are collapsed. Do not reserve the same 36px a second time.
-        property <length> sb-w: root.zen-mode ? 0px
-            : dock-area.sidebar-strip-outside
-                || dock-area.combine-collapsed-tools ? 0px
-            : root.sidebar-collapsed ? 36px : root.sidebar-width;
-        property <length> sb-h: root.zen-mode ? 0px
-            : dock-area.sidebar-strip-outside
-                || dock-area.combine-collapsed-tools ? 0px
-            : root.sidebar-collapsed ? 36px : root.sidebar-height;
-        property <length> sp: root.zen-mode || root.sidebar-collapsed ? 0px : 4px;
-        // The collapsed bar (sb-h) already reserves the bottom strip now.
-        property <length> bottom-strip-h: 0px;
-
-        // Left sidebar — collapsible and drag-resizable, dockable to any edge.
-        // Only shown while expanded; collapsing swaps it for the ToolStrip icon
-        // bar below (mirrors the welcome sidebar), so no clipped widgets bleed
-        // through the 36px strip (#resource-collapse).
-        if !root.sidebar-collapsed : Rectangle {
-            x: root.sidebar-dock == "right" ? parent.width - parent.sb-w
-             : 0px;
-            y: root.sidebar-dock == "bottom" ? parent.height - parent.sb-h
-             : 0px;
-            width: root.sidebar-horizontal ? parent.sb-w : parent.width;
-            height: root.sidebar-horizontal ? parent.height : parent.sb-h;
-            clip: true;
-            Sidebar {
-            width: parent.width;
-            height: parent.height;
-            // Docked top/bottom → lay the resource widgets out in a row.
-            lay-horizontal: !root.sidebar-horizontal;
-            dock-edge: root.sidebar-dock;
-            animate width, height { duration: root.sidebar-dragging ? 0ms : 150ms; easing: ease-out; }
-            connection-state: root.connection-state;
-            conn-host: root.conn-host;
-            conn-state: root.conn-state;
-            resource-title: root.resource-title;
-            cpu-percent: root.cpu-percent;
-            mem-percent: root.mem-percent;
-            swap-percent: root.swap-percent;
-            mem-detail: root.mem-detail;
-            swap-detail: root.swap-detail;
-            net-top-up: root.net-top-up;
-            net-top-down: root.net-top-down;
-            net-top-history: root.net-top-history;
-            net-bot-up: root.net-bot-up;
-            net-bot-down: root.net-bot-down;
-            net-bot-history: root.net-bot-history;
-            net-ifaces: root.net-ifaces;
-            net-selected: root.net-selected;
-            net-show-selector: root.net-show-selector;
-            disks: root.disks;
-            system-info-available: root.system-info-available;
-            proc-available: root.proc-available;
-            app-version: root.app-version;
-            select-net-iface(i) => { root.select-net-iface(i); }
-            show-system-info() => { root.open-system-info(); }
-            show-processes() => { root.open-processes(); }
-            copy-host(h) => { root.copy-text(h); }   // reuse the clipboard helper (#192)
-            // Drag the sidebar header to dock it to another edge. Coordinates
-            // arrive in window space; convert to dock-area-relative fractions.
-            dock-drag-move(ax, ay) => {
-                root.panel-dragging = true;
-                root.drag-nx = (ax - dock-area.absolute-position.x) / dock-area.width;
-                root.drag-ny = (ay - dock-area.absolute-position.y) / dock-area.height;
-            }
-            dock-drag-end() => {
-                if (root.dock-target != "") {
-                    root.sidebar-dock = root.dock-target;
-                    if (root.welcome-as-sidebar && root.welcome-sidebar-dock == root.dock-target) {
+                    if (root.welcome-as-sidebar
+                            && root.welcome-sidebar-dock == root.quick-panel-dock) {
                         root.welcome-collapsed = true;
                         root.set-welcome-collapsed(true);
                     }
-                    if (root.quick-panel-open && root.quick-panel-dock == root.dock-target) {
+                }
+            }
+
+            // Collapsed welcome → a thin left icon strip (click the icon to re-open).
+            if root.welcome-as-sidebar && root.welcome-collapsed : ToolStrip {
+                x: root.welcome-sidebar-dock == "right"
+                    ? parent.width - parent.quick-right - parent.welcome-strip
+                    : root.welcome-sidebar-dock == "left" ? parent.quick-left : parent.quick-left;
+                y: root.welcome-sidebar-dock == "bottom"
+                    ? parent.height - parent.quick-bottom - parent.welcome-strip
+                    : root.welcome-sidebar-dock == "top" ? parent.quick-top : parent.quick-top;
+                width: parent.welcome-horizontal ? parent.welcome-strip
+                    : parent.width - parent.quick-left - parent.quick-right;
+                height: parent.welcome-horizontal
+                    ? parent.height - parent.quick-top - parent.quick-bottom : parent.welcome-strip;
+                dock-edge: root.welcome-sidebar-dock;
+                glyph: "\u{E88A}";   // session list / welcome
+                show-second: parent.combine-collapsed-tools || parent.quick-merge-welcome;
+                second-glyph: parent.combine-collapsed-tools ? "\u{E871}" : "\u{E3E7}";
+                show-third: parent.combine-collapsed-tools && parent.quick-merge-welcome;
+                third-glyph: "\u{E3E7}";
+                expand => {
+                    root.welcome-collapsed = false;
+                    root.set-welcome-collapsed(false);
+                    if (root.sidebar-dock == root.welcome-sidebar-dock) {
+                        root.sidebar-collapsed = true;
+                        root.set-sidebar-collapsed(true);
+                    }
+                    if (root.quick-panel-open
+                            && root.quick-panel-dock == root.welcome-sidebar-dock) {
                         root.quick-panel-collapsed = true;
                     }
-                    root.persist-sidebar-dock(root.sidebar-dock);
                 }
-                root.panel-dragging = false;
+                expand-second => {
+                    if (parent.combine-collapsed-tools) {
+                        root.sidebar-collapsed = false;
+                        root.set-sidebar-collapsed(false);
+                        if (root.quick-panel-open && root.quick-panel-dock == root.sidebar-dock) {
+                            root.quick-panel-collapsed = true;
+                        }
+                    } else {
+                        root.quick-panel-collapsed = false;
+                    }
+                }
+                expand-third => { root.quick-panel-collapsed = false; }
             }
-            toggle-collapse() => {
-                root.sidebar-collapsed = !root.sidebar-collapsed;
-                root.set-sidebar-collapsed(root.sidebar-collapsed);
-            }
-            }
-        }
 
-        // Collapsed resource panel → a ToolStrip icon bar at the same docked edge
-        // (M5), in place of the old floating expand button.
-        if root.sidebar-collapsed && !dock-area.combine-collapsed-tools && !dock-area.sidebar-strip-outside : ToolStrip {
-            x: root.sidebar-dock == "right" ? parent.width - parent.sb-w : 0px;
-            y: root.sidebar-dock == "bottom" ? parent.height - parent.sb-h : 0px;
-            width: root.sidebar-horizontal ? parent.sb-w : parent.width;
-            height: root.sidebar-horizontal ? parent.height : parent.sb-h;
-            dock-edge: root.sidebar-dock;
-            glyph: "\u{E871}";   // dashboard — resource panel
-            show-second: dock-area.quick-merge-sidebar;
-            second-glyph: "\u{E3E7}";
-            expand => {
-                root.sidebar-collapsed = false;
-                root.set-sidebar-collapsed(false);
-                if (root.welcome-as-sidebar && root.welcome-sidebar-dock == root.sidebar-dock) {
+            if dock-area.sidebar-strip-outside : ToolStrip {
+                x: root.welcome-sidebar-dock == "right"
+                    ? parent.width - parent.quick-right - parent.sidebar-outside-strip
+                    : root.welcome-sidebar-dock == "left" ? parent.quick-left : parent.quick-left;
+                y: root.welcome-sidebar-dock == "bottom"
+                    ? parent.height - parent.quick-bottom - parent.sidebar-outside-strip
+                    : root.welcome-sidebar-dock == "top" ? parent.quick-top : parent.quick-top;
+                width: parent.welcome-horizontal ? parent.sidebar-outside-strip
+                    : parent.width - parent.quick-left - parent.quick-right;
+                height: parent.welcome-horizontal
+                    ? parent.height - parent.quick-top - parent.quick-bottom : parent.sidebar-outside-strip;
+                dock-edge: root.welcome-sidebar-dock;
+                glyph: "\u{E871}";
+                show-second: parent.quick-merge-sidebar;
+                second-glyph: "\u{E3E7}";
+                expand => {
+                    root.sidebar-collapsed = false;
+                    root.set-sidebar-collapsed(false);
                     root.welcome-collapsed = true;
                     root.set-welcome-collapsed(true);
-                }
-                if (root.quick-panel-open && root.quick-panel-dock == root.sidebar-dock) {
-                    root.quick-panel-collapsed = true;
-                }
-            }
-            expand-second => { root.quick-panel-collapsed = false; }
-        }
-
-        // Splitter — drag to resize the sidebar. Orientation + which dimension it
-        // adjusts follow the dock edge. Hidden while collapsed.
-        Rectangle {
-            visible: !root.sidebar-collapsed;
-            // Horizontal docks → a vertical 4px bar at the sidebar's inner edge;
-            // vertical docks → a horizontal 4px bar.
-            x: root.sidebar-dock == "left"   ? parent.sb-w
-             : root.sidebar-dock == "right"  ? parent.width - parent.sb-w - 4px
-             : 0px;
-            y: root.sidebar-dock == "top"    ? parent.sb-h
-             : root.sidebar-dock == "bottom" ? parent.height - parent.sb-h - 4px
-             : 0px;
-            width:  root.sidebar-horizontal ? 4px : parent.width;
-            height: root.sidebar-horizontal ? parent.height : 4px;
-            background: sb-split-ta.has-hover || root.sidebar-dragging
-                ? Theme.accent
-                : Theme.border-subtle;
-            sb-split-ta := TouchArea {
-                mouse-cursor: root.sidebar-horizontal ? ew-resize : ns-resize;
-                pointer-event(ev) => {
-                    if (ev.kind == PointerEventKind.down) {
-                        root.sidebar-dragging = true;
-                    } else if (ev.kind == PointerEventKind.up) {
-                        root.sidebar-dragging = false;
-                        root.persist-sidebar-width(root.sidebar-width / 1px);
+                    if (root.quick-panel-open && root.quick-panel-dock == root.sidebar-dock) {
+                        root.quick-panel-collapsed = true;
                     }
                 }
-                moved => {
-                    if (root.sidebar-dragging) {
-                        if (root.sidebar-horizontal) {
-                            // Track the cursor in stable dock-area coordinates.
-                            // The splitter moves while resizing, so adding local
-                            // mouse deltas to the current width feeds the movement
-                            // back into itself and can suddenly widen the panel
-                            // on Win10 (#244).
-                            root.sidebar-width = clamp(
-                                root.sidebar-dock == "right"
-                                    ? dock-area.absolute-position.x + dock-area.width
-                                        - (self.absolute-position.x + self.mouse-x)
-                                    : (self.absolute-position.x + self.mouse-x)
-                                        - dock-area.absolute-position.x,
-                                160px, 520px);
-                        } else {
-                            root.sidebar-height = clamp(
-                                root.sidebar-dock == "bottom"
-                                    ? dock-area.absolute-position.y + dock-area.height
-                                        - (self.absolute-position.y + self.mouse-y)
-                                    : (self.absolute-position.y + self.mouse-y)
-                                        - dock-area.absolute-position.y,
-                                120px, 480px);
-                        }
-                    }
-                }
+                expand-second => { root.quick-panel-collapsed = false; }
             }
-        }
 
-        // Right side: tabs + content — positioned in the rect left after the
-        // sidebar is carved off its docked edge. Clipped so the terminal / SFTP
-        // panel can never bleed (visually or for clicks) onto a panel docked on
-        // the bottom or right (#dock).
-        quick-area := Rectangle {
-            x: root.sidebar-dock == "left" ? parent.sb-w + parent.sp : 0px;
-            y: root.sidebar-dock == "top"  ? parent.sb-h + parent.sp : 0px;
-            width:  root.sidebar-horizontal ? parent.width - parent.sb-w - parent.sp : parent.width;
-            height: root.sidebar-horizontal ? parent.height : parent.height - parent.sb-h - parent.sp - parent.bottom-strip-h;
-            clip: true;
-            property <bool> quick-horizontal:
-                root.quick-panel-dock == "left" || root.quick-panel-dock == "right";
-            property <length> quick-w:
-                !root.zen-mode && root.quick-panel-open && !root.quick-panel-collapsed ? root.quick-panel-width : 0px;
-            property <length> quick-h:
-                !root.zen-mode && root.quick-panel-open && !root.quick-panel-collapsed ? root.quick-panel-height : 0px;
-            property <length> quick-sp:
-                !root.zen-mode && root.quick-panel-open && !root.quick-panel-collapsed ? 4px : 0px;
-
-            central := Rectangle {
-            x: root.quick-panel-open && !root.quick-panel-collapsed && root.quick-panel-dock == "left"
-                ? parent.quick-w + parent.quick-sp : 0px;
-            y: root.quick-panel-open && !root.quick-panel-collapsed && root.quick-panel-dock == "top"
-                ? parent.quick-h + parent.quick-sp : 0px;
-            width: root.quick-panel-open && !root.quick-panel-collapsed && parent.quick-horizontal
-                ? parent.width - parent.quick-w - parent.quick-sp : parent.width;
-            height: root.quick-panel-open && !root.quick-panel-collapsed && !parent.quick-horizontal
-                ? parent.height - parent.quick-h - parent.quick-sp : parent.height;
-            clip: true;
-            // Split-pane area (v0.5): panes tile this rect; each pane has its own
-            // tab strip + active terminal / welcome. Rust flattens the split tree
-            // into `panes` for the size we report here.
-            pane-area := Rectangle {
-                width: parent.width;
-                height: parent.height;
-                changed width => { root.content-resized(self.width, self.height); }
-                changed height => { root.content-resized(self.width, self.height); }
-            for pane[pi] in root.panes : Rectangle {
-                x: pane.x; y: pane.y; width: pane.w; height: pane.h;
+            // Welcome / session list, to the right of the icon strip. Hidden when
+            // collapsed — its icon stays in the strip; clicking it re-opens.
+            if root.welcome-as-sidebar && !root.welcome-collapsed : Rectangle {
+                x: root.welcome-sidebar-dock == "right" ? parent.width - parent.quick-right - parent.sidebar-outside-strip - parent.welcome-size
+                 : root.welcome-sidebar-dock == "left" ? parent.quick-left + parent.sidebar-outside-strip
+                 : parent.quick-left;
+                y: root.welcome-sidebar-dock == "bottom" ? parent.height - parent.quick-bottom - parent.sidebar-outside-strip - parent.welcome-size
+                 : root.welcome-sidebar-dock == "top" ? parent.quick-top + parent.sidebar-outside-strip
+                 : parent.quick-top;
+                width: parent.welcome-horizontal ? parent.welcome-size
+                    : parent.width - parent.quick-left - parent.quick-right;
+                height: parent.welcome-horizontal
+                    ? parent.height - parent.quick-top - parent.quick-bottom : parent.welcome-size;
+                background: Theme.bg-panel;
                 clip: true;
-                VerticalLayout {
-                spacing: 0;
-
-                HorizontalLayout {
-                spacing: 0;
-                // (Collapsed resource panel now reserves its own ToolStrip slot in
-                // `rest`, so the tab strip no longer needs a spacer for it.)
-                TabBar {
-                    horizontal-stretch: 1;
-                    // Reserve room for the top-right toolbar icons that sit over
-                    // this row so tabs don't slide underneath them (#122).
-                    reserve-right: pane.reserve-right;
-                    show-new-tab: !root.welcome-as-sidebar;
-                    can-merge-pane: root.panes.length > 1;
-                    tabs: pane.tabs;
-                    active-id: pane.active-id;
-                    tab-selected(id) => { root.pane-tab-selected(pane.id, id); }
-                    tab-closed(id) => { root.pane-tab-closed(pane.id, id); }
-                    new-tab() => { root.pane-new-tab(pane.id); }
-                    tab-reorder(from-index, direction) => {
-                        root.pane-tab-reorder(pane.id, from-index, direction);
-                    }
-                    tab-split(id, dir) => { root.pane-split(pane.id, id, dir); }
-                    merge-pane() => { root.pane-merge(pane.id); }
-                    tab-duplicate(id) => { root.tab-duplicate(id); }
-                    tab-drag-move(id, ax, ay) => {
-                        root.tab-drag-move(id,
-                            ax - pane-area.absolute-position.x,
-                            ay - pane-area.absolute-position.y);
-                    }
-                    tab-drag-drop(id, ax, ay) => {
-                        root.tab-drag-drop(id,
-                            ax - pane-area.absolute-position.x,
-                            ay - pane-area.absolute-position.y);
-                    }
-                }
-            }
-
-            // Content area swaps based on active tab kind.
-            Rectangle {
-                vertical-stretch: 1;
-                background: Theme.bg-root;
-
-                // Empty pane outside welcome-sidebar mode: keep a small hint for
-                // rare empty panes, but do not cover the wallpaper when the
-                // session list is already visible as a sidebar.
-                if pane.tabs.length == 0 && !root.welcome-as-sidebar : Rectangle {
+                Welcome {
                     width: parent.width;
                     height: parent.height;
-                    Text {
-                        text: root.lang-en
-                            ? "Pick a session on the left to begin"
-                            : "从左侧选择一个会话开始";
-                        color: Theme.text-muted;
-                        font-size: Theme.fs-sm;
-                        horizontal-alignment: center;
-                        vertical-alignment: center;
-                    }
-                }
-
-                // Welcome tab — fill the content area explicitly (some renderers
-                // don't auto-fill, which spread the header/card apart) (#dock).
-                if pane.active-id == "welcome" : Welcome {
-                    width: parent.width;
-                    height: parent.height;
+                    compact: true;
+                    dock-edge: root.welcome-sidebar-dock;
                     sessions: root.sessions;
                     import-hint: root.ssh-import-hint;
                     search-query <=> root.host-search-query;
                     search-changed(query) => { root.host-search-changed(query); }
+                    collapse => {
+                        root.welcome-collapsed = true;
+                        root.set-welcome-collapsed(true);
+                    }
+                    dock-drag-move(ax, ay) => {
+                        root.panel-dragging = true;
+                        root.drag-nx = (ax - dock-area.absolute-position.x) / dock-area.width;
+                        root.drag-ny = (ay - dock-area.absolute-position.y) / dock-area.height;
+                    }
+                    dock-drag-end() => {
+                        if (root.dock-target != "") {
+                            root.welcome-sidebar-dock = root.dock-target;
+                            if (root.sidebar-dock == root.dock-target) {
+                                root.sidebar-collapsed = true;
+                                root.set-sidebar-collapsed(true);
+                            }
+                            if (root.quick-panel-open && root.quick-panel-dock == root.dock-target) {
+                                root.quick-panel-collapsed = true;
+                            }
+                            root.persist-welcome-sidebar-dock(root.welcome-sidebar-dock);
+                        }
+                        root.panel-dragging = false;
+                    }
                     new-session => { root.new-session-clicked(); }
                     import-ssh-config => { root.import-ssh-config(); }
                     connect-session(id) => { root.connect-session(id); }
@@ -1532,367 +1209,740 @@ export component AppWindow inherits Window {
                     }
                     delete-group(name) => { root.delete-group(name); }
                     remove-session(id) => { root.remove-session(id); }
-                    cycle-tab(reverse) => { root.cycle-tab(reverse); }
                 }
+                Rectangle {
+                    x: root.welcome-sidebar-dock == "left" ? parent.width - 1px : 0px;
+                    y: root.welcome-sidebar-dock == "top" ? parent.height - 1px : 0px;
+                    width: root.welcome-sidebar-horizontal ? 1px : parent.width;
+                    height: root.welcome-sidebar-horizontal ? parent.height : 1px;
+                    background: Theme.border-subtle;
+                }
+            }
 
-                // Terminal tabs — one TerminalView per terminal state. Only
-                // the one matching `active-tab-id` is visible. Slint doesn't
-                // allow nesting `if` directly inside a `for`, so we toggle
-                // visibility instead and rely on the layout to overlap them.
-                for term[i] in root.terminals : TerminalView {
-                    visible: term.id == pane.active-id;
-                    active: term.id == root.active-tab-id;
-                    zen-mode: root.zen-mode;
-                    width: term.id == pane.active-id ? parent.width : 0px;
-                    height: term.id == pane.active-id ? parent.height : 0px;
-                    tab-id: term.id;
-                    status-line: term.status;
-                    spans: term.spans;
-                    cursor-row: term.cursor-row;
-                    cursor-col: term.cursor-col;
-                    cursor-style: root.term-cursor-style;
-                    cursor-color: root.term-cursor-color;
-                    terminal-line-spacing: root.terminal-line-spacing;
-                    extra-paste-shortcuts-enabled: root.extra-paste-shortcuts-enabled;
-                    rows-used: term.rows-used;
-                    scroll-max: term.scroll-max;
-                    scroll-offset: term.scroll-offset;
-                    is-alt-screen: term.is-alt-screen;
-                    find-matches: term.find-matches;
-                    selection: term.selection;
-                    sftp-panel-height: term.sftp-panel-height;
-                    set-sftp-panel-height(v) => { root.set-pane-sftp-height(term.id, v); }
-                    sftp-panel-width: term.sftp-panel-width;
-                    set-sftp-panel-width(v) => { root.set-pane-sftp-width(term.id, v); }
-                    sftp-dock <=> root.sftp-dock;
-                    sftp-collapsed: term.sftp-collapsed;
-                    set-sftp-collapsed(v) => { root.set-pane-sftp-collapsed(term.id, v); }
-                    sftp-saved-height: term.sftp-saved-height;
-                    set-sftp-saved-height(v) => { root.set-pane-sftp-saved-height(term.id, v); }
-                    sftp-tree-width: root.sftp-tree-width;
-                    persist-sftp-tree-width(v) => { root.persist-sftp-tree-width(v); }
-                    sftp-path: term.sftp-path;
-                    sftp-entries: term.sftp-entries;
-                    sftp-status: term.sftp-status;
-                    sftp-loading: term.sftp-loading;
-                    sftp-tree-nodes: term.sftp-tree-nodes;
-                    sftp-transfer-targets: root.tabs;
-                    sftp-selected-count: term.sftp-selected-count;
-                    sftp-sort-key: term.sftp-sort-key;
-                    sftp-sort-dir: term.sftp-sort-dir;
-                    sftp-available: term.sftp-available && !root.zen-mode;
-                    tunnels: term.tunnels;
-                    quick-commands: root.quick-commands;
-                    quick-sidebar-enabled: root.quick-commands-as-sidebar;
-                    quick-panel-docked: root.quick-panel-open;
-                    quick-external-command: root.quick-external-command;
-                    quick-external-send-enter: root.quick-external-send-enter;
-                    quick-external-sequence: root.quick-external-sequence;
-                    command-history: root.command-history;
-                    history-view: root.history-view;
-                    run-command(cmd, all) => { root.run-command(term.id, cmd, all); }
-                    copy-text(t) => { root.copy-text(t); }
-                    delete-history(i) => { root.delete-history(i); }
-                    delete-history-cmd(c) => { root.delete-history-cmd(c); }
-                    search-history(q) => { root.search-history(q); }
-                    manage-quick-commands() => {
-                        root.qcm-name = "";
-                        root.qcm-command = "";
-                        root.qcm-group = "";
-                        root.qcm-edit-index = -1;
-                        root.quick-cmd-manage-open = true;
-                    }
-                    quick-dock-drag-move(ax, ay) => {
-                        root.panel-dragging = true;
-                        root.drag-nx = (ax - dock-area.absolute-position.x) / dock-area.width;
-                        root.drag-ny = (ay - dock-area.absolute-position.y) / dock-area.height;
-                    }
-                    quick-dock-drag-end() => {
-                        if (root.dock-target != "") {
-                            root.quick-panel-dock = root.dock-target;
-                            root.quick-panel-open = true;
-                            root.quick-panel-collapsed = false;
-                            if (root.sidebar-dock == root.dock-target) {
-                                root.sidebar-collapsed = true;
-                                root.set-sidebar-collapsed(true);
-                            }
-                            if (root.welcome-as-sidebar
-                                    && root.welcome-sidebar-dock == root.dock-target) {
-                                root.welcome-collapsed = true;
-                                root.set-welcome-collapsed(true);
-                            }
+            // Drag the welcome sidebar's right edge to resize it (v0.5 M3b).
+            if root.welcome-as-sidebar && !root.welcome-collapsed : Rectangle {
+                x: root.welcome-sidebar-dock == "left" ? parent.quick-left + parent.sidebar-outside-strip + parent.welcome-size - 2px
+                 : root.welcome-sidebar-dock == "right" ? parent.width - parent.quick-right - parent.sidebar-outside-strip - parent.welcome-size - 2px
+                 : parent.quick-left;
+                y: root.welcome-sidebar-dock == "top" ? parent.quick-top + parent.sidebar-outside-strip + parent.welcome-size - 2px
+                 : root.welcome-sidebar-dock == "bottom" ? parent.height - parent.quick-bottom - parent.sidebar-outside-strip - parent.welcome-size - 2px
+                 : parent.quick-top;
+                width: parent.welcome-horizontal ? 4px
+                    : parent.width - parent.quick-left - parent.quick-right;
+                height: parent.welcome-horizontal
+                    ? parent.height - parent.quick-top - parent.quick-bottom : 4px;
+                background: ws-split-ta.has-hover || dock-area.welcome-sidebar-dragging
+                    ? Theme.accent : transparent;
+                ws-split-ta := TouchArea {
+                    mouse-cursor: dock-area.welcome-horizontal ? ew-resize : ns-resize;
+                    pointer-event(ev) => {
+                        if (ev.kind == PointerEventKind.down) {
+                            dock-area.welcome-sidebar-dragging = true;
+                        } else if (ev.kind == PointerEventKind.up) {
+                            dock-area.welcome-sidebar-dragging = false;
+                            root.persist-welcome-sidebar-width(root.welcome-sidebar-width / 1px);
                         }
-                        root.panel-dragging = false;
                     }
-                    toggle-quick-group(g) => { root.toggle-quick-group(g); }
-                    edit-quick-command(i) => { root.edit-quick-command(i); }
-                    duplicate-quick-command(i) => { root.duplicate-quick-command(i); }
-                    delete-quick-command(i) => { root.delete-quick-command(i); }
-                    move-quick-command(i, g) => { root.move-quick-command(i, g); }
-                    new-quick-group() => { root.qcg-orig = ""; root.qcg-name = ""; root.qcg-open = true; }
-                    rename-quick-group(g) => { root.qcg-orig = g; root.qcg-name = g; root.qcg-open = true; }
-                    delete-quick-group(g) => { root.delete-quick-group(g); }
-                    send-key(key, ctrl, alt, shift) => { root.send-key(term.id, key, ctrl, alt, shift) }
-                    diagnose-key-event(key, control, meta, alt, shift) => {
-                        root.diagnose-key-event(term.id, key, control, meta, alt, shift);
-                    }
-                    cycle-tab(reverse) => { root.cycle-tab(reverse); }
-                    terminal-resize(w, h) => { root.terminal-resize(term.id, w, h) }
-                    sftp-navigate(path) => { root.sftp-navigate(term.id, path); }
-                    sftp-download(path) => { root.sftp-download(term.id, path); }
-                    sftp-upload-clicked(dir, folder) => { root.sftp-upload-clicked(term.id, dir, folder); }
-                    sftp-refresh(path) => { root.sftp-refresh(term.id, path); }
-                    sftp-tree-expand(path) => { root.sftp-tree-expand(term.id, path); }
-                    sftp-toggle-select(i) => { root.sftp-toggle-select(term.id, i); }
-                    sftp-download-selected() => { root.sftp-download-selected(term.id); }
-                    sftp-copy-to-target(path, target) => { root.sftp-copy-to-target(term.id, path, target); }
-                    sftp-copy-selected-to-target(target) => { root.sftp-copy-selected-to-target(term.id, target); }
-                    // Confirm before deleting the checked entries (#100), reusing
-                    // the delete-confirm dialog in batch mode.
-                    sftp-delete-selected() => {
-                        root.confirm-delete-tab = term.id;
-                        root.confirm-delete-batch = true;
-                        root.confirm-delete-path = root.lang-en ? "the selected items" : "选中的项目";
-                        root.confirm-delete-open = true;
-                    }
-                    // Gate delete behind an in-app confirmation (#28): stash the
-                    // target and open the modal; the real delete fires on confirm.
-                    sftp-delete(path) => {
-                        root.confirm-delete-tab = term.id;
-                        root.confirm-delete-path = path;
-                        root.confirm-delete-open = true;
-                    }
-                    sftp-view(path) => { root.sftp-view(term.id, path); }
-                    sftp-edit(path) => { root.sftp-edit(term.id, path); }
-                    sftp-open-external(path) => { root.sftp-open-external(term.id, path); }
-                    sftp-edit-external(path) => { root.sftp-edit-external(term.id, path); }
-                    sftp-sort-request(key) => { root.sftp-sort-request(term.id, key); }
-                    sftp-clear-sort() => { root.sftp-clear-sort(term.id); }
-                    tunnel-add(name, kind, bind, bind-port, host, host-port) => {
-                        root.tunnel-add(term.id, name, kind, bind, bind-port, host, host-port);
-                    }
-                    tunnel-stop(id) => { root.tunnel-stop(term.id, id); }
-                    // #69 context-menu extensions → shared prompt dialog.
-                    sftp-rename-request(path, name) => {
-                        root.sftp-prompt-kind = "rename";
-                        root.sftp-prompt-tab = term.id;
-                        root.sftp-prompt-target = path;
-                        root.sftp-prompt-value = name;
-                        root.sftp-prompt-open = true;
-                    }
-                    sftp-chmod-request(path, name, mode) => {
-                        root.sftp-chmod-open(term.id, path, name, mode);
-                    }
-                    sftp-copy-path(path) => { root.sftp-copy-path(path); }
-                    sftp-new-folder(dir) => {
-                        root.sftp-prompt-kind = "mkdir";
-                        root.sftp-prompt-tab = term.id;
-                        root.sftp-prompt-target = dir;
-                        root.sftp-prompt-value = "";
-                        root.sftp-prompt-open = true;
-                    }
-                    sftp-new-file(dir) => {
-                        root.sftp-prompt-kind = "touch";
-                        root.sftp-prompt-tab = term.id;
-                        root.sftp-prompt-target = dir;
-                        root.sftp-prompt-value = "";
-                        root.sftp-prompt-open = true;
-                    }
-                    paste-from-clipboard() => { root.paste-from-clipboard(term.id); }
-                    copy-terminal-text() => { root.copy-terminal-text(term.id); }
-                    clear-terminal() => { root.clear-terminal(term.id); }
-                    find-query-changed(q) => { root.find-query-changed(term.id, q); }
-                    terminal-scroll(d) => { root.terminal-scroll(term.id, d); }
-                    terminal-wheel(d, c, r) => { root.terminal-wheel(term.id, d, c, r); }
-                    terminal-scroll-to(o) => { root.terminal-scroll-to(term.id, o); }
-                    select-start(r, c, ctrl, shift) => { root.term-select-start(term.id, r, c, ctrl, shift); }
-                    select-update(r, c) => { root.term-select-update(term.id, r, c); }
-                    select-end() => { root.term-select-end(term.id); }
-                    select-word(r, c) => { root.term-select-word(term.id, r, c); }
-                    select-autoscroll(dir) => { root.term-select-autoscroll(term.id, dir); }
-                }
-
-                // Windows may show the terminal model being reconstructed when
-                // restoring from minimize (#183). Briefly cover the terminal area
-                // until the restore repaint settles; the underlying PTY/buffer is
-                // untouched.
-                if root.terminal-restore-cover && pane.active-id != "welcome" && pane.tabs.length > 0 : Rectangle {
-                    width: parent.width;
-                    height: parent.height;
-                    background: Theme.term-bg;
-                }
-            }
-            }
-            }
-
-            // Draggable splitters between panes. Single pane => the model is
-            // empty, so this renders nothing. The handle is a thin 6px bar but its
-            // TouchArea reaches ±5px beyond so it's easy to grab.
-            for sp[si] in root.splitters : Rectangle {
-                x: sp.x; y: sp.y; width: sp.w; height: sp.h;
-                // A tab dropped on a pane boundary leaves the pointer hovering
-                // over this splitter. Highlight only while the splitter itself
-                // is being dragged, otherwise that hover looks like a stuck
-                // full-height tab insertion caret.
-                background: sp-ta.pressed ? Theme.accent : Theme.border-strong;
-                animate background { duration: 100ms; }
-                sp-ta := TouchArea {
-                    x: sp.vertical ? -5px : 0px;
-                    y: sp.vertical ? 0px : -5px;
-                    width: sp.vertical ? parent.width + 10px : parent.width;
-                    height: sp.vertical ? parent.height : parent.height + 10px;
-                    mouse-cursor: sp.vertical ? ew-resize : ns-resize;
                     moved => {
-                        if (self.pressed) {
-                            root.splitter-drag(sp.split-id,
-                                sp.vertical ? sp.x - 5px + self.mouse-x
-                                            : sp.y - 5px + self.mouse-y,
-                                sp.vertical);
+                        if (dock-area.welcome-sidebar-dragging) {
+                            if (dock-area.welcome-horizontal) {
+                                root.welcome-sidebar-width = clamp(
+                                    root.welcome-sidebar-dock == "right"
+                                        ? dock-area.absolute-position.x + dock-area.width
+                                            - (self.absolute-position.x + self.mouse-x)
+                                        : self.absolute-position.x + self.mouse-x
+                                            - dock-area.absolute-position.x,
+                                    160px, 480px);
+                            } else {
+                                root.welcome-sidebar-width = clamp(
+                                    root.welcome-sidebar-dock == "bottom"
+                                        ? dock-area.absolute-position.y + dock-area.height
+                                            - (self.absolute-position.y + self.mouse-y)
+                                        : self.absolute-position.y + self.mouse-y
+                                            - dock-area.absolute-position.y,
+                                    120px, 360px);
+                            }
                         }
                     }
                 }
             }
 
-            // Drag-to-split drop-zone highlight (v0.5). Purely visual (no
-            // TouchArea) so it never eats the drag; Rust sets the rect.
-            if root.drag-active : Rectangle {
-                x: root.drag-hl-x;
-                y: root.drag-hl-y;
-                width: root.drag-hl-w;
-                height: root.drag-hl-h;
-                background: Theme.accent.with-alpha(0.22);
-                border-width: 2px;
-                border-color: Theme.accent;
-                border-radius: Theme.radius-sm;
-            }
-            }
-        }
+            // Everything except the welcome strip/sidebar — the resource panel,
+            // splitter and the central tab/pane content — sits to the right of them.
+            rest := Rectangle {
+            x: (root.welcome-sidebar-dock == "left" ? parent.welcome-taken : 0px)
+                + parent.quick-left;
+            y: (root.welcome-sidebar-dock == "top" ? parent.welcome-taken : 0px)
+                + parent.quick-top;
+            width: parent.width
+                - (parent.welcome-horizontal ? parent.welcome-taken : 0px)
+                - parent.quick-left - parent.quick-right;
+            height: parent.height
+                - (!parent.welcome-horizontal ? parent.welcome-taken : 0px)
+                - parent.quick-top - parent.quick-bottom;
+            // A shared ToolStrip is already reserved outside `rest` while the
+            // welcome panel is expanded, or by the merged welcome strip while both
+            // panels are collapsed. Do not reserve the same 36px a second time.
+            property <length> sb-w: root.zen-mode ? 0px
+                : dock-area.sidebar-strip-outside
+                    || dock-area.combine-collapsed-tools ? 0px
+                : root.sidebar-collapsed ? 36px : root.sidebar-width;
+            property <length> sb-h: root.zen-mode ? 0px
+                : dock-area.sidebar-strip-outside
+                    || dock-area.combine-collapsed-tools ? 0px
+                : root.sidebar-collapsed ? 36px : root.sidebar-height;
+            property <length> sp: root.zen-mode || root.sidebar-collapsed ? 0px : 4px;
+            // The collapsed bar (sb-h) already reserves the bottom strip now.
+            property <length> bottom-strip-h: 0px;
 
-        if root.quick-panel-open && !root.quick-panel-collapsed : QuickDockPanel {
-            x: root.quick-panel-dock == "right" ? parent.width - parent.quick-w : 0px;
-            y: root.quick-panel-dock == "bottom" ? parent.height - parent.quick-h : 0px;
-            width: parent.quick-horizontal ? parent.quick-w : parent.width;
-            height: parent.quick-horizontal ? parent.height : parent.quick-h;
-            commands: root.quick-commands;
-            dock-edge: root.quick-panel-dock;
-            activate(command, send-enter) => {
-                root.quick-external-command = command;
-                root.quick-external-send-enter = send-enter;
-                root.quick-external-sequence += 1;
-            }
-            toggle-group(group) => { root.toggle-quick-group(group); }
-            manage => {
-                root.qcm-name = "";
-                root.qcm-command = "";
-                root.qcm-group = "";
-                root.qcm-edit-index = -1;
-                root.quick-cmd-manage-open = true;
-            }
-            close => { root.quick-panel-collapsed = true; }
-            dock-drag-move(ax, ay) => {
-                root.panel-dragging = true;
-                root.drag-nx = (ax - dock-area.absolute-position.x) / dock-area.width;
-                root.drag-ny = (ay - dock-area.absolute-position.y) / dock-area.height;
-            }
-            dock-drag-end => {
-                if (root.dock-target != "") {
-                    root.quick-panel-dock = root.dock-target;
-                    if (root.sidebar-dock == root.dock-target) {
-                        root.sidebar-collapsed = true;
-                        root.set-sidebar-collapsed(true);
+            // Left sidebar — collapsible and drag-resizable, dockable to any edge.
+            // Only shown while expanded; collapsing swaps it for the ToolStrip icon
+            // bar below (mirrors the welcome sidebar), so no clipped widgets bleed
+            // through the 36px strip (#resource-collapse).
+            if !root.sidebar-collapsed : Rectangle {
+                x: root.sidebar-dock == "right" ? parent.width - parent.sb-w
+                 : 0px;
+                y: root.sidebar-dock == "bottom" ? parent.height - parent.sb-h
+                 : 0px;
+                width: root.sidebar-horizontal ? parent.sb-w : parent.width;
+                height: root.sidebar-horizontal ? parent.height : parent.sb-h;
+                clip: true;
+                Sidebar {
+                width: parent.width;
+                height: parent.height;
+                // Docked top/bottom → lay the resource widgets out in a row.
+                lay-horizontal: !root.sidebar-horizontal;
+                dock-edge: root.sidebar-dock;
+                animate width, height { duration: root.sidebar-dragging ? 0ms : 150ms; easing: ease-out; }
+                connection-state: root.connection-state;
+                conn-host: root.conn-host;
+                conn-state: root.conn-state;
+                resource-title: root.resource-title;
+                cpu-percent: root.cpu-percent;
+                mem-percent: root.mem-percent;
+                swap-percent: root.swap-percent;
+                mem-detail: root.mem-detail;
+                swap-detail: root.swap-detail;
+                net-top-up: root.net-top-up;
+                net-top-down: root.net-top-down;
+                net-top-history: root.net-top-history;
+                net-bot-up: root.net-bot-up;
+                net-bot-down: root.net-bot-down;
+                net-bot-history: root.net-bot-history;
+                net-ifaces: root.net-ifaces;
+                net-selected: root.net-selected;
+                net-show-selector: root.net-show-selector;
+                disks: root.disks;
+                system-info-available: root.system-info-available;
+                proc-available: root.proc-available;
+                app-version: root.app-version;
+                select-net-iface(i) => { root.select-net-iface(i); }
+                show-system-info() => { root.open-system-info(); }
+                show-processes() => { root.open-processes(); }
+                copy-host(h) => { root.copy-text(h); }   // reuse the clipboard helper (#192)
+                // Drag the sidebar header to dock it to another edge. Coordinates
+                // arrive in window space; convert to dock-area-relative fractions.
+                dock-drag-move(ax, ay) => {
+                    root.panel-dragging = true;
+                    root.drag-nx = (ax - dock-area.absolute-position.x) / dock-area.width;
+                    root.drag-ny = (ay - dock-area.absolute-position.y) / dock-area.height;
+                }
+                dock-drag-end() => {
+                    if (root.dock-target != "") {
+                        root.sidebar-dock = root.dock-target;
+                        if (root.welcome-as-sidebar && root.welcome-sidebar-dock == root.dock-target) {
+                            root.welcome-collapsed = true;
+                            root.set-welcome-collapsed(true);
+                        }
+                        if (root.quick-panel-open && root.quick-panel-dock == root.dock-target) {
+                            root.quick-panel-collapsed = true;
+                        }
+                        root.persist-sidebar-dock(root.sidebar-dock);
                     }
-                    if (root.welcome-as-sidebar
-                            && root.welcome-sidebar-dock == root.dock-target) {
+                    root.panel-dragging = false;
+                }
+                toggle-collapse() => {
+                    root.sidebar-collapsed = !root.sidebar-collapsed;
+                    root.set-sidebar-collapsed(root.sidebar-collapsed);
+                }
+                }
+            }
+
+            // Collapsed resource panel → a ToolStrip icon bar at the same docked edge
+            // (M5), in place of the old floating expand button.
+            if root.sidebar-collapsed && !dock-area.combine-collapsed-tools && !dock-area.sidebar-strip-outside : ToolStrip {
+                x: root.sidebar-dock == "right" ? parent.width - parent.sb-w : 0px;
+                y: root.sidebar-dock == "bottom" ? parent.height - parent.sb-h : 0px;
+                width: root.sidebar-horizontal ? parent.sb-w : parent.width;
+                height: root.sidebar-horizontal ? parent.height : parent.sb-h;
+                dock-edge: root.sidebar-dock;
+                glyph: "\u{E871}";   // dashboard — resource panel
+                show-second: dock-area.quick-merge-sidebar;
+                second-glyph: "\u{E3E7}";
+                expand => {
+                    root.sidebar-collapsed = false;
+                    root.set-sidebar-collapsed(false);
+                    if (root.welcome-as-sidebar && root.welcome-sidebar-dock == root.sidebar-dock) {
                         root.welcome-collapsed = true;
                         root.set-welcome-collapsed(true);
                     }
+                    if (root.quick-panel-open && root.quick-panel-dock == root.sidebar-dock) {
+                        root.quick-panel-collapsed = true;
+                    }
                 }
-                root.panel-dragging = false;
+                expand-second => { root.quick-panel-collapsed = false; }
             }
-        }
 
-        Rectangle {
-            visible: root.quick-panel-open && !root.quick-panel-collapsed;
-            x: root.quick-panel-dock == "left" ? parent.quick-w
-             : root.quick-panel-dock == "right" ? parent.width - parent.quick-w - 4px
-             : 0px;
-            y: root.quick-panel-dock == "top" ? parent.quick-h
-             : root.quick-panel-dock == "bottom" ? parent.height - parent.quick-h - 4px
-             : 0px;
-            width: parent.quick-horizontal ? 4px : parent.width;
-            height: parent.quick-horizontal ? parent.height : 4px;
-            background: quick-split-ta.has-hover ? Theme.accent : Theme.border-subtle;
-            quick-split-ta := TouchArea {
-                x: quick-area.quick-horizontal ? -4px : 0px;
-                y: quick-area.quick-horizontal ? 0px : -4px;
-                width: quick-area.quick-horizontal ? 12px : parent.width;
-                height: quick-area.quick-horizontal ? parent.height : 12px;
-                mouse-cursor: quick-area.quick-horizontal ? ew-resize : ns-resize;
-                moved => {
-                    if (self.pressed) {
-                        if (quick-area.quick-horizontal) {
-                            root.quick-panel-width = clamp(
-                                root.quick-panel-dock == "right"
-                                    ? quick-area.width - ((self.absolute-position.x + self.mouse-x)
-                                        - quick-area.absolute-position.x)
-                                    : (self.absolute-position.x + self.mouse-x)
-                                        - quick-area.absolute-position.x,
-                                180px, max(200px, quick-area.width - 240px));
-                        } else {
-                            root.quick-panel-height = clamp(
-                                root.quick-panel-dock == "bottom"
-                                    ? quick-area.height - ((self.absolute-position.y + self.mouse-y)
-                                        - quick-area.absolute-position.y)
-                                    : (self.absolute-position.y + self.mouse-y)
-                                        - quick-area.absolute-position.y,
-                                120px, max(140px, quick-area.height - 160px));
+            // Splitter — drag to resize the sidebar. Orientation + which dimension it
+            // adjusts follow the dock edge. Hidden while collapsed.
+            Rectangle {
+                visible: !root.sidebar-collapsed;
+                // Horizontal docks → a vertical 4px bar at the sidebar's inner edge;
+                // vertical docks → a horizontal 4px bar.
+                x: root.sidebar-dock == "left"   ? parent.sb-w
+                 : root.sidebar-dock == "right"  ? parent.width - parent.sb-w - 4px
+                 : 0px;
+                y: root.sidebar-dock == "top"    ? parent.sb-h
+                 : root.sidebar-dock == "bottom" ? parent.height - parent.sb-h - 4px
+                 : 0px;
+                width:  root.sidebar-horizontal ? 4px : parent.width;
+                height: root.sidebar-horizontal ? parent.height : 4px;
+                background: sb-split-ta.has-hover || root.sidebar-dragging
+                    ? Theme.accent
+                    : Theme.border-subtle;
+                sb-split-ta := TouchArea {
+                    mouse-cursor: root.sidebar-horizontal ? ew-resize : ns-resize;
+                    pointer-event(ev) => {
+                        if (ev.kind == PointerEventKind.down) {
+                            root.sidebar-dragging = true;
+                        } else if (ev.kind == PointerEventKind.up) {
+                            root.sidebar-dragging = false;
+                            root.persist-sidebar-width(root.sidebar-width / 1px);
+                        }
+                    }
+                    moved => {
+                        if (root.sidebar-dragging) {
+                            if (root.sidebar-horizontal) {
+                                // Track the cursor in stable dock-area coordinates.
+                                // The splitter moves while resizing, so adding local
+                                // mouse deltas to the current width feeds the movement
+                                // back into itself and can suddenly widen the panel
+                                // on Win10 (#244).
+                                root.sidebar-width = clamp(
+                                    root.sidebar-dock == "right"
+                                        ? dock-area.absolute-position.x + dock-area.width
+                                            - (self.absolute-position.x + self.mouse-x)
+                                        : (self.absolute-position.x + self.mouse-x)
+                                            - dock-area.absolute-position.x,
+                                    160px, 520px);
+                            } else {
+                                root.sidebar-height = clamp(
+                                    root.sidebar-dock == "bottom"
+                                        ? dock-area.absolute-position.y + dock-area.height
+                                            - (self.absolute-position.y + self.mouse-y)
+                                        : (self.absolute-position.y + self.mouse-y)
+                                            - dock-area.absolute-position.y,
+                                    120px, 480px);
+                            }
                         }
                     }
                 }
             }
-        }
-        }
-        }
 
-        // (Resource collapse now uses a ToolStrip inside `rest`, above.)
+            // Right side: tabs + content — positioned in the rect left after the
+            // sidebar is carved off its docked edge. Clipped so the terminal / SFTP
+            // panel can never bleed (visually or for clicks) onto a panel docked on
+            // the bottom or right (#dock).
+            quick-area := Rectangle {
+                x: root.sidebar-dock == "left" ? parent.sb-w + parent.sp : 0px;
+                y: root.sidebar-dock == "top"  ? parent.sb-h + parent.sp : 0px;
+                width:  root.sidebar-horizontal ? parent.width - parent.sb-w - parent.sp : parent.width;
+                height: root.sidebar-horizontal ? parent.height : parent.height - parent.sb-h - parent.sp - parent.bottom-strip-h;
+                clip: true;
+                property <bool> quick-horizontal:
+                    root.quick-panel-dock == "left" || root.quick-panel-dock == "right";
+                property <length> quick-w:
+                    !root.zen-mode && root.quick-panel-open && !root.quick-panel-collapsed ? root.quick-panel-width : 0px;
+                property <length> quick-h:
+                    !root.zen-mode && root.quick-panel-open && !root.quick-panel-collapsed ? root.quick-panel-height : 0px;
+                property <length> quick-sp:
+                    !root.zen-mode && root.quick-panel-open && !root.quick-panel-collapsed ? 4px : 0px;
 
-        // Drag-to-dock snap overlay — four edge zones; the one under the cursor
-        // (root.dock-target) lights up. Purely visual (no TouchArea) so the
-        // header's drag keeps receiving move events (#dock).
-        if root.panel-dragging : Rectangle {
-            x: 0; y: 0;
-            width: parent.width;
-            height: parent.height;
-            Rectangle {   // left zone
-                x: 0; y: 0; width: parent.width * 0.22; height: parent.height;
-                background: root.dock-target == "left"
-                    ? Theme.accent.with-alpha(0.35) : Theme.accent.with-alpha(0.10);
-                border-width: root.dock-target == "left" ? 2px : 0px;
-                border-color: Theme.accent;
+                central := Rectangle {
+                x: root.quick-panel-open && !root.quick-panel-collapsed && root.quick-panel-dock == "left"
+                    ? parent.quick-w + parent.quick-sp : 0px;
+                y: root.quick-panel-open && !root.quick-panel-collapsed && root.quick-panel-dock == "top"
+                    ? parent.quick-h + parent.quick-sp : 0px;
+                width: root.quick-panel-open && !root.quick-panel-collapsed && parent.quick-horizontal
+                    ? parent.width - parent.quick-w - parent.quick-sp : parent.width;
+                height: root.quick-panel-open && !root.quick-panel-collapsed && !parent.quick-horizontal
+                    ? parent.height - parent.quick-h - parent.quick-sp : parent.height;
+                clip: true;
+                // Split-pane area (v0.5): panes tile this rect; each pane has its own
+                // tab strip + active terminal / welcome. Rust flattens the split tree
+                // into `panes` for the size we report here.
+                pane-area := Rectangle {
+                    width: parent.width;
+                    height: parent.height;
+                    changed width => { root.content-resized(self.width, self.height); }
+                    changed height => { root.content-resized(self.width, self.height); }
+                for pane[pi] in root.panes : Rectangle {
+                    x: pane.x; y: pane.y; width: pane.w; height: pane.h;
+                    clip: true;
+                    VerticalLayout {
+                    spacing: 0;
+
+                    HorizontalLayout {
+                    spacing: 0;
+                    // (Collapsed resource panel now reserves its own ToolStrip slot in
+                    // `rest`, so the tab strip no longer needs a spacer for it.)
+                    TabBar {
+                        horizontal-stretch: 1;
+                        // Reserve room for the top-right toolbar icons that sit over
+                        // this row so tabs don't slide underneath them (#122).
+                        reserve-right: pane.reserve-right;
+                        show-new-tab: !root.welcome-as-sidebar;
+                        can-merge-pane: root.panes.length > 1;
+                        tabs: pane.tabs;
+                        active-id: pane.active-id;
+                        tab-selected(id) => { root.pane-tab-selected(pane.id, id); }
+                        tab-closed(id) => { root.pane-tab-closed(pane.id, id); }
+                        new-tab() => { root.pane-new-tab(pane.id); }
+                        tab-reorder(from-index, direction) => {
+                            root.pane-tab-reorder(pane.id, from-index, direction);
+                        }
+                        tab-split(id, dir) => { root.pane-split(pane.id, id, dir); }
+                        merge-pane() => { root.pane-merge(pane.id); }
+                        tab-duplicate(id) => { root.tab-duplicate(id); }
+                        tab-drag-move(id, ax, ay) => {
+                            root.tab-drag-move(id,
+                                ax - pane-area.absolute-position.x,
+                                ay - pane-area.absolute-position.y);
+                        }
+                        tab-drag-drop(id, ax, ay) => {
+                            root.tab-drag-drop(id,
+                                ax - pane-area.absolute-position.x,
+                                ay - pane-area.absolute-position.y);
+                        }
+                    }
+                }
+
+                // Content area swaps based on active tab kind.
+                Rectangle {
+                    vertical-stretch: 1;
+                    background: Theme.bg-root;
+
+                    // Empty pane outside welcome-sidebar mode: keep a small hint for
+                    // rare empty panes, but do not cover the wallpaper when the
+                    // session list is already visible as a sidebar.
+                    if pane.tabs.length == 0 && !root.welcome-as-sidebar : Rectangle {
+                        width: parent.width;
+                        height: parent.height;
+                        Text {
+                            text: root.lang-en
+                                ? "Pick a session on the left to begin"
+                                : "从左侧选择一个会话开始";
+                            color: Theme.text-muted;
+                            font-size: Theme.fs-sm;
+                            horizontal-alignment: center;
+                            vertical-alignment: center;
+                        }
+                    }
+
+                    // Welcome tab — fill the content area explicitly (some renderers
+                    // don't auto-fill, which spread the header/card apart) (#dock).
+                    if pane.active-id == "welcome" : Welcome {
+                        width: parent.width;
+                        height: parent.height;
+                        sessions: root.sessions;
+                        import-hint: root.ssh-import-hint;
+                        search-query <=> root.host-search-query;
+                        search-changed(query) => { root.host-search-changed(query); }
+                        new-session => { root.new-session-clicked(); }
+                        import-ssh-config => { root.import-ssh-config(); }
+                        connect-session(id) => { root.connect-session(id); }
+                        edit-session(id) => { root.edit-session(id); }
+                        duplicate-session(id) => { root.duplicate-session(id); }
+                        move-session(id, group) => { root.move-session(id, group); }
+                        toggle-group(group) => { root.toggle-group(group); }
+                        new-group => {
+                            root.group-dialog-orig = "";
+                            root.group-dialog-name = "";
+                            root.group-dialog-error = "";
+                            root.group-dialog-open = true;
+                        }
+                        edit-group(name) => {
+                            root.group-dialog-orig = name;
+                            root.group-dialog-name = name;
+                            root.group-dialog-error = "";
+                            root.group-dialog-open = true;
+                        }
+                        delete-group(name) => { root.delete-group(name); }
+                        remove-session(id) => { root.remove-session(id); }
+                        cycle-tab(reverse) => { root.cycle-tab(reverse); }
+                    }
+
+                    // Terminal tabs — one TerminalView per terminal state. Only
+                    // the one matching `active-tab-id` is visible. Slint doesn't
+                    // allow nesting `if` directly inside a `for`, so we toggle
+                    // visibility instead and rely on the layout to overlap them.
+                    for term[i] in root.terminals : TerminalView {
+                        visible: term.id == pane.active-id;
+                        active: term.id == root.active-tab-id;
+                        zen-mode: root.zen-mode;
+                        width: term.id == pane.active-id ? parent.width : 0px;
+                        height: term.id == pane.active-id ? parent.height : 0px;
+                        tab-id: term.id;
+                        status-line: term.status;
+                        spans: term.spans;
+                        cursor-row: term.cursor-row;
+                        cursor-col: term.cursor-col;
+                        cursor-style: root.term-cursor-style;
+                        cursor-color: root.term-cursor-color;
+                        terminal-line-spacing: root.terminal-line-spacing;
+                        extra-paste-shortcuts-enabled: root.extra-paste-shortcuts-enabled;
+                        rows-used: term.rows-used;
+                        scroll-max: term.scroll-max;
+                        scroll-offset: term.scroll-offset;
+                        is-alt-screen: term.is-alt-screen;
+                        find-matches: term.find-matches;
+                        selection: term.selection;
+                        sftp-panel-height: term.sftp-panel-height;
+                        set-sftp-panel-height(v) => { root.set-pane-sftp-height(term.id, v); }
+                        sftp-panel-width: term.sftp-panel-width;
+                        set-sftp-panel-width(v) => { root.set-pane-sftp-width(term.id, v); }
+                        sftp-dock <=> root.sftp-dock;
+                        sftp-collapsed: term.sftp-collapsed;
+                        set-sftp-collapsed(v) => { root.set-pane-sftp-collapsed(term.id, v); }
+                        sftp-saved-height: term.sftp-saved-height;
+                        set-sftp-saved-height(v) => { root.set-pane-sftp-saved-height(term.id, v); }
+                        sftp-tree-width: root.sftp-tree-width;
+                        persist-sftp-tree-width(v) => { root.persist-sftp-tree-width(v); }
+                        sftp-path: term.sftp-path;
+                        sftp-entries: term.sftp-entries;
+                        sftp-status: term.sftp-status;
+                        sftp-loading: term.sftp-loading;
+                        sftp-tree-nodes: term.sftp-tree-nodes;
+                        sftp-transfer-targets: root.tabs;
+                        sftp-selected-count: term.sftp-selected-count;
+                        sftp-sort-key: term.sftp-sort-key;
+                        sftp-sort-dir: term.sftp-sort-dir;
+                        sftp-available: term.sftp-available && !root.zen-mode;
+                        tunnels: term.tunnels;
+                        quick-commands: root.quick-commands;
+                        quick-sidebar-enabled: root.quick-commands-as-sidebar;
+                        quick-panel-docked: root.quick-panel-open;
+                        quick-external-command: root.quick-external-command;
+                        quick-external-send-enter: root.quick-external-send-enter;
+                        quick-external-sequence: root.quick-external-sequence;
+                        command-history: root.command-history;
+                        history-view: root.history-view;
+                        run-command(cmd, all) => { root.run-command(term.id, cmd, all); }
+                        copy-text(t) => { root.copy-text(t); }
+                        delete-history(i) => { root.delete-history(i); }
+                        delete-history-cmd(c) => { root.delete-history-cmd(c); }
+                        search-history(q) => { root.search-history(q); }
+                        manage-quick-commands() => {
+                            root.qcm-name = "";
+                            root.qcm-command = "";
+                            root.qcm-group = "";
+                            root.qcm-edit-index = -1;
+                            root.quick-cmd-manage-open = true;
+                        }
+                        quick-dock-drag-move(ax, ay) => {
+                            root.panel-dragging = true;
+                            root.drag-nx = (ax - dock-area.absolute-position.x) / dock-area.width;
+                            root.drag-ny = (ay - dock-area.absolute-position.y) / dock-area.height;
+                        }
+                        quick-dock-drag-end() => {
+                            if (root.dock-target != "") {
+                                root.quick-panel-dock = root.dock-target;
+                                root.quick-panel-open = true;
+                                root.quick-panel-collapsed = false;
+                                if (root.sidebar-dock == root.dock-target) {
+                                    root.sidebar-collapsed = true;
+                                    root.set-sidebar-collapsed(true);
+                                }
+                                if (root.welcome-as-sidebar
+                                        && root.welcome-sidebar-dock == root.dock-target) {
+                                    root.welcome-collapsed = true;
+                                    root.set-welcome-collapsed(true);
+                                }
+                            }
+                            root.panel-dragging = false;
+                        }
+                        toggle-quick-group(g) => { root.toggle-quick-group(g); }
+                        edit-quick-command(i) => { root.edit-quick-command(i); }
+                        duplicate-quick-command(i) => { root.duplicate-quick-command(i); }
+                        delete-quick-command(i) => { root.delete-quick-command(i); }
+                        move-quick-command(i, g) => { root.move-quick-command(i, g); }
+                        new-quick-group() => { root.qcg-orig = ""; root.qcg-name = ""; root.qcg-open = true; }
+                        rename-quick-group(g) => { root.qcg-orig = g; root.qcg-name = g; root.qcg-open = true; }
+                        delete-quick-group(g) => { root.delete-quick-group(g); }
+                        send-key(key, ctrl, alt, shift) => { root.send-key(term.id, key, ctrl, alt, shift) }
+                        diagnose-key-event(key, control, meta, alt, shift) => {
+                            root.diagnose-key-event(term.id, key, control, meta, alt, shift);
+                        }
+                        cycle-tab(reverse) => { root.cycle-tab(reverse); }
+                        new-window-key() => { root.new-window-clicked(); }
+                        zoom-key(direction) => { root.zoom-term-font(direction); }
+                        terminal-resize(w, h) => { root.terminal-resize(term.id, w, h) }
+                        sftp-navigate(path) => { root.sftp-navigate(term.id, path); }
+                        sftp-download(path) => { root.sftp-download(term.id, path); }
+                        sftp-upload-clicked(dir, folder) => { root.sftp-upload-clicked(term.id, dir, folder); }
+                        sftp-refresh(path) => { root.sftp-refresh(term.id, path); }
+                        sftp-tree-expand(path) => { root.sftp-tree-expand(term.id, path); }
+                        sftp-toggle-select(i) => { root.sftp-toggle-select(term.id, i); }
+                        sftp-download-selected() => { root.sftp-download-selected(term.id); }
+                        sftp-copy-to-target(path, target) => { root.sftp-copy-to-target(term.id, path, target); }
+                        sftp-copy-selected-to-target(target) => { root.sftp-copy-selected-to-target(term.id, target); }
+                        // Confirm before deleting the checked entries (#100), reusing
+                        // the delete-confirm dialog in batch mode.
+                        sftp-delete-selected() => {
+                            root.confirm-delete-tab = term.id;
+                            root.confirm-delete-batch = true;
+                            root.confirm-delete-path = root.lang-en ? "the selected items" : "选中的项目";
+                            root.confirm-delete-open = true;
+                        }
+                        // Gate delete behind an in-app confirmation (#28): stash the
+                        // target and open the modal; the real delete fires on confirm.
+                        sftp-delete(path) => {
+                            root.confirm-delete-tab = term.id;
+                            root.confirm-delete-path = path;
+                            root.confirm-delete-open = true;
+                        }
+                        sftp-view(path) => { root.sftp-view(term.id, path); }
+                        sftp-edit(path) => { root.sftp-edit(term.id, path); }
+                        sftp-open-external(path) => { root.sftp-open-external(term.id, path); }
+                        sftp-edit-external(path) => { root.sftp-edit-external(term.id, path); }
+                        sftp-sort-request(key) => { root.sftp-sort-request(term.id, key); }
+                        sftp-clear-sort() => { root.sftp-clear-sort(term.id); }
+                        tunnel-add(name, kind, bind, bind-port, host, host-port) => {
+                            root.tunnel-add(term.id, name, kind, bind, bind-port, host, host-port);
+                        }
+                        tunnel-stop(id) => { root.tunnel-stop(term.id, id); }
+                        // #69 context-menu extensions → shared prompt dialog.
+                        sftp-rename-request(path, name) => {
+                            root.sftp-prompt-kind = "rename";
+                            root.sftp-prompt-tab = term.id;
+                            root.sftp-prompt-target = path;
+                            root.sftp-prompt-value = name;
+                            root.sftp-prompt-open = true;
+                        }
+                        sftp-chmod-request(path, name, mode) => {
+                            root.sftp-chmod-open(term.id, path, name, mode);
+                        }
+                        sftp-copy-path(path) => { root.sftp-copy-path(path); }
+                        sftp-new-folder(dir) => {
+                            root.sftp-prompt-kind = "mkdir";
+                            root.sftp-prompt-tab = term.id;
+                            root.sftp-prompt-target = dir;
+                            root.sftp-prompt-value = "";
+                            root.sftp-prompt-open = true;
+                        }
+                        sftp-new-file(dir) => {
+                            root.sftp-prompt-kind = "touch";
+                            root.sftp-prompt-tab = term.id;
+                            root.sftp-prompt-target = dir;
+                            root.sftp-prompt-value = "";
+                            root.sftp-prompt-open = true;
+                        }
+                        paste-from-clipboard() => { root.paste-from-clipboard(term.id); }
+                        copy-terminal-text() => { root.copy-terminal-text(term.id); }
+                        clear-terminal() => { root.clear-terminal(term.id); }
+                        find-query-changed(q) => { root.find-query-changed(term.id, q); }
+                        terminal-scroll(d) => { root.terminal-scroll(term.id, d); }
+                        terminal-wheel(d, c, r) => { root.terminal-wheel(term.id, d, c, r); }
+                        terminal-scroll-to(o) => { root.terminal-scroll-to(term.id, o); }
+                        select-start(r, c, ctrl, shift) => { root.term-select-start(term.id, r, c, ctrl, shift); }
+                        select-update(r, c) => { root.term-select-update(term.id, r, c); }
+                        select-end() => { root.term-select-end(term.id); }
+                        select-word(r, c) => { root.term-select-word(term.id, r, c); }
+                        select-autoscroll(dir) => { root.term-select-autoscroll(term.id, dir); }
+                    }
+
+                    // Windows may show the terminal model being reconstructed when
+                    // restoring from minimize (#183). Briefly cover the terminal area
+                    // until the restore repaint settles; the underlying PTY/buffer is
+                    // untouched.
+                    if root.terminal-restore-cover && pane.active-id != "welcome" && pane.tabs.length > 0 : Rectangle {
+                        width: parent.width;
+                        height: parent.height;
+                        background: Theme.term-bg;
+                    }
+                }
+                }
+                }
+
+                // Draggable splitters between panes. Single pane => the model is
+                // empty, so this renders nothing. The handle is a thin 6px bar but its
+                // TouchArea reaches ±5px beyond so it's easy to grab.
+                for sp[si] in root.splitters : Rectangle {
+                    x: sp.x; y: sp.y; width: sp.w; height: sp.h;
+                    // A tab dropped on a pane boundary leaves the pointer hovering
+                    // over this splitter. Highlight only while the splitter itself
+                    // is being dragged, otherwise that hover looks like a stuck
+                    // full-height tab insertion caret.
+                    background: sp-ta.pressed ? Theme.accent : Theme.border-strong;
+                    animate background { duration: 100ms; }
+                    sp-ta := TouchArea {
+                        x: sp.vertical ? -5px : 0px;
+                        y: sp.vertical ? 0px : -5px;
+                        width: sp.vertical ? parent.width + 10px : parent.width;
+                        height: sp.vertical ? parent.height : parent.height + 10px;
+                        mouse-cursor: sp.vertical ? ew-resize : ns-resize;
+                        moved => {
+                            if (self.pressed) {
+                                root.splitter-drag(sp.split-id,
+                                    sp.vertical ? sp.x - 5px + self.mouse-x
+                                                : sp.y - 5px + self.mouse-y,
+                                    sp.vertical);
+                            }
+                        }
+                    }
+                }
+
+                // Drag-to-split drop-zone highlight (v0.5). Purely visual (no
+                // TouchArea) so it never eats the drag; Rust sets the rect.
+                if root.drag-active : Rectangle {
+                    x: root.drag-hl-x;
+                    y: root.drag-hl-y;
+                    width: root.drag-hl-w;
+                    height: root.drag-hl-h;
+                    background: Theme.accent.with-alpha(0.22);
+                    border-width: 2px;
+                    border-color: Theme.accent;
+                    border-radius: Theme.radius-sm;
+                }
+                }
             }
-            Rectangle {   // right zone
-                x: parent.width * 0.78; y: 0; width: parent.width * 0.22; height: parent.height;
-                background: root.dock-target == "right"
-                    ? Theme.accent.with-alpha(0.35) : Theme.accent.with-alpha(0.10);
-                border-width: root.dock-target == "right" ? 2px : 0px;
-                border-color: Theme.accent;
+
+            if root.quick-panel-open && !root.quick-panel-collapsed : QuickDockPanel {
+                x: root.quick-panel-dock == "right" ? parent.width - parent.quick-w : 0px;
+                y: root.quick-panel-dock == "bottom" ? parent.height - parent.quick-h : 0px;
+                width: parent.quick-horizontal ? parent.quick-w : parent.width;
+                height: parent.quick-horizontal ? parent.height : parent.quick-h;
+                commands: root.quick-commands;
+                dock-edge: root.quick-panel-dock;
+                activate(command, send-enter) => {
+                    root.quick-external-command = command;
+                    root.quick-external-send-enter = send-enter;
+                    root.quick-external-sequence += 1;
+                }
+                toggle-group(group) => { root.toggle-quick-group(group); }
+                manage => {
+                    root.qcm-name = "";
+                    root.qcm-command = "";
+                    root.qcm-group = "";
+                    root.qcm-edit-index = -1;
+                    root.quick-cmd-manage-open = true;
+                }
+                close => { root.quick-panel-collapsed = true; }
+                dock-drag-move(ax, ay) => {
+                    root.panel-dragging = true;
+                    root.drag-nx = (ax - dock-area.absolute-position.x) / dock-area.width;
+                    root.drag-ny = (ay - dock-area.absolute-position.y) / dock-area.height;
+                }
+                dock-drag-end => {
+                    if (root.dock-target != "") {
+                        root.quick-panel-dock = root.dock-target;
+                        if (root.sidebar-dock == root.dock-target) {
+                            root.sidebar-collapsed = true;
+                            root.set-sidebar-collapsed(true);
+                        }
+                        if (root.welcome-as-sidebar
+                                && root.welcome-sidebar-dock == root.dock-target) {
+                            root.welcome-collapsed = true;
+                            root.set-welcome-collapsed(true);
+                        }
+                    }
+                    root.panel-dragging = false;
+                }
             }
-            Rectangle {   // top zone
-                x: 0; y: 0; width: parent.width; height: parent.height * 0.22;
-                background: root.dock-target == "top"
-                    ? Theme.accent.with-alpha(0.35) : Theme.accent.with-alpha(0.10);
-                border-width: root.dock-target == "top" ? 2px : 0px;
-                border-color: Theme.accent;
+
+            Rectangle {
+                visible: root.quick-panel-open && !root.quick-panel-collapsed;
+                x: root.quick-panel-dock == "left" ? parent.quick-w
+                 : root.quick-panel-dock == "right" ? parent.width - parent.quick-w - 4px
+                 : 0px;
+                y: root.quick-panel-dock == "top" ? parent.quick-h
+                 : root.quick-panel-dock == "bottom" ? parent.height - parent.quick-h - 4px
+                 : 0px;
+                width: parent.quick-horizontal ? 4px : parent.width;
+                height: parent.quick-horizontal ? parent.height : 4px;
+                background: quick-split-ta.has-hover ? Theme.accent : Theme.border-subtle;
+                quick-split-ta := TouchArea {
+                    x: quick-area.quick-horizontal ? -4px : 0px;
+                    y: quick-area.quick-horizontal ? 0px : -4px;
+                    width: quick-area.quick-horizontal ? 12px : parent.width;
+                    height: quick-area.quick-horizontal ? parent.height : 12px;
+                    mouse-cursor: quick-area.quick-horizontal ? ew-resize : ns-resize;
+                    moved => {
+                        if (self.pressed) {
+                            if (quick-area.quick-horizontal) {
+                                root.quick-panel-width = clamp(
+                                    root.quick-panel-dock == "right"
+                                        ? quick-area.width - ((self.absolute-position.x + self.mouse-x)
+                                            - quick-area.absolute-position.x)
+                                        : (self.absolute-position.x + self.mouse-x)
+                                            - quick-area.absolute-position.x,
+                                    180px, max(200px, quick-area.width - 240px));
+                            } else {
+                                root.quick-panel-height = clamp(
+                                    root.quick-panel-dock == "bottom"
+                                        ? quick-area.height - ((self.absolute-position.y + self.mouse-y)
+                                            - quick-area.absolute-position.y)
+                                        : (self.absolute-position.y + self.mouse-y)
+                                            - quick-area.absolute-position.y,
+                                    120px, max(140px, quick-area.height - 160px));
+                            }
+                        }
+                    }
+                }
             }
-            Rectangle {   // bottom zone
-                x: 0; y: parent.height * 0.78; width: parent.width; height: parent.height * 0.22;
-                background: root.dock-target == "bottom"
-                    ? Theme.accent.with-alpha(0.35) : Theme.accent.with-alpha(0.10);
-                border-width: root.dock-target == "bottom" ? 2px : 0px;
-                border-color: Theme.accent;
+            }
+            }
+
+            // (Resource collapse now uses a ToolStrip inside `rest`, above.)
+
+            // Drag-to-dock snap overlay — four edge zones; the one under the cursor
+            // (root.dock-target) lights up. Purely visual (no TouchArea) so the
+            // header's drag keeps receiving move events (#dock).
+            if root.panel-dragging : Rectangle {
+                x: 0; y: 0;
+                width: parent.width;
+                height: parent.height;
+                Rectangle {   // left zone
+                    x: 0; y: 0; width: parent.width * 0.22; height: parent.height;
+                    background: root.dock-target == "left"
+                        ? Theme.accent.with-alpha(0.35) : Theme.accent.with-alpha(0.10);
+                    border-width: root.dock-target == "left" ? 2px : 0px;
+                    border-color: Theme.accent;
+                }
+                Rectangle {   // right zone
+                    x: parent.width * 0.78; y: 0; width: parent.width * 0.22; height: parent.height;
+                    background: root.dock-target == "right"
+                        ? Theme.accent.with-alpha(0.35) : Theme.accent.with-alpha(0.10);
+                    border-width: root.dock-target == "right" ? 2px : 0px;
+                    border-color: Theme.accent;
+                }
+                Rectangle {   // top zone
+                    x: 0; y: 0; width: parent.width; height: parent.height * 0.22;
+                    background: root.dock-target == "top"
+                        ? Theme.accent.with-alpha(0.35) : Theme.accent.with-alpha(0.10);
+                    border-width: root.dock-target == "top" ? 2px : 0px;
+                    border-color: Theme.accent;
+                }
+                Rectangle {   // bottom zone
+                    x: 0; y: parent.height * 0.78; width: parent.width; height: parent.height * 0.22;
+                    background: root.dock-target == "bottom"
+                        ? Theme.accent.with-alpha(0.35) : Theme.accent.with-alpha(0.10);
+                    border-width: root.dock-target == "bottom" ? 2px : 0px;
+                    border-color: Theme.accent;
+                }
             }
         }
-    }
+        }
     }
 
     // App toolbar icons (settings/download/theme/sync). They sit at the top-right
@@ -3577,12 +3627,20 @@ export component AppWindow inherits Window {
                 ShortcutRow { keys: root.is-mac ? "⌃⇧Tab" : "Ctrl+Shift+Tab"; desc: root.lang-en ? "Previous tab" : "上一个标签页"; }
 
                 Rectangle { height: 6px; }
+                Text { text: root.lang-en ? "Window" : "窗口";
+                       color: Theme.text-muted; font-size: Theme.fs-xs; }
+                ShortcutRow { keys: root.is-mac ? "⌘⇧N" : "Ctrl+Shift+N"; desc: root.lang-en ? "New window" : "新建窗口"; }
+
+                Rectangle { height: 6px; }
                 Text { text: root.lang-en ? "Terminal" : "终端";
                        color: Theme.text-muted; font-size: Theme.fs-xs; }
                 ShortcutRow { keys: root.is-mac ? "⌘C" : "Ctrl+Shift+C"; desc: root.lang-en ? "Copy selection" : "复制选中内容"; }
                 ShortcutRow { keys: root.is-mac ? "⌘V" : "Ctrl+V"; desc: root.lang-en ? "Paste" : "粘贴"; }
                 ShortcutRow { keys: root.is-mac ? "⌘F" : "Ctrl+F"; desc: root.lang-en ? "Find in terminal" : "查找"; }
                 ShortcutRow { keys: root.is-mac ? "⌘⇧R" : "Ctrl+Shift+R"; desc: root.lang-en ? "Jump to command history search" : "跳到命令历史搜索"; }
+                ShortcutRow { keys: root.is-mac ? "⌘=" : "Ctrl+="; desc: root.lang-en ? "Enlarge terminal font" : "放大终端字体"; }
+                ShortcutRow { keys: root.is-mac ? "⌘-" : "Ctrl+-"; desc: root.lang-en ? "Shrink terminal font" : "缩小终端字体"; }
+                ShortcutRow { keys: root.is-mac ? "⌘0" : "Ctrl+0"; desc: root.lang-en ? "Reset terminal font size" : "重置终端字体大小"; }
                 ShortcutRow { keys: root.lang-en ? "Drag" : "鼠标拖动"; desc: root.lang-en ? "Select text" : "选择文本"; }
                 ShortcutRow { keys: root.lang-en ? "Wheel / Scrollbar" : "滚轮 / 滚动条"; desc: root.lang-en ? "Scroll history" : "滚动历史"; }
 

--- a/ui/app.slint
+++ b/ui/app.slint
@@ -71,6 +71,7 @@ export struct TerminalState {
     sftp-sort-key: string,      // ""|"name"|"size"|"modified" (#248)
     sftp-sort-dir: int,         // 0 default / 1 asc / -1 desc (#248)
     sftp-available: bool,       // false for local/serial/telnet sessions
+    font-size: int,             // per-session zoom override in px (0 = follow window)
     tunnels: [TunnelInfo],      // runtime SSH tunnels (#206)
     sftp-collapsed: bool,       // SFTP panel minimised — per session (#v0.5)
     sftp-panel-height: length,  // SFTP panel extent (bottom dock) — per session
@@ -500,7 +501,9 @@ export component AppWindow inherits Window {
     }
     callback set-term-font(string);                // apply + persist font family
     callback set-term-font-size(int);              // apply + persist font size (px)
-    callback zoom-term-font(int);                  // Ctrl+=/-/0 zoom: +1 / -1 / reset
+    // Font zoom: Ctrl+=/-/0 → `tab-id`'s session only; Ctrl+Shift+=/-/0 →
+    // every session in this window (scope: false = session, true = window).
+    callback zoom-term-font(string /* tab-id */, int /* direction */, bool /* window-wide */);
     callback set-terminal-line-spacing(float);
     callback set-term-font-bold(bool);             // apply + persist bold terminal text
     callback set-term-cursor-style(string);        // apply + persist cursor shape (#275)
@@ -522,6 +525,11 @@ export component AppWindow inherits Window {
     // SFTP follows the terminal's cd; opt out in Interface settings.
     in-out property <bool> sftp-follow-cd: true;
     callback set-sftp-follow-cd(bool);             // apply + persist
+    // Hide the quick-command bar under the terminal; toolbar toggle persists it.
+    in-out property <bool> cmd-bar-hidden: false;
+    callback set-cmd-bar-hidden(bool);             // apply + persist
+    // Zen (focus) mode toggle shortcut: Ctrl+Alt+Z (⌘⌥Z on macOS).
+    callback toggle-zen-key();
     // Always ask where to save on each download (#87); default off.
     in-out property <bool> download-always-ask: false;
     callback set-download-always-ask(bool);        // apply + persist
@@ -810,7 +818,17 @@ export component AppWindow inherits Window {
     // Asks Rust to recompute the sidebar (status + resources) for whatever tab
     // is now active.  Fired on every active-tab change, UI- or code-driven.
     callback refresh-sidebar();
-    changed active-tab-id => { root.refresh-sidebar(); }
+    changed active-tab-id => {
+        root.refresh-sidebar();
+        // Closing the last session destroys the terminal's IME focus anchor
+        // and nothing else re-claims focus — with no focused item, Slint
+        // delivers keys nowhere, stranding the zen escape shortcut (and every
+        // window-level shortcut). Re-anchor on the shortcut scope whenever the
+        // welcome tab is active and no terminal remains.
+        if (root.active-tab-id == "welcome" && root.terminals.length == 0) {
+            shortcut-scope.focus();
+        }
+    }
 
     // Raw keystroke forwarding: Rust converts key+modifiers to PTY bytes.
     callback send-key(string /* tab-id */, string /* key */, bool /* ctrl */, bool /* alt */, bool /* shift */);
@@ -896,6 +914,19 @@ export component AppWindow inherits Window {
         image-fit: cover;
     }
 
+    // Zen (focus) mode keyboard toggle — same persist path as the Settings
+    // switch (#zen).
+    toggle-zen-key => {
+        root.zen-mode = !root.zen-mode;
+        root.set-zen-mode(root.zen-mode);
+        // Entering zen with no terminals can leave nothing focused (the
+        // welcome page may be hidden as a sidebar), which would strand the
+        // Ctrl+Alt+Z escape shortcut — anchor focus on the shortcut scope.
+        if (root.zen-mode && root.terminals.length == 0) {
+            shortcut-scope.focus();
+        }
+    }
+
     // Window-wide shortcut interceptor (#multi-window). Slint delivers a key
     // to the focused item first and only bubbles it up the ancestor chain when
     // it is rejected there; a Window itself cannot bind key-pressed. This
@@ -907,9 +938,27 @@ export component AppWindow inherits Window {
     // other widget. A focused terminal accepts ⌘⇧N / Ctrl+Shift+N on its own
     // (terminal_view.slint), which stops propagation, so the two never
     // double-fire.
-    FocusScope {
+    shortcut-scope := FocusScope {
         focus-on-click: false;
         focus-on-tab-navigation: false;
+        // A window restored into zen mode starts with nothing focused when no
+        // focusable widget is on screen (e.g. the welcome page is hidden as a
+        // sidebar and no terminal exists yet). Slint delivers keys only to the
+        // focused item, so the Ctrl+Alt+Z escape shortcut would be stranded in
+        // exactly that stuck state. Claim focus on the next event-loop turn —
+        // deferred like the welcome scope so AccessKit/winit aren't re-entered
+        // from `init` (#323); any real widget that takes focus later (welcome
+        // page, terminal IME anchor) simply overrides this.
+        property <bool> zen-focus-pending: false;
+        init => { shortcut-scope.zen-focus-pending = root.zen-mode && root.terminals.length == 0; }
+        Timer {
+            interval: 0ms;
+            running: shortcut-scope.zen-focus-pending;
+            triggered => {
+                shortcut-scope.zen-focus-pending = false;
+                shortcut-scope.focus();
+            }
+        }
         key-pressed(e) => {
             // New window: ⌘⇧N / Ctrl+Shift+N (#multi-window). On macOS Slint
             // maps `control` to Cmd (#158), so this single condition yields ⌘⇧N
@@ -920,17 +969,33 @@ export component AppWindow inherits Window {
                         || e.text == "\u{000e}")) {
                 root.new-window-clicked();
                 accept
-            // Font zoom: Ctrl+= / Ctrl+- / Ctrl+0 (⌘ on macOS). Same keys as
-            // the focused-terminal branch (terminal_view.slint); a focused
-            // terminal consumes them itself, so no double-fire.
-            } else if (e.modifiers.control && (e.text == "=" || e.text == "+")) {
-                root.zoom-term-font(1);
+            // Font zoom: Ctrl+= / Ctrl+- / Ctrl+0 zooms the active session;
+            // adding Alt zooms every session in this window (Alt, not Shift:
+            // Ctrl+Shift is the IME-switch hotkey on Chinese Windows). Same
+            // keys as the focused-terminal branch (terminal_view.slint); a
+            // focused terminal consumes them itself, so no double-fire.
+            // Ctrl+- arrives as \u{001f} (^_) on some backends.
+            } else if (e.modifiers.control && e.modifiers.alt
+                    && (e.text == "=" || e.text == "+" || e.text == "-"
+                        || e.text == "\u{001f}" || e.text == "0")) {
+                root.zoom-term-font(root.active-tab-id,
+                    e.text == "-" || e.text == "\u{001f}" ? -1
+                        : e.text == "0" ? 0 : 1, true);
                 accept
-            } else if (e.modifiers.control && e.text == "-") {
-                root.zoom-term-font(-1);
+            } else if (e.modifiers.control && (e.text == "=" || e.text == "+")) {
+                root.zoom-term-font(root.active-tab-id, 1, false);
+                accept
+            } else if (e.modifiers.control && (e.text == "-" || e.text == "\u{001f}")) {
+                root.zoom-term-font(root.active-tab-id, -1, false);
                 accept
             } else if (e.modifiers.control && e.text == "0") {
-                root.zoom-term-font(0);
+                root.zoom-term-font(root.active-tab-id, 0, false);
+                accept
+            // Zen (focus) mode: Ctrl+Alt+Z toggles, same as the terminal
+            // branch below (#zen).
+            } else if (e.modifiers.control && e.modifiers.alt
+                    && (e.text == "z" || e.text == "Z" || e.text == "\u{001a}")) {
+                root.toggle-zen-key();
                 accept
             } else {
                 reject
@@ -1627,11 +1692,12 @@ export component AppWindow inherits Window {
                         sftp-selected-count: term.sftp-selected-count;
                         sftp-sort-key: term.sftp-sort-key;
                         sftp-sort-dir: term.sftp-sort-dir;
-                        sftp-available: term.sftp-available && !root.zen-mode;
+                        sftp-available: term.sftp-available;
                         tunnels: term.tunnels;
                         quick-commands: root.quick-commands;
                         quick-sidebar-enabled: root.quick-commands-as-sidebar;
                         quick-panel-docked: root.quick-panel-open;
+                        cmd-bar-hidden: root.cmd-bar-hidden;
                         quick-external-command: root.quick-external-command;
                         quick-external-send-enter: root.quick-external-send-enter;
                         quick-external-sequence: root.quick-external-sequence;
@@ -1685,7 +1751,9 @@ export component AppWindow inherits Window {
                         }
                         cycle-tab(reverse) => { root.cycle-tab(reverse); }
                         new-window-key() => { root.new-window-clicked(); }
-                        zoom-key(direction) => { root.zoom-term-font(direction); }
+                        zoom-key(direction, window-wide) => { root.zoom-term-font(term.id, direction, window-wide); }
+                        zen-key() => { root.toggle-zen-key(); }
+                        term-font-size-px: term.font-size > 0 ? term.font-size * 1.0 : root.term-font-size / 1px;
                         terminal-resize(w, h) => { root.terminal-resize(term.id, w, h) }
                         sftp-navigate(path) => { root.sftp-navigate(term.id, path); }
                         sftp-download(path) => { root.sftp-download(term.id, path); }
@@ -1978,6 +2046,15 @@ export component AppWindow inherits Window {
             ? (root.sync-input ? "Sync input: ON" : "Sync input")
             : (root.sync-input ? "会话同步：开" : "会话同步");
         clicked => { root.sync-input = !root.sync-input; root.set-sync-input(root.sync-input); }
+    }
+    IconBtn {
+        x: root.width - 154px - root.toolbar-x-off; y: root.toolbar-y;
+        icon: "\u{E86F}";   // Material "code" — command bar
+        active: !root.cmd-bar-hidden;
+        tooltip: root.lang-en
+            ? (root.cmd-bar-hidden ? "Show command bar" : "Hide command bar")
+            : (root.cmd-bar-hidden ? "显示命令栏" : "隐藏命令栏");
+        clicked => { root.cmd-bar-hidden = !root.cmd-bar-hidden; root.set-cmd-bar-hidden(root.cmd-bar-hidden); }
     }
 
     // Frameless resize edges (#119): thin hit-zones that start an OS-level
@@ -3630,6 +3707,7 @@ export component AppWindow inherits Window {
                 Text { text: root.lang-en ? "Window" : "窗口";
                        color: Theme.text-muted; font-size: Theme.fs-xs; }
                 ShortcutRow { keys: root.is-mac ? "⌘⇧N" : "Ctrl+Shift+N"; desc: root.lang-en ? "New window" : "新建窗口"; }
+                ShortcutRow { keys: root.is-mac ? "⌘⌥Z" : "Ctrl+Alt+Z"; desc: root.lang-en ? "Toggle zen (focus) mode" : "切换专注模式"; }
 
                 Rectangle { height: 6px; }
                 Text { text: root.lang-en ? "Terminal" : "终端";
@@ -3638,9 +3716,12 @@ export component AppWindow inherits Window {
                 ShortcutRow { keys: root.is-mac ? "⌘V" : "Ctrl+V"; desc: root.lang-en ? "Paste" : "粘贴"; }
                 ShortcutRow { keys: root.is-mac ? "⌘F" : "Ctrl+F"; desc: root.lang-en ? "Find in terminal" : "查找"; }
                 ShortcutRow { keys: root.is-mac ? "⌘⇧R" : "Ctrl+Shift+R"; desc: root.lang-en ? "Jump to command history search" : "跳到命令历史搜索"; }
-                ShortcutRow { keys: root.is-mac ? "⌘=" : "Ctrl+="; desc: root.lang-en ? "Enlarge terminal font" : "放大终端字体"; }
-                ShortcutRow { keys: root.is-mac ? "⌘-" : "Ctrl+-"; desc: root.lang-en ? "Shrink terminal font" : "缩小终端字体"; }
-                ShortcutRow { keys: root.is-mac ? "⌘0" : "Ctrl+0"; desc: root.lang-en ? "Reset terminal font size" : "重置终端字体大小"; }
+                ShortcutRow { keys: root.is-mac ? "⌘=" : "Ctrl+="; desc: root.lang-en ? "Enlarge terminal font (this session)" : "放大终端字体（当前会话）"; }
+                ShortcutRow { keys: root.is-mac ? "⌘-" : "Ctrl+-"; desc: root.lang-en ? "Shrink terminal font (this session)" : "缩小终端字体（当前会话）"; }
+                ShortcutRow { keys: root.is-mac ? "⌘0" : "Ctrl+0"; desc: root.lang-en ? "Reset terminal font size (this session)" : "重置终端字体大小（当前会话）"; }
+                ShortcutRow { keys: root.is-mac ? "⌘⌥=" : "Ctrl+Alt+="; desc: root.lang-en ? "Enlarge terminal font (all sessions in window)" : "放大终端字体（本窗口所有会话）"; }
+                ShortcutRow { keys: root.is-mac ? "⌘⌥-" : "Ctrl+Alt+-"; desc: root.lang-en ? "Shrink terminal font (all sessions in window)" : "缩小终端字体（本窗口所有会话）"; }
+                ShortcutRow { keys: root.is-mac ? "⌘⌥0" : "Ctrl+Alt+0"; desc: root.lang-en ? "Reset terminal font size (all sessions in window)" : "重置终端字体大小（本窗口所有会话）"; }
                 ShortcutRow { keys: root.lang-en ? "Drag" : "鼠标拖动"; desc: root.lang-en ? "Select text" : "选择文本"; }
                 ShortcutRow { keys: root.lang-en ? "Wheel / Scrollbar" : "滚轮 / 滚动条"; desc: root.lang-en ? "Scroll history" : "滚动历史"; }
 

--- a/ui/app.slint
+++ b/ui/app.slint
@@ -765,6 +765,8 @@ export component AppWindow inherits Window {
     callback edit-session(string /* session-id */);
     callback duplicate-session(string /* session-id */);
     callback move-session(string /* session-id */, string /* group */);
+    callback reorder-session(string /* session-id */, int /* dir: -1 up, 1 down */);
+    callback reorder-session-end();
     callback toggle-group(string /* group */);
     callback remove-session(string /* session-id */);
     callback session-dialog-submit(SessionDraft);
@@ -795,6 +797,13 @@ export component AppWindow inherits Window {
     callback pane-merge(int /* pane-id */);
     // Open another connection to the same session as `tab-id` (a new tab).
     callback tab-duplicate(string /* tab-id */);
+    // Rename an open session's tab. Request pre-fills the dialog (Rust reads
+    // the current title); submit applies the new display name.
+    callback tab-rename-request(string /* tab-id */);
+    callback rename-tab(string /* tab-id */, string /* new-title */);
+    in-out property <bool> tab-rename-open: false;
+    in-out property <string> tab-rename-id: "";
+    in-out property <string> tab-rename-value: "";
     // Drag-to-split (v0.5): cursor moved / dropped while dragging `tab-id`, in
     // pane-area coordinates. Rust hit-tests the pane + edge zone.
     callback tab-drag-move(string /* tab-id */, length /* x */, length /* y */);
@@ -1259,6 +1268,8 @@ export component AppWindow inherits Window {
                     edit-session(id) => { root.edit-session(id); }
                     duplicate-session(id) => { root.duplicate-session(id); }
                     move-session(id, group) => { root.move-session(id, group); }
+                    reorder-session(id, dir) => { root.reorder-session(id, dir); }
+                    reorder-end => { root.reorder-session-end(); }
                     toggle-group(group) => { root.toggle-group(group); }
                     new-group => {
                         root.group-dialog-orig = "";
@@ -1579,6 +1590,7 @@ export component AppWindow inherits Window {
                         tab-split(id, dir) => { root.pane-split(pane.id, id, dir); }
                         merge-pane() => { root.pane-merge(pane.id); }
                         tab-duplicate(id) => { root.tab-duplicate(id); }
+                        tab-rename-request(id) => { root.tab-rename-request(id); }
                         tab-drag-move(id, ax, ay) => {
                             root.tab-drag-move(id,
                                 ax - pane-area.absolute-position.x,
@@ -1629,6 +1641,8 @@ export component AppWindow inherits Window {
                         edit-session(id) => { root.edit-session(id); }
                         duplicate-session(id) => { root.duplicate-session(id); }
                         move-session(id, group) => { root.move-session(id, group); }
+                        reorder-session(id, dir) => { root.reorder-session(id, dir); }
+                        reorder-end => { root.reorder-session-end(); }
                         toggle-group(group) => { root.toggle-group(group); }
                         new-group => {
                             root.group-dialog-orig = "";
@@ -2966,6 +2980,75 @@ export component AppWindow inherits Window {
                             if (root.group-dialog-error == "") {
                                 root.group-dialog-open = false;
                             }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // --- Rename-session dialog ----------------------------------------------
+    // Tab context menu → Rename: a display-name override for one open session.
+    // Submitting an empty name restores the saved session name.
+    if root.tab-rename-open : Rectangle {
+        width: parent.width;
+        height: parent.height;
+        background: #00000080;
+        TouchArea { clicked => { root.tab-rename-open = false; } }
+
+        Rectangle {
+            x: (parent.width - self.width) / 2;
+            y: (parent.height - self.height) / 2;
+            width: 340px;
+            height: 196px;
+            background: Theme.popup-bg;
+            border-radius: Theme.radius-md;
+            border-width: 1px;
+            border-color: Theme.border-strong;
+            drop-shadow-blur: 24px;
+            drop-shadow-color: #000000a0;
+            TouchArea {}   // swallow inside clicks
+
+            VerticalLayout {
+                padding: 18px;
+                spacing: 12px;
+                Text {
+                    text: root.lang-en ? "Rename session" : "重命名会话";
+                    color: Theme.text-primary;
+                    font-size: Theme.fs-lg;
+                    font-weight: 700;
+                }
+                Text {
+                    text: @tr("Session name");
+                    color: Theme.text-secondary;
+                    font-size: Theme.fs-sm;
+                }
+                tr-input := LineEdit {
+                    text <=> root.tab-rename-value;
+                    font-family: Theme.ui-font-family; // CJK-capable (#54)
+                    placeholder-text: @tr("Session name");
+                    accepted => {
+                        root.rename-tab(root.tab-rename-id, root.tab-rename-value);
+                    }
+                }
+                Text {
+                    text: @tr("Leave empty to restore the default name");
+                    color: Theme.text-muted;
+                    font-size: Theme.fs-xs;
+                }
+                Rectangle { vertical-stretch: 1; }
+                HorizontalLayout {
+                    alignment: end;
+                    spacing: 8px;
+                    Button {
+                        text: root.lang-en ? "Cancel" : "取消";
+                        clicked => { root.tab-rename-open = false; }
+                    }
+                    Button {
+                        text: root.lang-en ? "OK" : "确定";
+                        primary: true;
+                        clicked => {
+                            root.rename-tab(root.tab-rename-id, root.tab-rename-value);
                         }
                     }
                 }

--- a/ui/tabs.slint
+++ b/ui/tabs.slint
@@ -188,6 +188,8 @@ export component TabBar inherits Rectangle {
     callback tab-split(string /* tab-id */, string /* dir */);
     // Open another connection to the same session as `tab-id` (#v0.5).
     callback tab-duplicate(string /* tab-id */);
+    // Rename an open session's tab (display name only).
+    callback tab-rename-request(string /* tab-id */);
     callback merge-pane();
     // Drag-to-split (#v0.5): cursor moved / dropped while dragging `tab-id`, in
     // absolute (window) coordinates.
@@ -282,7 +284,7 @@ export component TabBar inherits Rectangle {
         x: root.menu-x;
         y: root.menu-y;
         width: 140px;
-        height: 6 * 29px + 13px;
+        height: 7 * 29px + 13px;
         Rectangle {
             background: Theme.popup-bg;
             border-radius: Theme.radius-sm;
@@ -297,6 +299,11 @@ export component TabBar inherits Rectangle {
                     label: @tr("Duplicate connection");
                     enabled: root.menu-target != "welcome";
                     clicked => { root.tab-duplicate(root.menu-target); }
+                }
+                TabMenuItem {
+                    label: @tr("Rename");
+                    enabled: root.menu-target != "welcome";
+                    clicked => { root.tab-rename-request(root.menu-target); }
                 }
                 Rectangle { height: 1px; background: Theme.border-subtle; }
                 TabMenuItem {

--- a/ui/tabs.slint
+++ b/ui/tabs.slint
@@ -71,24 +71,31 @@ component SingleTab inherits Rectangle {
             if (root.pressing) {
                 // A drag begins once the cursor drifts horizontally OR leaves the
                 // tab vertically (so a straight-down drag to split also counts).
-                if (abs(self.mouse-x - root.grab-offset) > 5px
-                        || self.mouse-y < -6px || self.mouse-y > root.height + 6px) {
+                if (!root.dragging
+                        && (abs(self.mouse-x - root.grab-offset) > 5px
+                            || self.mouse-y < -6px || self.mouse-y > root.height + 6px)) {
                     root.dragging = true;
                 }
-                // Tell the parent where the cursor is, for drop-to-split zones.
-                root.drag-moved(self.absolute-position.x + self.mouse-x,
-                                self.absolute-position.y + self.mouse-y);
-                // Reorder within the strip only while the cursor stays on the strip
-                // row; once it drops into a pane body we hand off to drag-to-split.
-                // One slot = the tab's own width + the 2px strip spacing; re-anchor
-                // grab-offset after each hop so the drift resets (no oscillation).
-                if (self.mouse-y > -10px && self.mouse-y < root.height + 10px) {
-                    if (self.mouse-x - root.grab-offset > (root.width + 2px) / 2) {
-                        root.reorder(1);
-                        root.grab-offset = self.mouse-x - (root.width + 2px);
-                    } else if (self.mouse-x - root.grab-offset < -(root.width + 2px) / 2) {
-                        root.reorder(-1);
-                        root.grab-offset = self.mouse-x + (root.width + 2px);
+                // Gate everything below on `dragging`: a plain click can emit
+                // tiny `moved` events (macOS), which would otherwise light up
+                // the drop-zone highlight and leave it stuck — no drop ever
+                // follows a click to clear it.
+                if (root.dragging) {
+                    // Tell the parent where the cursor is, for drop-to-split zones.
+                    root.drag-moved(self.absolute-position.x + self.mouse-x,
+                                    self.absolute-position.y + self.mouse-y);
+                    // Reorder within the strip only while the cursor stays on the strip
+                    // row; once it drops into a pane body we hand off to drag-to-split.
+                    // One slot = the tab's own width + the 2px strip spacing; re-anchor
+                    // grab-offset after each hop so the drift resets (no oscillation).
+                    if (self.mouse-y > -10px && self.mouse-y < root.height + 10px) {
+                        if (self.mouse-x - root.grab-offset > (root.width + 2px) / 2) {
+                            root.reorder(1);
+                            root.grab-offset = self.mouse-x - (root.width + 2px);
+                        } else if (self.mouse-x - root.grab-offset < -(root.width + 2px) / 2) {
+                            root.reorder(-1);
+                            root.grab-offset = self.mouse-x + (root.width + 2px);
+                        }
                     }
                 }
             }

--- a/ui/terminal_view.slint
+++ b/ui/terminal_view.slint
@@ -306,6 +306,10 @@ export component TerminalView inherits Rectangle {
     in property <[string]> command-history;   // oldest first (newest last, #113)
     in property <[string]> history-view;       // filtered dropdown, newest first (#101, #331)
     property <bool> send-to-all: false;
+    in property <bool> cmd-bar-hidden: false;  // toolbar toggle hides the whole bar
+    // Effective terminal font size in px: per-session zoom override when > 0,
+    // else the window/global size (Theme.term-font-size).
+    in property <float> term-font-size-px: Theme.term-font-size / 1px;
     property <bool> quick-open: false;         // quick-command popup visibility
     property <bool> history-open: false;       // history dropdown visibility
     property <bool> history-autocomplete: false; // live suggestions from command input (#349)
@@ -345,7 +349,9 @@ export component TerminalView inherits Rectangle {
     callback new-window-key();
     // Font zoom: Ctrl+= / Ctrl+- / Ctrl+0 (⌘ on macOS). Direction:
     // 1 = larger, -1 = smaller, 0 = reset to default.
-    callback zoom-key(int);
+    callback zoom-key(int /* direction */, bool /* window-wide */);
+    // Ctrl+Alt+Z (⌘⌥Z on macOS) — toggle zen (focus) mode.
+    callback zen-key();
     callback terminal-resize(float, float);
     callback sftp-navigate(string);
     callback sftp-download(string);
@@ -445,7 +451,7 @@ export component TerminalView inherits Rectangle {
     cell-probe := Text {
         text: "MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM"; // exactly 50×M
         font-family: Theme.term-font-family;
-        font-size: Theme.term-font-size;
+        font-size: root.term-font-size-px * 1px;
         font-weight: Theme.term-font-bold ? 700 : 400;
         // Keep it in layout but invisible: opacity:0 forces full font loading.
         opacity: 0;
@@ -573,12 +579,11 @@ export component TerminalView inherits Rectangle {
         // Side-docked SFTP needs enough room for its compact action row and a
         // usable path field. Clamp legacy/saved widths below that floor instead
         // of letting Slint squeeze controls out of alignment.
-        property <length> sf-w: root.zen-mode ? 0px
-            : root.sftp-collapsed ? 36px
+        property <length> sf-w: root.sftp-collapsed ? 36px
             : root.sftp-horizontal ? max(300px, root.sftp-panel-width)
             : root.sftp-panel-width;
-        property <length> sf-h: root.zen-mode ? 0px : root.sftp-collapsed ? 36px : root.sftp-panel-height;
-        property <length> sp: root.zen-mode || root.sftp-collapsed ? 0px : 4px;
+        property <length> sf-h: root.sftp-collapsed ? 36px : root.sftp-panel-height;
+        property <length> sp: root.sftp-collapsed ? 0px : 4px;
         // The collapsed bar (sf-h) already reserves the bottom strip now.
         property <length> bottom-strip-h: 0px;
 
@@ -791,7 +796,7 @@ export component TerminalView inherits Rectangle {
                                 // terminal font lacks CJK glyphs and Slint tofu's
                                 // *isolated* CJK punctuation (、。,) on fallback (#54).
                                 font-family: span.cjk ? Theme.ui-font-family : Theme.term-font-family;
-                                font-size: Theme.term-font-size;
+                                font-size: root.term-font-size-px * 1px;
                                 font-weight: (Theme.term-font-bold || span.bold) ? 700 : 400;
                             }
                             if span.emoji : Image {
@@ -1012,19 +1017,37 @@ export component TerminalView inherits Rectangle {
                                 || event.text == "\u{000e}")) {
                         root.new-window-key();
                         accept
+                    // ── Zen (focus) mode: Ctrl+Alt+Z toggles (#zen). Hidden
+                    // views reject it so the window-level fallback handles it.
+                    } else if (root.visible && event.modifiers.control && event.modifiers.alt
+                            && (event.text == "z" || event.text == "Z"
+                                || event.text == "\u{001a}")) {
+                        root.zen-key();
+                        accept
                     // ── Font zoom: Ctrl+= / Ctrl+- / Ctrl+0 (⌘ on macOS) ──
-                    // Adjusts the terminal font size (persisted like the
-                    // settings stepper); Ctrl+Shift+= types "+" on many
-                    // layouts and is accepted for zoom-in as well.
-                    } else if (event.modifiers.control
+                    // Zooms this session only; adding Alt zooms every session
+                    // in the window. Alt (not Shift) because Ctrl+Shift is the
+                    // IME-switch hotkey on Chinese Windows and gets swallowed.
+                    // A hidden (inactive tab) view that still holds focus
+                    // rejects these so the window-level fallback zooms the
+                    // visible session (#zoom).
+                    } else if (root.visible && event.modifiers.control && event.modifiers.alt
+                            && (event.text == "=" || event.text == "+"
+                                || event.text == "-" || event.text == "\u{001f}"
+                                || event.text == "0")) {
+                        root.zoom-key(event.text == "-" || event.text == "\u{001f}" ? -1
+                            : event.text == "0" ? 0 : 1, true);
+                        accept
+                    } else if (root.visible && event.modifiers.control
                             && (event.text == "=" || event.text == "+")) {
-                        root.zoom-key(1);
+                        root.zoom-key(1, false);
                         accept
-                    } else if (event.modifiers.control && event.text == "-") {
-                        root.zoom-key(-1);
+                    } else if (root.visible && event.modifiers.control
+                            && (event.text == "-" || event.text == "\u{001f}")) {
+                        root.zoom-key(-1, false);
                         accept
-                    } else if (event.modifiers.control && event.text == "0") {
-                        root.zoom-key(0);
+                    } else if (root.visible && event.modifiers.control && event.text == "0") {
+                        root.zoom-key(0, false);
                         accept
                     // ── Copy: ⌘C (macOS, no Shift) / Ctrl+Shift+C ──
                     } else if (event.modifiers.control
@@ -1199,8 +1222,8 @@ export component TerminalView inherits Rectangle {
 
         // --- Command bar (#55): quick commands + input box + history ---------
         cmd-bar := Rectangle {
-            visible: !root.zen-mode;
-            height: root.zen-mode ? 0px : 34px;
+            visible: !root.cmd-bar-hidden;
+            height: root.cmd-bar-hidden ? 0px : 34px;
             background: Theme.bg-panel-alt;
             border-width: 0;
 

--- a/ui/terminal_view.slint
+++ b/ui/terminal_view.slint
@@ -341,6 +341,11 @@ export component TerminalView inherits Rectangle {
     // Temporary on-device diagnostics for #312. Rust redacts printable text.
     callback diagnose-key-event(string, bool, bool, bool, bool);
     callback cycle-tab(bool /* reverse */);
+    // Ctrl+Shift+N (⌘⇧N on macOS) — open a new application window (#multi-window).
+    callback new-window-key();
+    // Font zoom: Ctrl+= / Ctrl+- / Ctrl+0 (⌘ on macOS). Direction:
+    // 1 = larger, -1 = smaller, 0 = reset to default.
+    callback zoom-key(int);
     callback terminal-resize(float, float);
     callback sftp-navigate(string);
     callback sftp-download(string);
@@ -996,6 +1001,30 @@ export component TerminalView inherits Rectangle {
                             && (event.text == "r" || event.text == "R"
                                 || event.text == "\u{0012}")) {
                         root.history-open = true;
+                        accept
+                    // ── New window: ⌘⇧N / Ctrl+Shift+N (#multi-window) ──
+                    // `control` is Cmd on macOS (Slint modifier swap, #158), so
+                    // this single condition gives ⌘⇧N there and Ctrl+Shift+N
+                    // elsewhere. Intercepted here — before send-key — so the
+                    // keystroke never reaches the remote shell.
+                    } else if (event.modifiers.control && event.modifiers.shift
+                            && (event.text == "n" || event.text == "N"
+                                || event.text == "\u{000e}")) {
+                        root.new-window-key();
+                        accept
+                    // ── Font zoom: Ctrl+= / Ctrl+- / Ctrl+0 (⌘ on macOS) ──
+                    // Adjusts the terminal font size (persisted like the
+                    // settings stepper); Ctrl+Shift+= types "+" on many
+                    // layouts and is accepted for zoom-in as well.
+                    } else if (event.modifiers.control
+                            && (event.text == "=" || event.text == "+")) {
+                        root.zoom-key(1);
+                        accept
+                    } else if (event.modifiers.control && event.text == "-") {
+                        root.zoom-key(-1);
+                        accept
+                    } else if (event.modifiers.control && event.text == "0") {
+                        root.zoom-key(0);
                         accept
                     // ── Copy: ⌘C (macOS, no Shift) / Ctrl+Shift+C ──
                     } else if (event.modifiers.control

--- a/ui/welcome.slint
+++ b/ui/welcome.slint
@@ -44,6 +44,10 @@ component SessionRow inherits Rectangle {
     // under the grab on every hop.
     in property <bool> drag-target: false;
     in property <length> drag-dy: 0px;
+    // List-level drag state, mirrored here so a press can detect a stale
+    // drag (the grab was lost when a hop changed the row count and rebuilt
+    // the model) and clear it instead of leaving the card lifted.
+    in property <bool> list-dragging: false;
     property <bool> system-row: root.session.builtin;
     // Local gesture state: this instance received the press and drives the
     // drag (it keeps the pointer grab across in-place model updates).
@@ -71,6 +75,12 @@ component SessionRow inherits Rectangle {
                 ctx-menu.show();
             } else if (e.button == PointerEventButton.left) {
                 if (e.kind == PointerEventKind.down) {
+                    // A press while the list still thinks a drag is running
+                    // means that drag's pointer grab was destroyed by a
+                    // row-count-changing hop; end it before starting fresh.
+                    if (root.list-dragging) {
+                        root.drag-end();
+                    }
                     root.pressing = true;
                     // Reset any stale drag (e.g. released outside the row).
                     root.grab-dragging = false;
@@ -753,6 +763,7 @@ export component Welcome inherits Rectangle {
                             reorder-enabled: root.search-query == "" && !session.builtin;
                             drag-target: root.list-dragging && root.drag-id == session.id;
                             drag-dy: root.drag-dy;
+                            list-dragging: root.list-dragging;
                             connect => { root.connect-session(session.id); }
                             edit => { root.edit-session(session.id); }
                             duplicate => { root.duplicate-session(session.id); }

--- a/ui/welcome.slint
+++ b/ui/welcome.slint
@@ -25,23 +25,42 @@ component SessionRow inherits Rectangle {
     callback duplicate();
     callback move-to-group(string);
     callback remove();
+    // Drag-to-reorder: direction -1 = up, 1 = down. Emitted once per row-hop.
+    callback reorder(int);
+    // Drag lifecycle, owned by the Welcome list: start publishes the dragged
+    // id, move streams the pointer-follow offset, end persists the order.
+    callback drag-start();
+    callback drag-move(length);
+    callback drag-end();
     // Full session list — group-header is non-empty once per group, so the
     // "move to group" submenu can iterate it to list each group exactly once.
     in property <[SessionInfo]> all-sessions;
+    // Drag is only allowed outside search (visible indices would not match
+    // stored order) and never on built-in system rows.
+    in property <bool> reorder-enabled: false;
+    // Shared list-level drag state (see Welcome): which session is being
+    // dragged and its offset. The lifted card follows the dragged session's
+    // DATA, not the component holding the pointer grab — rows swap contents
+    // under the grab on every hop.
+    in property <bool> drag-target: false;
+    in property <length> drag-dy: 0px;
     property <bool> system-row: root.session.builtin;
+    // Local gesture state: this instance received the press and drives the
+    // drag (it keeps the pointer grab across in-place model updates).
+    property <bool> pressing: false;
+    property <bool> grab-dragging: false;
+    property <length> grab-y;
 
     height: root.compact ? 44px : 36px;
-    border-radius: Theme.radius-sm;
-    background: touch.has-hover ? Theme.bg-hover : transparent;
-    animate background { duration: 120ms; }
 
     // Remember where the right-click landed so the popup can appear there.
     property <length> ctx-x;
     property <length> ctx-y;
 
     touch := TouchArea {
-        mouse-cursor: pointer;
-        clicked => { root.connect(); }
+        mouse-cursor: root.grab-dragging ? move : pointer;
+        // Connect is handled in pointer-event below so a finished drag never
+        // counts as a click.
         pointer-event(e) => {
             // Built-in PowerShell/CMD/WSL rows have no edit/move/delete actions.
             // All menu items are conditional on !system-row, so opening the
@@ -50,6 +69,55 @@ component SessionRow inherits Rectangle {
                 ctx-x = self.mouse-x;
                 ctx-y = self.mouse-y;
                 ctx-menu.show();
+            } else if (e.button == PointerEventButton.left) {
+                if (e.kind == PointerEventKind.down) {
+                    root.pressing = true;
+                    // Reset any stale drag (e.g. released outside the row).
+                    root.grab-dragging = false;
+                    root.grab-y = self.mouse-y;
+                } else if (e.kind == PointerEventKind.up) {
+                    // `pressing` proves this instance received the down: the
+                    // row under a released pointer must not treat it as a
+                    // click when the grab landed elsewhere after hops.
+                    if (root.pressing && !root.grab-dragging) {
+                        root.connect();
+                    }
+                    if (root.grab-dragging) {
+                        root.drag-end();
+                    }
+                    root.pressing = false;
+                    root.grab-dragging = false;
+                }
+            }
+        }
+        moved => {
+            if (!root.pressing) { return; }
+            if (!root.grab-dragging) {
+                // A few pixels of vertical drift start a reorder drag; below
+                // that the press still resolves to a connect click.
+                if (root.reorder-enabled && abs(touch.mouse-y - root.grab-y) > 5px) {
+                    root.grab-dragging = true;
+                    root.grab-y = touch.mouse-y;
+                    root.drag-start();
+                }
+            } else {
+                // Swap at the neighbour's midpoint, then shift the anchor by a
+                // full slot (row + 2px spacing) — NOT back to the cursor — so
+                // overshoot carries over and the drag stays glued to the
+                // pointer across consecutive hops.
+                if (touch.mouse-y - root.grab-y > (root.height + 2px) / 2) {
+                    root.grab-y = root.grab-y + root.height + 2px;
+                    root.reorder(1);
+                } else if (root.grab-y - touch.mouse-y > (root.height + 2px) / 2) {
+                    root.grab-y = root.grab-y - root.height - 2px;
+                    root.reorder(-1);
+                }
+                // Stream the pointer-follow offset to the list, which applies
+                // it to whichever row currently renders the dragged session.
+                // No animation — animating a pointer-following value always
+                // lags the cursor.
+                root.drag-move(clamp(touch.mouse-y - root.grab-y,
+                    -root.height, root.height));
             }
         }
     }
@@ -161,7 +229,20 @@ component SessionRow inherits Rectangle {
         }
     }
 
-    // Row content ------------------------------------------------------------
+    // Row content — wrapped in a card so the dragged row can lift (shadow +
+    // pointer-following offset) while the grabbing TouchArea keeps its grab.
+    card := Rectangle {
+        width: parent.width;
+        height: parent.height;
+        y: root.drag-target ? root.drag-dy : 0px;
+        border-radius: Theme.radius-sm;
+        background: root.drag-target ? Theme.bg-elevated
+            : (touch.has-hover ? Theme.bg-hover : transparent);
+        drop-shadow-blur: root.drag-target ? 14px : 0px;
+        drop-shadow-color: root.drag-target ? #00000060 : transparent;
+        animate background { duration: 120ms; }
+        animate drop-shadow-blur { duration: 120ms; }
+
     HorizontalLayout {
         padding-left: 10px;
         padding-right: 10px;
@@ -225,6 +306,7 @@ component SessionRow inherits Rectangle {
             horizontal-stretch: 1;
         }
     }
+    }
 }
 
 component CollapseButton inherits Rectangle {
@@ -259,6 +341,17 @@ export component Welcome inherits Rectangle {
     callback edit-session(string);
     callback duplicate-session(string);
     callback move-session(string /* id */, string /* group */);
+    // Drag-to-reorder a host card among its same-group siblings (dir: -1/1).
+    callback reorder-session(string /* id */, int /* dir */);
+    // Drag finished (pointer released) → persist the new order.
+    callback reorder-end();
+    // List-level drag-to-reorder state: which session is being dragged and its
+    // pointer-follow offset. Kept at list level because hops swap row data
+    // under the pointer grab — the lifted card must follow the dragged
+    // session's data, not the component that owns the grab.
+    property <string> drag-id;
+    property <bool> list-dragging: false;
+    property <length> drag-dy: 0px;
     callback toggle-group(string /* group */);
     callback new-group();
     callback edit-group(string /* current-name */);
@@ -655,10 +748,24 @@ export component Welcome inherits Rectangle {
                             session: session;
                             compact: root.compact;
                             all-sessions: root.sessions;
+                            // Drag-reorder is meaningless while the list is a
+                            // filtered subset, and system rows can't move.
+                            reorder-enabled: root.search-query == "" && !session.builtin;
+                            drag-target: root.list-dragging && root.drag-id == session.id;
+                            drag-dy: root.drag-dy;
                             connect => { root.connect-session(session.id); }
                             edit => { root.edit-session(session.id); }
                             duplicate => { root.duplicate-session(session.id); }
                             move-to-group(g) => { root.move-session(session.id, g); }
+                            reorder(dir) => { root.reorder-session(root.drag-id, dir); }
+                            drag-start => { root.drag-id = session.id; root.list-dragging = true; }
+                            drag-move(dy) => { root.drag-dy = dy; }
+                            drag-end => {
+                                root.list-dragging = false;
+                                root.drag-id = "";
+                                root.drag-dy = 0px;
+                                root.reorder-end();
+                            }
                             remove => { root.remove-session(session.id); }
                         }
                     }

--- a/ui/welcome.slint
+++ b/ui/welcome.slint
@@ -26,11 +26,12 @@ component SessionRow inherits Rectangle {
     callback move-to-group(string);
     callback remove();
     // Drag-to-reorder: direction -1 = up, 1 = down. Emitted once per row-hop.
-    callback reorder(int);
+    callback reorder(int) -> bool;
     // Drag lifecycle, owned by the Welcome list: start publishes the dragged
-    // id, move streams the pointer-follow offset, end persists the order.
+    // id, end persists the order. The card never follows the pointer — hops
+    // swap rows instantly, so overlapping neighbours / group headers cannot
+    // happen at all.
     callback drag-start();
-    callback drag-move(length);
     callback drag-end();
     // Full session list — group-header is non-empty once per group, so the
     // "move to group" submenu can iterate it to list each group exactly once.
@@ -39,11 +40,10 @@ component SessionRow inherits Rectangle {
     // stored order) and never on built-in system rows.
     in property <bool> reorder-enabled: false;
     // Shared list-level drag state (see Welcome): which session is being
-    // dragged and its offset. The lifted card follows the dragged session's
-    // DATA, not the component holding the pointer grab — rows swap contents
-    // under the grab on every hop.
+    // dragged. The lifted card follows the dragged session's DATA, not the
+    // component holding the pointer grab — rows swap contents under the grab
+    // on every hop.
     in property <bool> drag-target: false;
-    in property <length> drag-dy: 0px;
     // List-level drag state, mirrored here so a press can detect a stale
     // drag (the grab was lost when a hop changed the row count and rebuilt
     // the model) and clear it instead of leaving the card lifted.
@@ -97,6 +97,14 @@ component SessionRow inherits Rectangle {
                     }
                     root.pressing = false;
                     root.grab-dragging = false;
+                } else if (e.kind == PointerEventKind.cancel) {
+                    // System-cancelled grab (e.g. compositor takeover): treat
+                    // as a release but never as a connect click.
+                    if (root.grab-dragging) {
+                        root.drag-end();
+                    }
+                    root.pressing = false;
+                    root.grab-dragging = false;
                 }
             }
         }
@@ -114,20 +122,18 @@ component SessionRow inherits Rectangle {
                 // Swap at the neighbour's midpoint, then shift the anchor by a
                 // full slot (row + 2px spacing) — NOT back to the cursor — so
                 // overshoot carries over and the drag stays glued to the
-                // pointer across consecutive hops.
+                // pointer across consecutive hops. Only advance the anchor
+                // when the swap happened: at list boundaries reorder fails,
+                // and advancing anyway would drift the anchor out of sync.
                 if (touch.mouse-y - root.grab-y > (root.height + 2px) / 2) {
-                    root.grab-y = root.grab-y + root.height + 2px;
-                    root.reorder(1);
+                    if (root.reorder(1)) {
+                        root.grab-y = root.grab-y + root.height + 2px;
+                    }
                 } else if (root.grab-y - touch.mouse-y > (root.height + 2px) / 2) {
-                    root.grab-y = root.grab-y - root.height - 2px;
-                    root.reorder(-1);
+                    if (root.reorder(-1)) {
+                        root.grab-y = root.grab-y - root.height - 2px;
+                    }
                 }
-                // Stream the pointer-follow offset to the list, which applies
-                // it to whichever row currently renders the dragged session.
-                // No animation — animating a pointer-following value always
-                // lags the cursor.
-                root.drag-move(clamp(touch.mouse-y - root.grab-y,
-                    -root.height, root.height));
             }
         }
     }
@@ -240,11 +246,11 @@ component SessionRow inherits Rectangle {
     }
 
     // Row content — wrapped in a card so the dragged row can lift (shadow +
-    // pointer-following offset) while the grabbing TouchArea keeps its grab.
+    // highlight) while the grabbing TouchArea keeps its grab. The card stays
+    // in its slot: row swaps alone convey the reorder.
     card := Rectangle {
         width: parent.width;
         height: parent.height;
-        y: root.drag-target ? root.drag-dy : 0px;
         border-radius: Theme.radius-sm;
         background: root.drag-target ? Theme.bg-elevated
             : (touch.has-hover ? Theme.bg-hover : transparent);
@@ -352,16 +358,28 @@ export component Welcome inherits Rectangle {
     callback duplicate-session(string);
     callback move-session(string /* id */, string /* group */);
     // Drag-to-reorder a host card among its same-group siblings (dir: -1/1).
-    callback reorder-session(string /* id */, int /* dir */);
+    // Returns true when the card actually moved.
+    callback reorder-session(string /* id */, int /* dir */) -> bool;
     // Drag finished (pointer released) → persist the new order.
     callback reorder-end();
-    // List-level drag-to-reorder state: which session is being dragged and its
-    // pointer-follow offset. Kept at list level because hops swap row data
-    // under the pointer grab — the lifted card must follow the dragged
-    // session's data, not the component that owns the grab.
+    // Bumped by Rust whenever the sessions model is rebuilt wholesale; that
+    // destroys the dragging row's pointer grab, so end the drag cleanly
+    // instead of leaving the lifted card stuck (its grab is already gone —
+    // no release event will ever arrive).
+    in property <int> sessions-revision: 0;
+    changed sessions-revision => {
+        if (root.list-dragging) {
+            root.list-dragging = false;
+            root.drag-id = "";
+            root.reorder-end();
+        }
+    }
+    // List-level drag-to-reorder state: which session is being dragged.
+    // Kept at list level because hops swap row data under the pointer grab —
+    // the lifted card must follow the dragged session's data, not the
+    // component that owns the grab.
     property <string> drag-id;
     property <bool> list-dragging: false;
-    property <length> drag-dy: 0px;
     callback toggle-group(string /* group */);
     callback new-group();
     callback edit-group(string /* current-name */);
@@ -760,21 +778,20 @@ export component Welcome inherits Rectangle {
                             all-sessions: root.sessions;
                             // Drag-reorder is meaningless while the list is a
                             // filtered subset, and system rows can't move.
+                            // (Whitespace-only queries never reach here: the
+                            // search handler normalizes them to "".)
                             reorder-enabled: root.search-query == "" && !session.builtin;
                             drag-target: root.list-dragging && root.drag-id == session.id;
-                            drag-dy: root.drag-dy;
                             list-dragging: root.list-dragging;
                             connect => { root.connect-session(session.id); }
                             edit => { root.edit-session(session.id); }
                             duplicate => { root.duplicate-session(session.id); }
                             move-to-group(g) => { root.move-session(session.id, g); }
-                            reorder(dir) => { root.reorder-session(root.drag-id, dir); }
+                            reorder(dir) => { return root.reorder-session(root.drag-id, dir); }
                             drag-start => { root.drag-id = session.id; root.list-dragging = true; }
-                            drag-move(dy) => { root.drag-dy = dy; }
                             drag-end => {
                                 root.list-dragging = false;
                                 root.drag-id = "";
-                                root.drag-dy = 0px;
                                 root.reorder-end();
                             }
                             remove => { root.remove-session(session.id); }

--- a/ui/widgets.slint
+++ b/ui/widgets.slint
@@ -6,6 +6,9 @@ import { Theme } from "theme.slint";
 export component IconButton inherits Rectangle {
     in property <string> glyph;
     in property <string> tooltip;
+    // Empty = default UI font (text glyphs like "+" / "×"); set to
+    // "Material Icons" to render Material codepoints (#multi-window).
+    in property <string> font-family;
     in property <length> size: 28px;
     in property <brush> fg: Theme.text-secondary;
     in property <brush> fg-hover: Theme.text-primary;
@@ -19,6 +22,7 @@ export component IconButton inherits Rectangle {
 
     Text {
         text: glyph;
+        font-family: root.font-family;
         color: touch.has-hover ? fg-hover : fg;
         font-size: Theme.fs-md;
         horizontal-alignment: center;


### PR DESCRIPTION
1. 多窗口支持与标签拖拽管理
   - Chrome 式单进程多窗口：新建/聚焦窗口，实例间 IPC 转发启动意图（--new-window）
   - 标签可拖出当前窗口成为新窗口，也可跨窗口拖动合并

   2.命令栏显隐、字体缩放与专注模式快捷键
   - 工具栏一键显示/隐藏命令栏（快捷命令 + 输入框）
   - 终端字体缩放，支持会话级和全局两种粒度
   - 专注模式快捷键（⌘⌥Z / Ctrl+Alt+Z），命令栏与 SFTP 在专注模式下仍可用

   3. 主机列表拖动排序与会话重命名
   - 会话列表主机卡片支持拖动排序（带拖动动画）
   - 标签右键菜单重命名已打开的会话