### PR TITLE
fix(scroll): 滚动到边界时跳过整屏重建

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -5334,15 +5334,22 @@ fn wire_key_input(
         let weak = window.as_weak();
         window.on_terminal_scroll(move |tab_id: SharedString, delta: i32| {
             let tid = tab_id.to_string();
-            with_term_buf(&bufs_scroll, &tid, |buf| {
+            let changed = with_term_buf(&bufs_scroll, &tid, |buf| {
                 // Scroll within our own session scrollback (history lines above
                 // the live screen).  Offset 0 = live bottom.
                 let max_off = buf.history.len() as i64;
                 let cur = buf.view_offset as i64;
-                buf.view_offset = (cur + delta as i64).clamp(0, max_off) as usize;
+                let new_off = (cur + delta as i64).clamp(0, max_off);
+                let changed = new_off != cur;
+                buf.view_offset = new_off as usize;
+                changed
             });
-            if let Some(win) = weak.upgrade() {
-                rebuild_tab_display(&win, &bufs_scroll, &tid);
+            // Scrolling at a boundary (or an empty scrollback) leaves the offset
+            // unchanged; skip the full rebuild since the screen is identical.
+            if changed == Some(true) {
+                if let Some(win) = weak.upgrade() {
+                    rebuild_tab_display(&win, &bufs_scroll, &tid);
+                }
             }
         });
     }
@@ -5404,12 +5411,19 @@ fn wire_key_input(
         let weak = window.as_weak();
         window.on_terminal_scroll_to(move |tab_id: SharedString, offset: i32| {
             let tid = tab_id.to_string();
-            with_term_buf(&bufs_scroll, &tid, |buf| {
+            let changed = with_term_buf(&bufs_scroll, &tid, |buf| {
                 let max_off = buf.history.len() as i64;
-                buf.view_offset = (offset as i64).clamp(0, max_off) as usize;
+                let new_off = (offset as i64).clamp(0, max_off);
+                let changed = new_off != buf.view_offset as i64;
+                buf.view_offset = new_off as usize;
+                changed
             });
-            if let Some(win) = weak.upgrade() {
-                rebuild_tab_display(&win, &bufs_scroll, &tid);
+            // Same guard as on_terminal_scroll: an unchanged clamped offset
+            // must not pay for a full grid rebuild.
+            if changed == Some(true) {
+                if let Some(win) = weak.upgrade() {
+                    rebuild_tab_display(&win, &bufs_scroll, &tid);
+                }
             }
         });
     }


### PR DESCRIPTION
## 背景

`on_terminal_scroll`（滚轮）与 `on_terminal_scroll_to`（滚动条）此前**无条件**调用 `rebuild_tab_display`，即使 `view_offset` 被 clamp 后没有变化——典型场景：

- 已在顶部/底部继续朝边界滚动；
- scrollback 为空。

## 改动

- 两个 handler 的 `with_term_buf` 闭包改为返回"偏移是否变化"；
- 仅当 `changed == Some(true)` 时才重建，与已有的拖选自动滚动守卫行为对齐。

## 验证

- `cargo check` 通过；
- 临时 `tracing::debug!` 实测：边界滚动打 "skip"、正常滚动打 "rebuild"，验证后日志已移除；
- 全量测试 169/169 通过。
