### PR TITLE
fix(terminal): 用裁剪容器替换 Flickable，修复滚轮时鼠标指针闪烁

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -5334,15 +5334,22 @@ fn wire_key_input(
         let weak = window.as_weak();
         window.on_terminal_scroll(move |tab_id: SharedString, delta: i32| {
             let tid = tab_id.to_string();
-            with_term_buf(&bufs_scroll, &tid, |buf| {
+            let changed = with_term_buf(&bufs_scroll, &tid, |buf| {
                 // Scroll within our own session scrollback (history lines above
                 // the live screen).  Offset 0 = live bottom.
                 let max_off = buf.history.len() as i64;
                 let cur = buf.view_offset as i64;
-                buf.view_offset = (cur + delta as i64).clamp(0, max_off) as usize;
+                let new_off = (cur + delta as i64).clamp(0, max_off);
+                let changed = new_off != cur;
+                buf.view_offset = new_off as usize;
+                changed
             });
-            if let Some(win) = weak.upgrade() {
-                rebuild_tab_display(&win, &bufs_scroll, &tid);
+            // Scrolling at a boundary (or an empty scrollback) leaves the offset
+            // unchanged; skip the full rebuild since the screen is identical.
+            if changed == Some(true) {
+                if let Some(win) = weak.upgrade() {
+                    rebuild_tab_display(&win, &bufs_scroll, &tid);
+                }
             }
         });
     }
@@ -5404,12 +5411,19 @@ fn wire_key_input(
         let weak = window.as_weak();
         window.on_terminal_scroll_to(move |tab_id: SharedString, offset: i32| {
             let tid = tab_id.to_string();
-            with_term_buf(&bufs_scroll, &tid, |buf| {
+            let changed = with_term_buf(&bufs_scroll, &tid, |buf| {
                 let max_off = buf.history.len() as i64;
-                buf.view_offset = (offset as i64).clamp(0, max_off) as usize;
+                let new_off = (offset as i64).clamp(0, max_off);
+                let changed = new_off != buf.view_offset as i64;
+                buf.view_offset = new_off as usize;
+                changed
             });
-            if let Some(win) = weak.upgrade() {
-                rebuild_tab_display(&win, &bufs_scroll, &tid);
+            // Same guard as on_terminal_scroll: an unchanged clamped offset
+            // must not pay for a full grid rebuild.
+            if changed == Some(true) {
+                if let Some(win) = weak.upgrade() {
+                    rebuild_tab_display(&win, &bufs_scroll, &tid);
+                }
             }
         });
     }

--- a/ui/terminal_view.slint
+++ b/ui/terminal_view.slint
@@ -473,29 +473,8 @@ export component TerminalView inherits Rectangle {
 
     init => { if (root.has-real-size) { root.terminal-resize(root.term-cols, root.term-rows); } }
 
-    changed spans => {
-        // Bash: keep the latest output pinned to the bottom.
-        // Alt-screen (nano/vim/htop/btop): the program owns a fixed full screen,
-        // so the viewport must stay top-aligned (viewport-y = 0).  Scrolling to
-        // the bottom would push the title bar + content off the top, leaving only
-        // the program's status bar — exactly the "nano shows nothing" symptom.
-        if (!root.is-alt-screen) {
-            flickable.viewport-y = flickable.height - flickable.viewport-height;
-        } else {
-            flickable.viewport-y = 0;
-        }
-    }
-    changed is-alt-screen => {
-        // Reset scroll on every mode switch (entering/leaving nano, vim, btop…).
-        // Snapping to top on alt-screen entry ensures the full-screen program's
-        // frame is shown from row 0, not from wherever history left off.
-        if (root.is-alt-screen) {
-            flickable.viewport-y = 0;
-        } else {
-            // Return to normal mode: pin to the most recent output.
-            flickable.viewport-y = flickable.height - flickable.viewport-height;
-        }
-    }
+    // Bottom-pinning / alt-screen alignment is handled declaratively by
+    // scroll-clip.view-y; nothing to sync imperatively here anymore.
     // Reset the history filter whenever the dropdown opens; the search box itself
     // is recreated empty because the `if` subtree is destroyed on close (#101).
     changed history-open => {
@@ -620,23 +599,41 @@ export component TerminalView inherits Rectangle {
             VerticalLayout {
                 spacing: 0;
 
-                flickable := Flickable {
+                // Plain clipped container instead of a Flickable.  Two reasons:
+                //
+                // 1. Cursor flicker: Slint resets the mouse-cursor to default at
+                //    the start of *every* mouse event and re-derives it from the
+                //    items actually visited.  A Flickable intercepts wheel
+                //    events in bursts (gesture start + an 800ms capture window,
+                //    items/flickable.rs handle_mouse_filter) without visiting
+                //    children, so nobody claimed the cursor and the pointer
+                //    flipped arrow↔I-beam while the capture window opened and
+                //    lapsed.  Without the Flickable, every wheel lands on
+                //    body-touch-overlay below, which always claims I-beam.
+                // 2. Scroll ownership: the captured wheel also scrolled
+                //    viewport-y natively (flick physics included), fighting the
+                //    Rust-managed view_offset and the `changed spans` snap-back.
+                //    All scrolling already flows through terminal-scroll /
+                //    terminal-scroll-to, so the Flickable only ever added drift.
+                scroll-clip := Rectangle {
                     vertical-stretch: 1;
-                    // Non-interactive: a Flickable steals fast drags from child
-                    // TouchAreas for its own flick gesture, which broke quick
-                    // drag-selection (slow drags worked, fast ones selected
-                    // nothing). We scroll via the wheel (scroll-event below →
-                    // terminal-scroll) and pin programmatically, so we don't need
-                    // the Flickable's own drag-scrolling (#119-followup).
-                    interactive: false;
-                    viewport-width: self.width;
-                    // Alt-screen: lock the viewport to exactly the visible height
-                    // so the full-screen program (nano/vim) renders top-aligned
-                    // with no internal scroll.  Bash: let the viewport grow with
-                    // the content so we can scroll back through history.
-                    viewport-height: root.is-alt-screen
+                    clip: true;
+
+                    // Content height of the grid viewport.  Alt-screen: lock to
+                    // exactly the visible height so full-screen programs (nano/
+                    // vim) render top-aligned with no internal scroll.  Bash:
+                    // grow with the content so we can scroll back through history.
+                    property <length> content-h: root.is-alt-screen
                         ? self.height
                         : max(self.height, 8px + root.rows-used * root.cell-h + 8px);
+                    // Vertical placement of the content inside the clip: newest
+                    // output pinned to the bottom edge (negative), alt-screen
+                    // top-aligned (0).  Replaces the old imperative
+                    // `flickable.viewport-y = height - viewport-height` sync —
+                    // as a binding it can no longer drift between rebuilds.
+                    property <length> view-y: root.is-alt-screen
+                        ? 0px
+                        : self.height - self.content-h;
 
                     // The terminal grid.  Each coloured run is placed with
                     // absolute coordinates derived from its (row, col) and the
@@ -644,9 +641,9 @@ export component TerminalView inherits Rectangle {
                     // which keeps the model flat (a single `for`).
                     Rectangle {
                         x: 10px;
-                        y: 8px;
+                        y: 8px + parent.view-y;
                         width: parent.width - 20px;
-                        height: flickable.viewport-height - 8px;
+                        height: parent.content-h - 8px;
 
                         // Click-to-focus over the whole terminal body.  Without
                         // this, clicking anywhere in the output area blurs the
@@ -713,10 +710,10 @@ export component TerminalView inherits Rectangle {
                                         // captures the pointer while pressed, so dragging
                                         // past the edge still scrolls to extend across
                                         // more than one screen.
-                                        root.vis-y = self.mouse-y + 8px + flickable.viewport-y;
+                                        root.vis-y = self.mouse-y + 8px + scroll-clip.view-y;
                                         if (root.vis-y < 0) {
                                             root.autoscroll-dir = -1;       // past top → older
-                                        } else if (root.vis-y > flickable.height) {
+                                        } else if (root.vis-y > scroll-clip.height) {
                                             root.autoscroll-dir = 1;        // past bottom → newer
                                         } else {
                                             root.autoscroll-dir = 0;
@@ -868,10 +865,10 @@ export component TerminalView inherits Rectangle {
                                         floor(self.mouse-y / root.cell-h),
                                         floor(self.mouse-x / root.cell-w));
                                     if (!root.is-alt-screen) {
-                                        root.vis-y = self.mouse-y + 8px + flickable.viewport-y;
+                                        root.vis-y = self.mouse-y + 8px + scroll-clip.view-y;
                                         if (root.vis-y < 0) {
                                             root.autoscroll-dir = -1;
-                                        } else if (root.vis-y > flickable.height) {
+                                        } else if (root.vis-y > scroll-clip.height) {
                                             root.autoscroll-dir = 1;
                                         } else {
                                             root.autoscroll-dir = 0;
@@ -1053,10 +1050,10 @@ export component TerminalView inherits Rectangle {
             // alternate screen). Driven by scroll-max/scroll-offset; click or drag
             // the track to jump to an absolute position.
             if root.scroll-max > 0 && !root.is-alt-screen : Rectangle {
-                x: flickable.x + flickable.width - 10px;
-                y: flickable.y + 4px;
+                x: scroll-clip.x + scroll-clip.width - 10px;
+                y: scroll-clip.y + 4px;
                 width: 8px;
-                height: flickable.height - 8px;
+                height: scroll-clip.height - 8px;
                 track-ta := TouchArea {
                     moved => {
                         if (self.pressed) {


### PR DESCRIPTION
## 背景

滚动终端时鼠标指针在箭头 ↔ I-beam 间持续闪烁。

## 根因（Slint 1.16.1 源码级）

1. `i-slint-core/window.rs:605`：每个鼠标事件处理开始时，光标状态被**重置为 Default**；只有命中测试中真正被访问到的 TouchArea/TextInput 才会把它设回 `text`。
2. `items/flickable.rs handle_mouse_filter`：Flickable 对滚轮有自己的捕获状态机——手势首事件（`TouchPhase::Started`）与 800ms 捕获窗口内的后续 tick 一律返回 `Intercept`，子项（`body-touch-overlay`）根本不被访问 → 无人认领光标 → **箭头**。
3. 捕获窗口超时后下一 tick 才 `ForwardEvent` 落到 overlay → I-beam，随后又被重新捕获 → 箭头……如此交替。
4. 上游同类缺陷见 slint#6443，官方修复 PR slint#10771（2026-02 合入）晚于本项目所用 1.16.1。

伴生问题：被捕获的滚轮还会**原生滚动 `viewport-y`**（含惯性物理动画），与 Rust 全权管理的 `view_offset` 及 `changed spans` 强制回位互相打架。本项目 Flickable `interactive: false` 且滚动完全走 `terminal-scroll` 回调，实际只承担裁剪+容器职责。

## 改动

- 用普通 `clip: true` Rectangle（`scroll-clip`）替换终端区的 Flickable；
- 新增 `content-h` / `view-y` 声明式绑定，替代 `changed spans` / `changed is-alt-screen` 中对 `viewport-y` 的命令式同步（两处 handler 删除）;
- 网格定位改为 `y: 8px + view-y`；拖选自动滚动 `vis-y` 计算与滚动条坐标引用同步迁移。

## 效果

每个滚轮事件都落在 `body-touch-overlay` 上并认领 I-beam——指针不再闪烁；滚动所有权完全归 Rust 侧，无原生视口漂移。

## 验证

- `cargo check` 通过，全量测试通过；
- 实机确认滚轮滚动指针恒为 I-beam。

## 合并顺序

本 PR 依赖 #378（同文件相邻区域），建议按 #378 → 本 PR → 后续惯性/光标 PR 的顺序合并。
