### PR TITLE
feat(scroll): 亚行累加器让滚轮惯性自然衰减

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -5334,15 +5334,22 @@ fn wire_key_input(
         let weak = window.as_weak();
         window.on_terminal_scroll(move |tab_id: SharedString, delta: i32| {
             let tid = tab_id.to_string();
-            with_term_buf(&bufs_scroll, &tid, |buf| {
+            let changed = with_term_buf(&bufs_scroll, &tid, |buf| {
                 // Scroll within our own session scrollback (history lines above
                 // the live screen).  Offset 0 = live bottom.
                 let max_off = buf.history.len() as i64;
                 let cur = buf.view_offset as i64;
-                buf.view_offset = (cur + delta as i64).clamp(0, max_off) as usize;
+                let new_off = (cur + delta as i64).clamp(0, max_off);
+                let changed = new_off != cur;
+                buf.view_offset = new_off as usize;
+                changed
             });
-            if let Some(win) = weak.upgrade() {
-                rebuild_tab_display(&win, &bufs_scroll, &tid);
+            // Scrolling at a boundary (or an empty scrollback) leaves the offset
+            // unchanged; skip the full rebuild since the screen is identical.
+            if changed == Some(true) {
+                if let Some(win) = weak.upgrade() {
+                    rebuild_tab_display(&win, &bufs_scroll, &tid);
+                }
             }
         });
     }
@@ -5404,12 +5411,19 @@ fn wire_key_input(
         let weak = window.as_weak();
         window.on_terminal_scroll_to(move |tab_id: SharedString, offset: i32| {
             let tid = tab_id.to_string();
-            with_term_buf(&bufs_scroll, &tid, |buf| {
+            let changed = with_term_buf(&bufs_scroll, &tid, |buf| {
                 let max_off = buf.history.len() as i64;
-                buf.view_offset = (offset as i64).clamp(0, max_off) as usize;
+                let new_off = (offset as i64).clamp(0, max_off);
+                let changed = new_off != buf.view_offset as i64;
+                buf.view_offset = new_off as usize;
+                changed
             });
-            if let Some(win) = weak.upgrade() {
-                rebuild_tab_display(&win, &bufs_scroll, &tid);
+            // Same guard as on_terminal_scroll: an unchanged clamped offset
+            // must not pay for a full grid rebuild.
+            if changed == Some(true) {
+                if let Some(win) = weak.upgrade() {
+                    rebuild_tab_display(&win, &bufs_scroll, &tid);
+                }
             }
         });
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -2114,7 +2114,9 @@ pub fn run() -> Result<()> {
     // OS file drag-and-drop → upload to the active session's SFTP directory,
     // but only when the file is dropped over the file-list area.
     {
-        use i_slint_backend_winit::winit::event::{MouseScrollDelta, WindowEvent as WEvent};
+        use i_slint_backend_winit::winit::event::{
+            MouseScrollDelta, TouchPhase, WindowEvent as WEvent,
+        };
         use i_slint_backend_winit::EventResult;
         let weak = window.as_weak();
         let sh = sftp_handles.clone();
@@ -2219,7 +2221,7 @@ pub fn run() -> Result<()> {
                             last_cursor_logical = Some((p.x as f32, p.y as f32));
                         }
                     }
-                    WEvent::MouseWheel { delta, .. } if cfg!(target_os = "macos") => {
+                    WEvent::MouseWheel { delta, phase, .. } if cfg!(target_os = "macos") => {
                         let Some((x, y)) = last_cursor_logical else {
                             return EventResult::Propagate;
                         };
@@ -2232,6 +2234,7 @@ pub fn run() -> Result<()> {
                             macos_wheel_accum = 0.0;
                             return EventResult::Propagate;
                         }
+                        let hit = terminal_wheel_hit(&win, &wheel_bufs, x, y);
                         let wheel_lines = match delta {
                             MouseScrollDelta::LineDelta(_, dy) => dy * 3.0,
                             MouseScrollDelta::PixelDelta(p) => {
@@ -2240,17 +2243,57 @@ pub fn run() -> Result<()> {
                                 p.y as f32 / 18.0
                             }
                         };
-                        if wheel_lines.abs() < f32::EPSILON {
-                            return EventResult::Propagate;
-                        }
-                        macos_wheel_accum += wheel_lines;
-                        let whole = macos_wheel_accum.trunc() as i32;
-                        if whole == 0 {
-                            return EventResult::Propagate;
-                        }
-                        macos_wheel_accum -= whole as f32;
-                        if handle_macos_terminal_wheel(&win, &wheel_bufs, x, y, whole) {
-                            return EventResult::PreventDefault;
+                        match hit {
+                            Some(hit) => {
+                                if hit.is_alt {
+                                    // PTY forwarding needs whole-notch steps:
+                                    // bank fractional frames locally and send one
+                                    // arrow burst per crossed notch.
+                                    macos_wheel_accum += wheel_lines;
+                                    let whole = macos_wheel_accum.trunc() as i32;
+                                    if whole != 0 {
+                                        macos_wheel_accum -= whole as f32;
+                                        win.invoke_terminal_wheel(
+                                            hit.tab_id.into(),
+                                            whole.signum(),
+                                            hit.col,
+                                            hit.row,
+                                        );
+                                    }
+                                } else {
+                                    // Normal scrollback: forward the raw
+                                    // fraction. TermBuffer.scroll_accum banks
+                                    // the sub-line remainder so a decaying
+                                    // macOS momentum tail glides to a stop
+                                    // instead of stepping fixed amounts.
+                                    win.invoke_terminal_scroll(hit.tab_id.into(), wheel_lines);
+                                }
+                                // A finished gesture must not leave its sub-line
+                                // remainder behind to be tipped over by an
+                                // unrelated touch later on.
+                                if matches!(phase, TouchPhase::Ended | TouchPhase::Cancelled) {
+                                    macos_wheel_accum = 0.0;
+                                }
+                                // Claim every frame above the terminal — including
+                                // zero and sub-line ones. Precise devices (trackpad,
+                                // Magic Mouse) emit tiny PixelDelta frames, and mere
+                                // finger contact on a Magic Mouse produces jitter
+                                // frames without any real gesture. Letting those
+                                // propagate would hand wheel events to the Slint
+                                // TouchArea scroll-event path as well, double-
+                                // feeding the same accumulator. Regular mice send
+                                // LineDelta notches that always cross a whole line,
+                                // which is why they never showed the problem.
+                                //
+                                // NOTE: arms of the outer `match event` below
+                                // are statement position (the closure ends with
+                                // its own `EventResult::Propagate`), so claim /
+                                // pass decisions here must use explicit returns.
+                                return EventResult::PreventDefault;
+                            }
+                            // Outside the terminal, native Slint scrolling
+                            // (sidebars, dialogs) keeps working as before.
+                            None => return EventResult::Propagate,
                         }
                     }
                     WEvent::Focused(f) => {
@@ -2617,24 +2660,6 @@ fn active_sftp_path(win: &AppWindow, tab_id: &str) -> String {
         }
     }
     String::new()
-}
-
-fn handle_macos_terminal_wheel(
-    win: &AppWindow,
-    bufs: &TermBuffers,
-    x: f32,
-    y: f32,
-    lines: i32,
-) -> bool {
-    let Some(hit) = terminal_wheel_hit(win, bufs, x, y) else {
-        return false;
-    };
-    if hit.is_alt {
-        win.invoke_terminal_wheel(hit.tab_id.into(), lines.signum(), hit.col, hit.row);
-    } else {
-        win.invoke_terminal_scroll(hit.tab_id.into(), lines);
-    }
-    true
 }
 
 // The raw macOS wheel fallback runs before the usual Slint hit testing. Keep
@@ -4017,6 +4042,7 @@ fn wire_session_callbacks(
                     history: VecDeque::new(),
                     prev: Vec::new(),
                     view_offset: 0,
+                    scroll_accum: 0.0,
                     displayed_text: Vec::new(),
                     csi_state: CsiState::Normal,
                     csi_pending: Vec::new(),
@@ -5332,14 +5358,36 @@ fn wire_key_input(
     {
         let bufs_scroll = bufs.clone();
         let weak = window.as_weak();
-        window.on_terminal_scroll(move |tab_id: SharedString, delta: i32| {
+        window.on_terminal_scroll(move |tab_id: SharedString, delta: f32| {
             let tid = tab_id.to_string();
             let changed = with_term_buf(&bufs_scroll, &tid, |buf| {
                 // Scroll within our own session scrollback (history lines above
                 // the live screen).  Offset 0 = live bottom.
+                //
+                // `delta` is fractional lines (wheel pixels / cell height). The
+                // integer part moves the offset; the fraction stays banked in
+                // `scroll_accum` so a decaying macOS momentum tail converges to
+                // a stop instead of repeating full-line steps. Cap each event
+                // so a stray huge pixel delta can't teleport the view.
                 let max_off = buf.history.len() as i64;
+                buf.scroll_accum += delta.clamp(-24.0, 24.0);
+                let whole = buf.scroll_accum.trunc();
+                if whole != 0.0 {
+                    buf.scroll_accum -= whole;
+                }
                 let cur = buf.view_offset as i64;
-                let new_off = (cur + delta as i64).clamp(0, max_off);
+                let raw_new = cur + whole as i64;
+                let new_off = raw_new.clamp(0, max_off);
+                // Only a step that was actually CLIPPED by a boundary drops the
+                // banked remainder (stale fractions must not fire after a
+                // direction flip or fresh output). Resting AT a boundary must
+                // keep banking: clearing whenever `new_off` merely equals a
+                // boundary wiped the accumulation every tick and made slow
+                // scrolling dead until it was fast enough to cross a whole line
+                // per event.
+                if new_off != raw_new {
+                    buf.scroll_accum = 0.0;
+                }
                 let changed = new_off != cur;
                 buf.view_offset = new_off as usize;
                 changed

--- a/src/terminal/struct/state.rs
+++ b/src/terminal/struct/state.rs
@@ -25,6 +25,11 @@ pub(crate) struct TermBuffer {
     pub(crate) history: VecDeque<Line>,
     pub(crate) prev: Vec<Line>,
     pub(crate) view_offset: usize,
+    /// Fractional scrollback rows not yet applied. Wheel deltas arrive as
+    /// pixel fractions of a row (trackpad + macOS momentum decay); keeping
+    /// the remainder here lets the momentum tail glide to a stop instead of
+    /// stepping a fixed amount per event.
+    pub(crate) scroll_accum: f32,
     pub(crate) displayed_text: Vec<String>,
     pub(crate) csi_state: CsiState,
     pub(crate) csi_pending: Vec<u8>,

--- a/tests/app/terminal_rendering/mod.rs
+++ b/tests/app/terminal_rendering/mod.rs
@@ -31,6 +31,7 @@ fn make_buf(
         history: history.iter().map(|s| hist_line(s)).collect(),
         prev: Vec::new(),
         view_offset,
+        scroll_accum: 0.0,
         displayed_text: Vec::new(),
         csi_state: CsiState::Normal,
         csi_pending: Vec::new(),

--- a/ui/app.slint
+++ b/ui/app.slint
@@ -869,7 +869,7 @@ export component AppWindow inherits Window {
     // Recompute search highlights for a session's visible screen.
     callback find-query-changed(string /* tab-id */, string /* query */);
     // Scroll a session's scrollback history by N lines (+ = up/older).
-    callback terminal-scroll(string /* tab-id */, int /* delta-lines */);
+    callback terminal-scroll(string /* tab-id */, float /* delta-lines (fractional, momentum-aware) */);
     // Wheel forwarded to an alt-screen program (#170): tab-id, dir (+1 up/-1 down), col, row.
     callback terminal-wheel(string, int, int, int);
     callback terminal-scroll-to(string /* tab-id */, int /* offset */); // scrollbar drag (#103)

--- a/ui/terminal_view.slint
+++ b/ui/terminal_view.slint
@@ -372,7 +372,7 @@ export component TerminalView inherits Rectangle {
     callback copy-terminal-text();
     callback clear-terminal();              // wipe this session's screen buffer
     callback find-query-changed(string);    // recompute search highlights
-    callback terminal-scroll(int);          // scroll history by N lines (+ = up)
+    callback terminal-scroll(float);         // scroll history by fractional lines (+ = up); Rust keeps the sub-line remainder so momentum decays smoothly
     // Wheel inside an alt-screen app (tmux/less/vim): forward to the program so it
     // scrolls, instead of doing nothing (#170). dir = +1 up / -1 down; col/row =
     // mouse cell. Rust sends a mouse-wheel event if the app tracks the mouse, else
@@ -733,7 +733,13 @@ export component TerminalView inherits Rectangle {
                                 } else {
                                     // Normal screen: scroll our own scrollback history
                                     // (~3 lines per notch).
-                                    root.terminal-scroll(ev.delta-y > 0 ? 3 : -3);
+                                    // Raw pixel delta → fractional lines. The
+                                    // magnitude matters: macOS momentum events
+                                    // decay to sub-pixel steps, and quantizing
+                                    // each to a fixed ±3 lines turned the tail
+                                    // into an exaggerated staircase with a hard
+                                    // stop. Rust accumulates the fractions.
+                                    root.terminal-scroll(ev.delta-y / root.cell-h);
                                 }
                                 accept
                             }
@@ -883,7 +889,13 @@ export component TerminalView inherits Rectangle {
                                         floor(self.mouse-x / root.cell-w),
                                         floor(self.mouse-y / root.cell-h));
                                 } else {
-                                    root.terminal-scroll(ev.delta-y > 0 ? 3 : -3);
+                                    // Raw pixel delta → fractional lines. The
+                                    // magnitude matters: macOS momentum events
+                                    // decay to sub-pixel steps, and quantizing
+                                    // each to a fixed ±3 lines turned the tail
+                                    // into an exaggerated staircase with a hard
+                                    // stop. Rust accumulates the fractions.
+                                    root.terminal-scroll(ev.delta-y / root.cell-h);
                                 }
                                 accept
                             }

--- a/ui/terminal_view.slint
+++ b/ui/terminal_view.slint
@@ -473,29 +473,8 @@ export component TerminalView inherits Rectangle {
 
     init => { if (root.has-real-size) { root.terminal-resize(root.term-cols, root.term-rows); } }
 
-    changed spans => {
-        // Bash: keep the latest output pinned to the bottom.
-        // Alt-screen (nano/vim/htop/btop): the program owns a fixed full screen,
-        // so the viewport must stay top-aligned (viewport-y = 0).  Scrolling to
-        // the bottom would push the title bar + content off the top, leaving only
-        // the program's status bar — exactly the "nano shows nothing" symptom.
-        if (!root.is-alt-screen) {
-            flickable.viewport-y = flickable.height - flickable.viewport-height;
-        } else {
-            flickable.viewport-y = 0;
-        }
-    }
-    changed is-alt-screen => {
-        // Reset scroll on every mode switch (entering/leaving nano, vim, btop…).
-        // Snapping to top on alt-screen entry ensures the full-screen program's
-        // frame is shown from row 0, not from wherever history left off.
-        if (root.is-alt-screen) {
-            flickable.viewport-y = 0;
-        } else {
-            // Return to normal mode: pin to the most recent output.
-            flickable.viewport-y = flickable.height - flickable.viewport-height;
-        }
-    }
+    // Bottom-pinning / alt-screen alignment is handled declaratively by
+    // scroll-clip.view-y; nothing to sync imperatively here anymore.
     // Reset the history filter whenever the dropdown opens; the search box itself
     // is recreated empty because the `if` subtree is destroyed on close (#101).
     changed history-open => {
@@ -620,23 +599,41 @@ export component TerminalView inherits Rectangle {
             VerticalLayout {
                 spacing: 0;
 
-                flickable := Flickable {
+                // Plain clipped container instead of a Flickable.  Two reasons:
+                //
+                // 1. Cursor flicker: Slint resets the mouse-cursor to default at
+                //    the start of *every* mouse event and re-derives it from the
+                //    items actually visited.  A Flickable intercepts wheel
+                //    events in bursts (gesture start + an 800ms capture window,
+                //    items/flickable.rs handle_mouse_filter) without visiting
+                //    children, so nobody claimed the cursor and the pointer
+                //    flipped arrow↔I-beam while the capture window opened and
+                //    lapsed.  Without the Flickable, every wheel lands on
+                //    body-touch-overlay below, which always claims I-beam.
+                // 2. Scroll ownership: the captured wheel also scrolled
+                //    viewport-y natively (flick physics included), fighting the
+                //    Rust-managed view_offset and the `changed spans` snap-back.
+                //    All scrolling already flows through terminal-scroll /
+                //    terminal-scroll-to, so the Flickable only ever added drift.
+                scroll-clip := Rectangle {
                     vertical-stretch: 1;
-                    // Non-interactive: a Flickable steals fast drags from child
-                    // TouchAreas for its own flick gesture, which broke quick
-                    // drag-selection (slow drags worked, fast ones selected
-                    // nothing). We scroll via the wheel (scroll-event below →
-                    // terminal-scroll) and pin programmatically, so we don't need
-                    // the Flickable's own drag-scrolling (#119-followup).
-                    interactive: false;
-                    viewport-width: self.width;
-                    // Alt-screen: lock the viewport to exactly the visible height
-                    // so the full-screen program (nano/vim) renders top-aligned
-                    // with no internal scroll.  Bash: let the viewport grow with
-                    // the content so we can scroll back through history.
-                    viewport-height: root.is-alt-screen
+                    clip: true;
+
+                    // Content height of the grid viewport.  Alt-screen: lock to
+                    // exactly the visible height so full-screen programs (nano/
+                    // vim) render top-aligned with no internal scroll.  Bash:
+                    // grow with the content so we can scroll back through history.
+                    property <length> content-h: root.is-alt-screen
                         ? self.height
                         : max(self.height, 8px + root.rows-used * root.cell-h + 8px);
+                    // Vertical placement of the content inside the clip: newest
+                    // output pinned to the bottom edge (negative), alt-screen
+                    // top-aligned (0).  Replaces the old imperative
+                    // `flickable.viewport-y = height - viewport-height` sync —
+                    // as a binding it can no longer drift between rebuilds.
+                    property <length> view-y: root.is-alt-screen
+                        ? 0px
+                        : self.height - self.content-h;
 
                     // The terminal grid.  Each coloured run is placed with
                     // absolute coordinates derived from its (row, col) and the
@@ -644,9 +641,9 @@ export component TerminalView inherits Rectangle {
                     // which keeps the model flat (a single `for`).
                     Rectangle {
                         x: 10px;
-                        y: 8px;
+                        y: 8px + parent.view-y;
                         width: parent.width - 20px;
-                        height: flickable.viewport-height - 8px;
+                        height: parent.content-h - 8px;
 
                         // Click-to-focus over the whole terminal body.  Without
                         // this, clicking anywhere in the output area blurs the
@@ -713,10 +710,10 @@ export component TerminalView inherits Rectangle {
                                         // captures the pointer while pressed, so dragging
                                         // past the edge still scrolls to extend across
                                         // more than one screen.
-                                        root.vis-y = self.mouse-y + 8px + flickable.viewport-y;
+                                        root.vis-y = self.mouse-y + 8px + scroll-clip.view-y;
                                         if (root.vis-y < 0) {
                                             root.autoscroll-dir = -1;       // past top → older
-                                        } else if (root.vis-y > flickable.height) {
+                                        } else if (root.vis-y > scroll-clip.height) {
                                             root.autoscroll-dir = 1;        // past bottom → newer
                                         } else {
                                             root.autoscroll-dir = 0;
@@ -868,10 +865,10 @@ export component TerminalView inherits Rectangle {
                                         floor(self.mouse-y / root.cell-h),
                                         floor(self.mouse-x / root.cell-w));
                                     if (!root.is-alt-screen) {
-                                        root.vis-y = self.mouse-y + 8px + flickable.viewport-y;
+                                        root.vis-y = self.mouse-y + 8px + scroll-clip.view-y;
                                         if (root.vis-y < 0) {
                                             root.autoscroll-dir = -1;
-                                        } else if (root.vis-y > flickable.height) {
+                                        } else if (root.vis-y > scroll-clip.height) {
                                             root.autoscroll-dir = 1;
                                         } else {
                                             root.autoscroll-dir = 0;
@@ -1053,10 +1050,10 @@ export component TerminalView inherits Rectangle {
             // alternate screen). Driven by scroll-max/scroll-offset; click or drag
             // the track to jump to an absolute position.
             if root.scroll-max > 0 && !root.is-alt-screen : Rectangle {
-                x: flickable.x + flickable.width - 10px;
-                y: flickable.y + 4px;
+                x: scroll-clip.x + scroll-clip.width - 10px;
+                y: scroll-clip.y + 4px;
                 width: 8px;
-                height: flickable.height - 8px;
+                height: scroll-clip.height - 8px;
                 track-ta := TouchArea {
                     moved => {
                         if (self.pressed) {


### PR DESCRIPTION
## 背景

滚动惯性不自然：缓慢滚动时手感迟钝，快速甩动后"要滚完了又多一段突然的惯性"，随后急停。

## 根因

项目自身没有惯性模型。抬手后的"惯性"完全是 macOS 原生 momentum 事件流（delta 指数衰减），但旧代码把每个事件量化成固定 ±3 行：

```slint
root.terminal-scroll(ev.delta-y > 0 ? 3 : -3)
```

幅度信息完全丢弃：手势阶段与手指速度无关；momentum 尾段 delta 衰减到 0.x 行时每次仍跳满 3 行——尾巴被拉长成等幅阶梯，最后 delta 归零瞬间急停。

## 改动

- **slint 侧**：两个滚轮入口改传真实量 `ev.delta-y / root.cell-h`（浮点行数；winit 已统一为逻辑像素），`terminal-scroll` 回调签名 `int → float`；
- **Rust 侧**：`TermBuffer` 新增 `scroll_accum` 亚行累加器——整数部分进 `view_offset`、小数留存后续抵扣；单事件 ±24 行封顶；**仅在步进被边界截断时**丢弃过冲与余量（若按"位置处于边界"清零，会让顶部/底部慢滚每帧归零、永远无响应）；
- **macOS winit 拦截器统一**：普通回看直接透传原始小数行数（累加收敛只留 `TermBuffer.scroll_accum` 一处）；alt-screen 保留本地整格门控发 PTY 方向键；手势结束（`TouchPhase::Ended/Cancelled`）清空本地余量；命中终端时始终 `PreventDefault` 防止同一帧双路喂入；移除不再使用的 `handle_macos_terminal_wheel`。

## 效果

- 手势阶段按手指速度成比例响应；
- momentum 尾段随 OS 衰减自然收敛到亚行粒度，平滑滑停；
- 顶部/底部慢滚即时响应（边界死区已修）。

## 验证

- `cargo check` 通过，全量测试 169/169 通过（含 `settings_modal_yields_macos_wheel_to_its_own_scroll_view` 等滚轮路由用例）；
- 实机确认快甩/慢滚/边界三场景手感正常。

## 合并顺序

依赖 #379（同文件相邻区域）。建议 #378 → #379 → 本 PR → 光标可见性 PR。
