### PR TITLE
feat(terminal): 支持 rz ZMODEM 文件上传

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes are documented here. 本文件记录所有重要变更。
 
 ## [0.7.0] - 2026-08-27
 
+- **终端内 ZMODEM 支持 `rz` 上传（#308）。** 远端执行 `rz` 后会自动打开本地多文件选择器，通过当前 SSH PTY 上传所选文件，并在传输列表显示进度；取消选择、协议错误或远端取消时会发送标准取消序列，避免会话卡住。握手检测现在会区分 `sz` 的 `ZRQINIT` 与 `rz` 的 `ZRINIT`，已有 `sz` 下载保持不变。
+- **Support in-terminal ZMODEM uploads with `rz` (#308).** Running `rz` remotely now opens a local multi-file picker, uploads the selected files over the current SSH PTY, and reports progress in the transfer list. Cancelling the picker, protocol failures, and remote aborts send the standard cancel sequence so the shell does not hang. Handshake detection now distinguishes `sz`'s `ZRQINIT` from `rz`'s `ZRINIT`, while existing `sz` downloads remain unchanged.
+
 - **新增 Android Beta 安装包。** 发布流水线现在构建 ARM64 APK，以 `-beta.apk` 后缀作为工作流产物并自动附加到 GitHub Release。首个实验版提供密码认证、交互式 SSH Shell 和每次连接前的服务器 SHA-256 密钥指纹确认；桌面版的构建与功能保持不变。
 - **Add an Android Beta package.** The release workflow now builds an ARM64 APK, stores it as a `-beta.apk` workflow artifact, and attaches it to tagged GitHub Releases. This first experimental build provides password authentication, an interactive SSH shell, and per-connection SHA-256 server-key confirmation; desktop builds and features remain unchanged.
 

--- a/README.en.md
+++ b/README.en.md
@@ -94,7 +94,7 @@ open /Applications/meatshell.app
     / `~/.config/meatshell/sessions.json` (Linux)
     / `~/Library/Application Support/meatshell/sessions.json` (macOS)
 - [x] SSH (`russh`, pure Rust): password / private key / encrypted key (passphrase)
-- [x] SFTP browser + upload / download (drag-and-drop) + in-terminal ZMODEM (`sz`) receive
+- [x] SFTP browser + upload / download (drag-and-drop) + in-terminal ZMODEM (`sz` download / `rz` multi-file upload)
 - [x] SSH port forwarding / tunnels: local -L / remote -R / dynamic -D (SOCKS5)
 - [x] Quick commands + command box (broadcast to all sessions) + command history
 - [x] Serial / Telnet sessions

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ open /Applications/meatshell.app
     / `~/.config/meatshell/sessions.json`（Linux）
     / `~/Library/Application Support/meatshell/sessions.json`（macOS）
 - [x] SSH（`russh`，纯 Rust）：密码 / 私钥 / 加密私钥（密码短语）
-- [x] SFTP 文件浏览 + 上传 / 下载（拖拽）+ 终端内 ZMODEM（`sz`）接收
+- [x] SFTP 文件浏览 + 上传 / 下载（拖拽）+ 终端内 ZMODEM（`sz` 下载 / `rz` 多文件上传）
 - [x] SSH 端口转发 / 隧道：本地 -L / 远程 -R / 动态 -D（SOCKS5）
 - [x] 快捷命令 + 命令输入框（可群发到所有会话）+ 命令历史
 - [x] 串口 / Telnet 会话

--- a/src/ssh/impls/ssh.rs
+++ b/src/ssh/impls/ssh.rs
@@ -1884,6 +1884,16 @@ async fn run_session(
                                         zmodem_done_at = Some(std::time::Instant::now());
                                         continue;
                                     }
+                                    let _ = events.send(SessionEvent::Output(format!(
+                                        "\r\n[meatshell] {} {}...\r\n",
+                                        t("开始上传", "Uploading"),
+                                        files
+                                            .iter()
+                                            .filter_map(|path| path.file_name())
+                                            .map(|name| name.to_string_lossy())
+                                            .collect::<Vec<_>>()
+                                            .join(", ")
+                                    )));
                                     crate::terminal::zmodem::send(
                                         &mut channel,
                                         &data,
@@ -1912,7 +1922,7 @@ async fn run_session(
                                     tracing::warn!("zmodem {direction:?} failed: {e:#}");
                                     let _ = channel.data(&ZMODEM_CANCEL[..]).await;
                                     let _ = events.send(SessionEvent::Output(format!(
-                                        "\r\n[meatshell] {}: {e}\r\n",
+                                        "\r\n[meatshell] {}: {e:#}\r\n",
                                         match direction {
                                             ZmodemDirection::Download => t(
                                                 "ZMODEM 接收失败,已取消",

--- a/src/ssh/impls/ssh.rs
+++ b/src/ssh/impls/ssh.rs
@@ -375,15 +375,40 @@ async fn remote_supports_prompt_setup(handle: &Handle<ClientHandler>) -> bool {
         .unwrap_or(false)
 }
 
-/// Detect the start of a ZMODEM transfer (sz/rz) in a raw channel chunk.
-///
-/// Every ZMODEM frame begins with ZDLE (0x18) followed by a type byte; the
-/// `sz` handshake leads with a ZRQINIT hex header (`**\x18B00...`). Matching
-/// ZDLE followed by `B` (hex frame) or `C` (binary frame) reliably catches the
-/// handshake without false-positiving on a lone 0x18 (Ctrl-X) in normal output.
-fn contains_zmodem_init(data: &[u8]) -> bool {
-    data.windows(2)
-        .any(|w| w[0] == 0x18 && (w[1] == b'B' || w[1] == b'C'))
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ZmodemDirection {
+    /// Remote `sz` sends files; MeatShell receives them.
+    Download,
+    /// Remote `rz` receives files; MeatShell sends selected local files.
+    Upload,
+}
+
+/// Identify the first hex ZMODEM handshake by its actual frame type. Remote
+/// `sz` starts with ZRQINIT (`00`), while remote `rz` starts with ZRINIT (`01`).
+/// Treating both as a receive operation made `rz` deadlock because each side
+/// waited for the other to start sending (#308).
+fn zmodem_direction(data: &[u8]) -> Option<ZmodemDirection> {
+    data.windows(4).find_map(|window| {
+        if window[0] != 0x18 || window[1] != b'B' {
+            return None;
+        }
+        let high = zmodem_hex_nibble(window[2])?;
+        let low = zmodem_hex_nibble(window[3])?;
+        match (high << 4) | low {
+            0 => Some(ZmodemDirection::Download),
+            1 => Some(ZmodemDirection::Upload),
+            _ => None,
+        }
+    })
+}
+
+fn zmodem_hex_nibble(value: u8) -> Option<u8> {
+    match value {
+        b'0'..=b'9' => Some(value - b'0'),
+        b'a'..=b'f' => Some(value - b'a' + 10),
+        b'A'..=b'F' => Some(value - b'A' + 10),
+        _ => None,
+    }
 }
 
 fn line_start_before(text: &str, pos: usize) -> usize {
@@ -1824,14 +1849,50 @@ async fn run_session(
             msg = channel.wait() => {
                 match msg {
                     Some(ChannelMsg::Data { data }) => {
-                        // A `sz` in the terminal starts a ZMODEM send. Receive it
-                        // straight to the Downloads dir (FinalShell style, #76).
-                        // On any protocol error, cancel so the session recovers.
+                        // Route the two ZMODEM handshakes in opposite directions:
+                        // remote `sz` downloads into Downloads; remote `rz` opens
+                        // a local multi-file picker and uploads the selection.
                         let zmodem_cooldown = zmodem_done_at
                             .is_some_and(|t| t.elapsed() < std::time::Duration::from_secs(2));
-                        if !zmodem_cooldown && contains_zmodem_init(&data) {
-                            let result =
-                                crate::terminal::zmodem::receive(&mut channel, &data, &events).await;
+                        if let Some(direction) = (!zmodem_cooldown)
+                            .then(|| zmodem_direction(&data))
+                            .flatten()
+                        {
+                            let result = match direction {
+                                ZmodemDirection::Download => {
+                                    crate::terminal::zmodem::receive(&mut channel, &data, &events)
+                                        .await
+                                }
+                                ZmodemDirection::Upload => {
+                                    let files = tokio::task::spawn_blocking(|| {
+                                        rfd::FileDialog::new()
+                                            .set_title(t(
+                                                "选择要通过 rz 上传的文件",
+                                                "Choose files to upload via rz",
+                                            ))
+                                            .pick_files()
+                                            .unwrap_or_default()
+                                    })
+                                    .await
+                                    .unwrap_or_default();
+                                    if files.is_empty() {
+                                        let _ = channel.data(&ZMODEM_CANCEL[..]).await;
+                                        let _ = events.send(SessionEvent::Output(format!(
+                                            "\r\n[meatshell] {}\r\n",
+                                            t("已取消 rz 上传", "rz upload cancelled")
+                                        )));
+                                        zmodem_done_at = Some(std::time::Instant::now());
+                                        continue;
+                                    }
+                                    crate::terminal::zmodem::send(
+                                        &mut channel,
+                                        &data,
+                                        &files,
+                                        &events,
+                                    )
+                                    .await
+                                }
+                            };
                             zmodem_done_at = Some(std::time::Instant::now());
                             match result {
                                 Ok(leftover) => {
@@ -1848,12 +1909,21 @@ async fn run_session(
                                     }
                                 }
                                 Err(e) => {
-                                    tracing::warn!("zmodem receive failed: {e:#}");
+                                    tracing::warn!("zmodem {direction:?} failed: {e:#}");
                                     let _ = channel.data(&ZMODEM_CANCEL[..]).await;
                                     let _ = events.send(SessionEvent::Output(format!(
                                         "\r\n[meatshell] {}: {e}\r\n",
-                                        t("ZMODEM 接收失败,已取消", "ZMODEM receive failed; cancelled")
-                                    ).into()));
+                                        match direction {
+                                            ZmodemDirection::Download => t(
+                                                "ZMODEM 接收失败,已取消",
+                                                "ZMODEM receive failed; cancelled",
+                                            ),
+                                            ZmodemDirection::Upload => t(
+                                                "ZMODEM 上传失败,已取消",
+                                                "ZMODEM upload failed; cancelled",
+                                            ),
+                                        }
+                                    )));
                                 }
                             }
                             continue;
@@ -2995,6 +3065,29 @@ mod prompt_setup_echo_tests {
 
         assert_eq!(parser.screen().contents().lines().next(), Some(prompt));
         assert_eq!(parser.screen().cursor_position(), (0, prompt.len() as u16));
+    }
+}
+
+#[cfg(test)]
+mod zmodem_detection_tests {
+    use super::{zmodem_direction, ZmodemDirection};
+
+    #[test]
+    fn distinguishes_remote_sz_from_remote_rz() {
+        assert_eq!(
+            zmodem_direction(b"**\x18B00000000000000\r\n"),
+            Some(ZmodemDirection::Download)
+        );
+        assert_eq!(
+            zmodem_direction(b"rz waiting to receive.**\x18B0100000023be50\r\n\x11"),
+            Some(ZmodemDirection::Upload)
+        );
+    }
+
+    #[test]
+    fn ignores_non_handshake_frames_and_ctrl_x() {
+        assert_eq!(zmodem_direction(b"plain \x18 text"), None);
+        assert_eq!(zmodem_direction(b"**\x18B08000000000000\r\n"), None);
     }
 }
 

--- a/src/terminal/impls/zmodem.rs
+++ b/src/terminal/impls/zmodem.rs
@@ -325,11 +325,13 @@ impl<'a> Rx<'a> {
         if crc16(&bytes) != crc {
             bail!("hex header CRC mismatch");
         }
-        // Swallow the trailing CR/LF (+ optional XON) up to the newline.
+        // Swallow the trailing CR/LF (+ optional XON) up to the newline. GNU
+        // lrzsz sets the high bit on LF (`0x8a`). ZFIN has no following XON, so
+        // failing to recognise that byte deadlocks: we wait for a third byte
+        // while remote `rz` waits for our final "OO" (#308).
         for _ in 0..3 {
-            match self.byte().await? {
-                b'\n' => break,
-                _ => continue,
+            if is_zmodem_line_feed(self.byte().await?) {
+                break;
             }
         }
         Ok((bytes[0], [bytes[1], bytes[2], bytes[3], bytes[4]]))
@@ -496,6 +498,10 @@ fn from_hex(c: u8) -> Result<u8> {
     }
 }
 
+fn is_zmodem_line_feed(byte: u8) -> bool {
+    byte & 0x7f == b'\n'
+}
+
 /// CRC-16/XMODEM (poly 0x1021, init 0, no final xor) — ZMODEM header/subpacket.
 fn crc16(data: &[u8]) -> u16 {
     let mut crc: u16 = 0;
@@ -542,6 +548,13 @@ mod tests {
     fn crc32_known_vector() {
         // CRC-32 of "123456789" is 0xCBF43926.
         assert_eq!(crc32_of(b"123456789"), 0xCBF4_3926);
+    }
+
+    #[test]
+    fn accepts_lrzsz_high_bit_line_feed() {
+        assert!(is_zmodem_line_feed(b'\n'));
+        assert!(is_zmodem_line_feed(0x8a));
+        assert!(!is_zmodem_line_feed(b'\r'));
     }
 
     #[test]

--- a/src/terminal/impls/zmodem.rs
+++ b/src/terminal/impls/zmodem.rs
@@ -1,4 +1,4 @@
-//! Minimal ZMODEM **receiver** — the `rz` side of an `sz` transfer (#76).
+//! Minimal bidirectional ZMODEM implementation for terminal `sz` / `rz`.
 //!
 //! When the user runs `sz <file>` in the terminal, the remote starts a ZMODEM
 //! send. We implement just enough of the protocol to receive: reply to ZRQINIT
@@ -9,9 +9,10 @@
 //! We advertise CANFC32, so the sender uses CRC-32 binary frames; the CRC-16
 //! paths are implemented for completeness but rarely exercised.
 //!
-//! This is intentionally a *receive-only* implementation; `rz` (upload) is not
-//! handled here. Every header is logged at debug level to aid diagnosis, since
-//! the binary protocol can't easily be tested without a live server.
+//! When the remote runs `rz`, the complementary sender path lets the user pick
+//! local files and streams them over the existing PTY. Every header is logged
+//! at debug level to aid diagnosis, since the binary protocol is otherwise hard
+//! to inspect.
 
 use crate::i18n::t;
 use crate::ssh::SessionEvent;
@@ -24,11 +25,16 @@ use std::time::Duration;
 use tokio::io::AsyncWriteExt;
 use tokio::sync::mpsc::UnboundedSender;
 
+#[path = "zmodem_send.rs"]
+mod send_impl;
+pub(crate) use send_impl::send;
+
 // --- Frame types -----------------------------------------------------------
 const ZRQINIT: u8 = 0;
 const ZRINIT: u8 = 1;
 const ZACK: u8 = 3;
 const ZFILE: u8 = 4;
+const ZSKIP: u8 = 5;
 const ZNAK: u8 = 6;
 const ZABORT: u8 = 7;
 const ZFIN: u8 = 8;
@@ -113,7 +119,7 @@ pub async fn receive(
                     .await
                     .with_context(|| format!("create {}", path.display()))?;
                 let id = format!("zmodem-{}", uuid::Uuid::new_v4());
-                emit(events, &id, &name, 0, size, 0, "");
+                emit(events, &id, &name, (false, 0, size, 0, ""));
                 cur = Some(CurFile {
                     file,
                     name,
@@ -132,10 +138,7 @@ pub async fn receive(
                         events,
                         &c.id,
                         &c.name,
-                        c.written,
-                        c.size.max(c.written),
-                        0,
-                        "",
+                        (false, c.written, c.size.max(c.written), 0, ""),
                     );
                 }
                 match end {
@@ -160,10 +163,7 @@ pub async fn receive(
                         events,
                         &c.id,
                         &c.name,
-                        c.written,
-                        c.size.max(c.written),
-                        1,
-                        "",
+                        (false, c.written, c.size.max(c.written), 1, ""),
                     );
                     received += 1;
                 }
@@ -468,15 +468,13 @@ fn emit(
     events: &UnboundedSender<SessionEvent>,
     id: &str,
     name: &str,
-    transferred: u64,
-    total: u64,
-    state: u8,
-    msg: &str,
+    progress: (bool, u64, u64, u8, &str),
 ) {
+    let (is_upload, transferred, total, state, msg) = progress;
     let _ = events.send(SessionEvent::SftpTransfer {
         id: id.to_string(),
         name: name.to_string(),
-        is_upload: false,
+        is_upload,
         transferred,
         total,
         state,

--- a/src/terminal/impls/zmodem_send.rs
+++ b/src/terminal/impls/zmodem_send.rs
@@ -1,0 +1,294 @@
+//! ZMODEM sender used when the remote shell runs `rz`.
+
+use super::*;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, UNIX_EPOCH};
+use tokio::io::{AsyncReadExt, AsyncSeekExt};
+
+const SEND_BLOCK_SIZE: usize = 16 * 1024;
+
+/// Send one or more local files to a remote `rz`. `first` contains the ZRINIT
+/// frame that triggered upload detection. The returned bytes belong to the
+/// shell after the ZMODEM close handshake and must be rendered by the caller.
+pub(crate) async fn send(
+    channel: &mut Channel<Msg>,
+    first: &[u8],
+    files: &[PathBuf],
+    events: &UnboundedSender<SessionEvent>,
+) -> Result<Vec<u8>> {
+    tracing::debug!(
+        "zmodem: send start, first[{}]={:02x?}, files={}",
+        first.len(),
+        &first[..first.len().min(80)],
+        files.len()
+    );
+
+    let mut io = Rx::new(channel, first);
+    let receiver = wait_for_header(&mut io, &[ZRINIT]).await?;
+    let crc32 = receiver.1[3] & CANFC32 != 0;
+    let total_bytes = files
+        .iter()
+        .filter_map(|path| path.metadata().ok())
+        .map(|metadata| metadata.len())
+        .sum();
+    let mut bytes_left = total_bytes;
+
+    for (index, path) in files.iter().enumerate() {
+        let size = tokio::fs::metadata(path)
+            .await
+            .with_context(|| format!("read metadata for {}", path.display()))?
+            .len();
+        if size > u32::MAX as u64 {
+            bail!(
+                "{}: {}",
+                t(
+                    "ZMODEM 不支持上传超过 4 GiB 的单个文件",
+                    "ZMODEM cannot upload an individual file larger than 4 GiB"
+                ),
+                path.display()
+            );
+        }
+        let files_left = files.len().saturating_sub(index);
+        send_file(&mut io, path, size, files_left, bytes_left, crc32, events).await?;
+        bytes_left = bytes_left.saturating_sub(size);
+    }
+
+    io.send_hex(ZFIN, [0; 4]).await?;
+    let _ = wait_for_header(&mut io, &[ZFIN]).await?;
+    io.ch
+        .data(&b"OO"[..])
+        .await
+        .context("zmodem send close marker")?;
+
+    // `byte()` pulls a whole SSH chunk; putting the first prompt byte back
+    // preserves that complete chunk for the normal terminal output path.
+    if io.buf.is_empty() {
+        if let Ok(Ok(first_prompt_byte)) =
+            tokio::time::timeout(Duration::from_millis(800), io.byte()).await
+        {
+            io.buf.push_front(first_prompt_byte);
+        }
+    }
+
+    let _ = events.send(SessionEvent::Output(format!(
+        "\r\n[meatshell] {} {}\r\n",
+        files.len(),
+        t("个文件已通过 rz 上传", "file(s) uploaded via rz")
+    )));
+    Ok(io.buf.drain(..).collect())
+}
+
+async fn send_file(
+    io: &mut Rx<'_>,
+    path: &Path,
+    size: u64,
+    files_left: usize,
+    bytes_left: u64,
+    crc32: bool,
+    events: &UnboundedSender<SessionEvent>,
+) -> Result<()> {
+    let name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .filter(|value| !value.is_empty())
+        .unwrap_or("upload");
+    let id = format!("zmodem-{}", uuid::Uuid::new_v4());
+    emit(events, &id, name, (true, 0, size, 0, ""));
+
+    let result = send_file_inner(
+        io, path, name, size, files_left, bytes_left, crc32, events, &id,
+    )
+    .await;
+    match &result {
+        Ok(()) => emit(events, &id, name, (true, size, size, 1, "")),
+        Err(error) => emit(events, &id, name, (true, 0, size, 2, &error.to_string())),
+    }
+    result
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn send_file_inner(
+    io: &mut Rx<'_>,
+    path: &Path,
+    name: &str,
+    size: u64,
+    files_left: usize,
+    bytes_left: u64,
+    crc32: bool,
+    events: &UnboundedSender<SessionEvent>,
+    id: &str,
+) -> Result<()> {
+    let metadata = tokio::fs::metadata(path).await?;
+    let modified = metadata
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0);
+    let info = file_info(name, size, modified, files_left, bytes_left);
+
+    // A receiver may repeat ZRINIT while the file picker is open. Resend ZFILE
+    // until the current receiver answers with the requested starting offset.
+    io.send_bin(ZFILE, [0; 4], crc32).await?;
+    io.send_subpacket(info.as_bytes(), ZCRCW, crc32).await?;
+    let mut requested = loop {
+        let (frame, data) = io.read_header().await?;
+        tracing::debug!("zmodem upload rx header type={frame} data={data:02x?}");
+        match frame {
+            ZRPOS => break u32::from_le_bytes(data) as u64,
+            ZSKIP => return Ok(()),
+            ZCAN | ZABORT => bail!("{}", t("传输被远端取消", "transfer aborted by receiver")),
+            ZRINIT => {
+                io.send_bin(ZFILE, [0; 4], crc32).await?;
+                io.send_subpacket(info.as_bytes(), ZCRCW, crc32).await?;
+            }
+            _ => {}
+        }
+    };
+
+    loop {
+        if requested > size {
+            bail!("receiver requested invalid offset {requested} for {size}-byte file");
+        }
+        let mut file = tokio::fs::File::open(path)
+            .await
+            .with_context(|| format!("open {}", path.display()))?;
+        file.seek(std::io::SeekFrom::Start(requested)).await?;
+        io.send_bin(ZDATA, (requested as u32).to_le_bytes(), crc32)
+            .await?;
+
+        let mut position = requested;
+        let mut buffer = vec![0u8; SEND_BLOCK_SIZE];
+        if position == size {
+            io.send_subpacket(&[], ZCRCE, crc32).await?;
+        } else {
+            while position < size {
+                let read = file.read(&mut buffer).await.context("read upload file")?;
+                if read == 0 {
+                    bail!("upload file ended at {position} of {size} bytes");
+                }
+                position += read as u64;
+                let terminator = if position == size { ZCRCE } else { ZCRCG };
+                io.send_subpacket(&buffer[..read], terminator, crc32)
+                    .await?;
+                emit(events, id, name, (true, position, size, 0, ""));
+            }
+        }
+        io.send_bin(ZEOF, (position as u32).to_le_bytes(), crc32)
+            .await?;
+
+        loop {
+            let (frame, data) = io.read_header().await?;
+            tracing::debug!("zmodem upload rx header type={frame} data={data:02x?}");
+            match frame {
+                ZRINIT => return Ok(()),
+                ZRPOS => {
+                    requested = u32::from_le_bytes(data) as u64;
+                    break;
+                }
+                ZSKIP => return Ok(()),
+                ZCAN | ZABORT => {
+                    bail!("{}", t("传输被远端取消", "transfer aborted by receiver"))
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+async fn wait_for_header(io: &mut Rx<'_>, expected: &[u8]) -> Result<(u8, [u8; 4])> {
+    loop {
+        let header = io.read_header().await?;
+        tracing::debug!(
+            "zmodem upload rx header type={} data={:02x?}",
+            header.0,
+            header.1
+        );
+        if expected.contains(&header.0) {
+            return Ok(header);
+        }
+        if matches!(header.0, ZCAN | ZABORT) {
+            bail!("{}", t("传输被远端取消", "transfer aborted by receiver"));
+        }
+    }
+}
+
+fn file_info(name: &str, size: u64, modified: u64, files_left: usize, bytes_left: u64) -> String {
+    format!("{name}\0{size} {modified:o} 0 0 {files_left} {bytes_left}\0")
+}
+
+impl Rx<'_> {
+    /// Send a binary CRC-16/CRC-32 header using the receiver's advertised mode.
+    async fn send_bin(&mut self, ftype: u8, data: [u8; 4], crc32: bool) -> Result<()> {
+        let payload = [ftype, data[0], data[1], data[2], data[3]];
+        let mut out = vec![ZPAD, ZDLE, if crc32 { ZBIN32 } else { ZBIN }];
+        append_escaped(&mut out, &payload);
+        if crc32 {
+            append_escaped(&mut out, &crc32_of(&payload).to_le_bytes());
+        } else {
+            append_escaped(&mut out, &crc16(&payload).to_be_bytes());
+        }
+        tracing::debug!("zmodem tx binary type={ftype} len={}", out.len());
+        self.ch
+            .data(&out[..])
+            .await
+            .context("zmodem send binary header")?;
+        Ok(())
+    }
+
+    /// Send one escaped data subpacket and its CRC.
+    async fn send_subpacket(&mut self, data: &[u8], end: u8, crc32: bool) -> Result<()> {
+        let mut out = Vec::with_capacity(data.len() + data.len() / 16 + 8);
+        append_escaped(&mut out, data);
+        out.extend_from_slice(&[ZDLE, end]);
+        let mut crc_input = Vec::with_capacity(data.len() + 1);
+        crc_input.extend_from_slice(data);
+        crc_input.push(end);
+        if crc32 {
+            append_escaped(&mut out, &crc32_of(&crc_input).to_le_bytes());
+        } else {
+            append_escaped(&mut out, &crc16(&crc_input).to_be_bytes());
+        }
+        self.ch
+            .data(&out[..])
+            .await
+            .context("zmodem send data subpacket")?;
+        Ok(())
+    }
+}
+
+fn append_escaped(out: &mut Vec<u8>, bytes: &[u8]) {
+    for &byte in bytes {
+        match byte {
+            0x7f => out.extend_from_slice(&[ZDLE, ZRUB0]),
+            0xff => out.extend_from_slice(&[ZDLE, ZRUB1]),
+            // Escaping every C0 control byte avoids XON/XOFF or the PTY line
+            // discipline consuming file contents in transit.
+            0x00..=0x1f | 0x90 | 0x91 | 0x93 => out.extend_from_slice(&[ZDLE, byte ^ 0x40]),
+            _ => out.push(byte),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metadata_uses_zmodem_fields_and_octal_mtime() {
+        assert_eq!(
+            file_info("report.txt", 12, 8, 2, 34),
+            concat!("report.txt\0", "12 10 0 0 2 34\0")
+        );
+    }
+
+    #[test]
+    fn control_bytes_are_zdle_escaped() {
+        let mut encoded = Vec::new();
+        append_escaped(&mut encoded, &[0x00, 0x11, ZDLE, 0x7f, 0xff, b'A']);
+        assert_eq!(
+            encoded,
+            [ZDLE, 0x40, ZDLE, 0x51, ZDLE, 0x58, ZDLE, ZRUB0, ZDLE, ZRUB1, b'A']
+        );
+    }
+}

--- a/src/terminal/impls/zmodem_send.rs
+++ b/src/terminal/impls/zmodem_send.rs
@@ -5,7 +5,11 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, UNIX_EPOCH};
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
 
-const SEND_BLOCK_SIZE: usize = 16 * 1024;
+// The ZMODEM specification caps data subpackets at 1 KiB; GNU lrzsz supports
+// the widely used 8 KiB extension, but its receiver buffer is exactly 8 KiB.
+// A 16 KiB subpacket works for tiny files (only the final short packet is sent)
+// and then silently fails as soon as a file reaches one full block (#308).
+const SEND_BLOCK_SIZE: usize = 8 * 1024;
 
 /// Send one or more local files to a remote `rz`. `first` contains the ZRINIT
 /// frame that triggered upload detection. The returned bytes belong to the
@@ -16,7 +20,7 @@ pub(crate) async fn send(
     files: &[PathBuf],
     events: &UnboundedSender<SessionEvent>,
 ) -> Result<Vec<u8>> {
-    tracing::debug!(
+    tracing::info!(
         "zmodem: send start, first[{}]={:02x?}, files={}",
         first.len(),
         &first[..first.len().min(80)],
@@ -31,6 +35,12 @@ pub(crate) async fn send(
         )
     })?;
     let crc32 = receiver.1[3] & CANFC32 != 0;
+    tracing::info!(
+        "zmodem upload: receiver ready flags={:02x?}, crc32={}, block_size={}",
+        receiver.1,
+        crc32,
+        SEND_BLOCK_SIZE
+    );
     let total_bytes = files
         .iter()
         .filter_map(|path| path.metadata().ok())
@@ -69,6 +79,7 @@ pub(crate) async fn send(
         .data(&b"OO"[..])
         .await
         .context("zmodem send close marker")?;
+    tracing::info!("zmodem upload: close handshake complete");
 
     // `byte()` pulls a whole SSH chunk; putting the first prompt byte back
     // preserves that complete chunk for the normal terminal output path.
@@ -136,6 +147,9 @@ async fn send_file_inner(
         .map(|duration| duration.as_secs())
         .unwrap_or(0);
     let info = file_info(name, size, modified, files_left, bytes_left);
+    tracing::info!(
+        "zmodem upload: sending file name={name:?}, size={size}, files_left={files_left}"
+    );
 
     // A receiver may repeat ZRINIT while the file picker is open. Resend ZFILE
     // until the current receiver answers with the requested starting offset.
@@ -150,7 +164,11 @@ async fn send_file_inner(
         })?;
         tracing::debug!("zmodem upload rx header type={frame} data={data:02x?}");
         match frame {
-            ZRPOS => break u32::from_le_bytes(data) as u64,
+            ZRPOS => {
+                let position = u32::from_le_bytes(data) as u64;
+                tracing::info!("zmodem upload: receiver accepted file at offset={position}");
+                break position;
+            }
             ZSKIP => return Ok(()),
             ZCAN | ZABORT => bail!("{}", t("传输被远端取消", "transfer aborted by receiver")),
             ZRINIT => {
@@ -191,6 +209,7 @@ async fn send_file_inner(
         }
         io.send_bin(ZEOF, (position as u32).to_le_bytes(), crc32)
             .await?;
+        tracing::info!("zmodem upload: sent ZEOF position={position}");
 
         loop {
             let (frame, data) = io.read_header().await.with_context(|| {
@@ -201,9 +220,15 @@ async fn send_file_inner(
             })?;
             tracing::debug!("zmodem upload rx header type={frame} data={data:02x?}");
             match frame {
-                ZRINIT => return Ok(()),
+                ZRINIT => {
+                    tracing::info!("zmodem upload: receiver confirmed file completion");
+                    return Ok(());
+                }
                 ZRPOS => {
                     requested = u32::from_le_bytes(data) as u64;
+                    tracing::warn!(
+                        "zmodem upload: receiver requested retransmit from offset={requested}"
+                    );
                     break;
                 }
                 ZSKIP => return Ok(()),
@@ -310,5 +335,10 @@ mod tests {
             encoded,
             [ZDLE, 0x40, ZDLE, 0x51, ZDLE, 0x58, ZDLE, ZRUB0, ZDLE, ZRUB1, b'A']
         );
+    }
+
+    #[test]
+    fn send_blocks_fit_lrzsz_receiver_limit() {
+        assert!(SEND_BLOCK_SIZE <= 8 * 1024);
     }
 }

--- a/src/terminal/impls/zmodem_send.rs
+++ b/src/terminal/impls/zmodem_send.rs
@@ -24,7 +24,12 @@ pub(crate) async fn send(
     );
 
     let mut io = Rx::new(channel, first);
-    let receiver = wait_for_header(&mut io, &[ZRINIT]).await?;
+    let receiver = wait_for_header(&mut io, &[ZRINIT]).await.with_context(|| {
+        t(
+            "等待远端 rz 的初始 ZRINIT 握手",
+            "waiting for the initial ZRINIT handshake from remote rz",
+        )
+    })?;
     let crc32 = receiver.1[3] & CANFC32 != 0;
     let total_bytes = files
         .iter()
@@ -54,7 +59,12 @@ pub(crate) async fn send(
     }
 
     io.send_hex(ZFIN, [0; 4]).await?;
-    let _ = wait_for_header(&mut io, &[ZFIN]).await?;
+    let _ = wait_for_header(&mut io, &[ZFIN]).await.with_context(|| {
+        t(
+            "等待远端 rz 的 ZFIN 关闭握手",
+            "waiting for the ZFIN close handshake from remote rz",
+        )
+    })?;
     io.ch
         .data(&b"OO"[..])
         .await
@@ -132,7 +142,12 @@ async fn send_file_inner(
     io.send_bin(ZFILE, [0; 4], crc32).await?;
     io.send_subpacket(info.as_bytes(), ZCRCW, crc32).await?;
     let mut requested = loop {
-        let (frame, data) = io.read_header().await?;
+        let (frame, data) = io.read_header().await.with_context(|| {
+            t(
+                "已发送文件信息，等待远端 rz 返回 ZRPOS",
+                "sent file metadata; waiting for ZRPOS from remote rz",
+            )
+        })?;
         tracing::debug!("zmodem upload rx header type={frame} data={data:02x?}");
         match frame {
             ZRPOS => break u32::from_le_bytes(data) as u64,
@@ -178,7 +193,12 @@ async fn send_file_inner(
             .await?;
 
         loop {
-            let (frame, data) = io.read_header().await?;
+            let (frame, data) = io.read_header().await.with_context(|| {
+                t(
+                    "已发送文件数据和 ZEOF，等待远端 rz 确认",
+                    "sent file data and ZEOF; waiting for remote rz confirmation",
+                )
+            })?;
             tracing::debug!("zmodem upload rx header type={frame} data={data:02x?}");
             match frame {
                 ZRINIT => return Ok(()),


### PR DESCRIPTION
## 改动说明

- 区分远端 `sz` 的 `ZRQINIT` 和远端 `rz` 的 `ZRINIT`，不再把两个方向都当作下载。
- 执行远端 `rz` 时打开本地多文件选择器，并通过当前 SSH PTY 发送 ZMODEM 文件。
- 支持 CRC-16/CRC-32、续传位置响应、多个文件、进度事件、取消以及完整关闭握手。
- 兼容 GNU `lrzsz` 使用的高位换行字节 `0x8a`。
- 将数据子包限制为 8 KiB，符合 GNU `lrzsz` 接收端的 `MAX_BLOCK=8192` 限制，修复大文件在 `ZEOF` 后超时的问题。
- 增加上传握手、文件大小、块大小、重传位置和完成状态日志，便于诊断兼容性问题。

## 使用方式

在远端终端执行：

```console
rz
```

随后在本地文件选择窗口中选择一个或多个文件即可。

## 测试情况

已经实际测试可用：

- Ubuntu 24.04 + GNU `lrzsz 0.12.21rc`。
- 通过真实 SSH PTY 完成端到端上传，并非仅测试协议编码。
- 上传 512 KiB 二进制文件成功，本地与远端文件大小一致。
- 本地与远端 SHA-256 均为 `33bc8aab40703678c3ebe94d2dd8f2afff285dd901f9234e841e4679f8204fd5`。
- `cargo test`：203 个测试全部通过。
- Windows debug 构建成功，并由实际界面执行 `rz`、选择文件验证触发流程和错误诊断。

关联：#308
