### PR TITLE
fix(ui): 历史命令下拉列表恢复为最新命令排在最后

### DIFF
--- a/src/app/terminal_ui.rs
+++ b/src/app/terminal_ui.rs
@@ -73,21 +73,20 @@ pub(super) fn validate_output_highlight_rule(
     Ok(())
 }
 
-/// Build the filtered history-view rows for the dropdown, newest first. The
-/// command-history model itself remains oldest first so ↑/↓ recall keeps its
-/// existing shell-like navigation semantics (#55, #101, #331).
+/// Build the filtered history-view rows for the dropdown, oldest first with the
+/// newest command at the bottom (#55, #101). The command-history model shares
+/// the same storage order so ↑/↓ recall keeps its shell-like semantics.
 pub(super) fn history_view_rows(history: &[String], query: &str) -> Vec<SharedString> {
     let q = query.trim().to_lowercase();
     history
         .iter()
-        .rev()
         .filter(|command| q.is_empty() || command.to_lowercase().contains(&q))
         .map(|command| command.clone().into())
         .collect()
 }
 
 /// Build the filtered history-view model for the dropdown: case-insensitive
-/// substring matches of `query`, ordered from newest to oldest (#101, #331).
+/// substring matches of `query`, ordered from oldest to newest (#101).
 pub(super) fn history_view_model(store: &ConfigStore, query: &str) -> ModelRc<SharedString> {
     let rows = history_view_rows(store.command_history(), query);
     ModelRc::from(Rc::new(VecModel::from(rows)))

--- a/tests/app/command_history/mod.rs
+++ b/tests/app/command_history/mod.rs
@@ -1,7 +1,7 @@
 use super::history_view_rows;
 
 #[test]
-fn lists_and_filters_commands_newest_first() {
+fn lists_and_filters_commands_newest_last() {
     let history = vec![
         "git status".to_string(),
         "cargo check".to_string(),
@@ -12,11 +12,11 @@ fn lists_and_filters_commands_newest_first() {
         .into_iter()
         .map(Into::into)
         .collect();
-    assert_eq!(all, ["git log", "cargo check", "git status"]);
+    assert_eq!(all, ["git status", "cargo check", "git log"]);
 
     let filtered: Vec<String> = history_view_rows(&history, "GIT")
         .into_iter()
         .map(Into::into)
         .collect();
-    assert_eq!(filtered, ["git log", "git status"]);
+    assert_eq!(filtered, ["git status", "git log"]);
 }

--- a/ui/app.slint
+++ b/ui/app.slint
@@ -505,7 +505,7 @@ export component AppWindow inherits Window {
     property <bool> quick-external-send-enter;
     property <int> quick-external-sequence;
     in property <[string]> command-history;          // oldest first (newest last, #113)
-    in property <[string]> history-view;             // filtered dropdown, newest first (#101, #331)
+    in property <[string]> history-view;             // filtered dropdown, oldest first (newest last, #101)
     callback run-command(string /* tab-id */, string /* cmd */, bool /* to-all */);
     callback copy-text(string);                 // copy a history command (#96)
     callback delete-history(int /* index */);   // remove a history entry (#96)

--- a/ui/terminal_view.slint
+++ b/ui/terminal_view.slint
@@ -304,7 +304,7 @@ export component TerminalView inherits Rectangle {
     // fed from Rust); send-to-all is a per-tab toggle.
     in property <[QuickCmd]> quick-commands;
     in property <[string]> command-history;   // oldest first (newest last, #113)
-    in property <[string]> history-view;       // filtered dropdown, newest first (#101, #331)
+    in property <[string]> history-view;       // filtered dropdown, oldest first (newest last, #101)
     property <bool> send-to-all: false;
     in property <bool> cmd-bar-hidden: false;  // toolbar toggle hides the whole bar
     // Effective terminal font size in px: per-session zoom override when > 0,
@@ -491,7 +491,9 @@ export component TerminalView inherits Rectangle {
     changed history-open => {
         if (root.history-open) {
             if (!root.history-autocomplete) { root.search-history(""); }
-            root.history-selected = 0;
+            // List is oldest→newest (#101): default-select the newest entry.
+            root.history-selected = root.history-view.length > 0
+                ? root.history-view.length - 1 : 0;
         } else {
             root.history-autocomplete = false;
         }
@@ -1326,6 +1328,9 @@ export component TerminalView inherits Rectangle {
                             root.history-autocomplete = self.text != "";
                             root.search-history(self.text);
                             root.history-open = root.history-autocomplete;
+                            // Oldest→newest list: default-select the newest match.
+                            root.history-selected = root.history-view.length > 0
+                                ? root.history-view.length - 1 : 0;
                         }
                         key-pressed(e) => {
                             if (e.text == Key.Return && !e.modifiers.shift) {
@@ -1864,7 +1869,7 @@ export component TerminalView inherits Rectangle {
                                     // half-built layout, panicking with "Recursion
                                     // detected" (#349 / #343).
                                     init => { root.history-search-focus-pending = true; }
-                                    edited => { root.search-history(self.text); root.history-selected = 0; }
+                                    edited => { root.search-history(self.text); root.history-selected = root.history-view.length > 0 ? root.history-view.length - 1 : 0; }
                                     // ↑/↓ move the selection, Enter runs it, Esc
                                     // closes and returns focus to the terminal (#140).
                                     key-pressed(e) => {


### PR DESCRIPTION
回退 #331 引入的最新在前的展示顺序：history_view_rows 不再反转
存储顺序，列表恢复为最旧在前、最新在后，与输入框 ↑/↓ 召回顺序
及会话列表的排序习惯一致。

列表反转后索引 0 变为最旧命令，打开历史弹窗、输入框实时过滤与
搜索框过滤三处的默认选中项由第 0 项改为最后一项，保证打开时高
亮的仍是最新命令，Tab 补全与 Enter 执行行为不变。

同步更新 command_history 测试断言（lists_and_filters_commands_ newest_first → lists_and_filters_commands_newest_last）。

解决[历史命令排序不正常 #384](https://github.com/yituorou/meatshell/issues/384)