### PR TITLE
feat: 实现vt100绘制图形功能 & fix(ui): 历史命令下拉列表恢复为最新命令排在最后

### DIFF
--- a/lang/en/LC_MESSAGES/meatshell.po
+++ b/lang/en/LC_MESSAGES/meatshell.po
@@ -369,6 +369,12 @@ msgstr "Terminal character encoding"
 msgid "Use GBK for servers configured for GB2312 or GBK output."
 msgstr "Use GBK for servers configured for GB2312 or GBK output."
 
+msgid "Enable VT100 line drawing even in UTF-8 mode"
+msgstr "Enable VT100 line drawing even in UTF-8 mode"
+
+msgid "Show box-drawing output from servers that switch charsets (ESC(0, SO/SI) while staying in UTF-8, e.g. top or mc frames."
+msgstr "Show box-drawing output from servers that switch charsets (ESC(0, SO/SI) while staying in UTF-8, e.g. top or mc frames."
+
 msgid "Local (-L)"
 msgstr "Local (-L)"
 

--- a/lang/zh/LC_MESSAGES/meatshell.po
+++ b/lang/zh/LC_MESSAGES/meatshell.po
@@ -369,6 +369,12 @@ msgstr "终端字符集"
 msgid "Use GBK for servers configured for GB2312 or GBK output."
 msgstr "远端使用 GB2312 或 GBK 输出时请选择 GBK。"
 
+msgid "Enable VT100 line drawing even in UTF-8 mode"
+msgstr "启用 VT100 线框绘制（即使 UTF-8 模式）"
+
+msgid "Show box-drawing output from servers that switch charsets (ESC(0, SO/SI) while staying in UTF-8, e.g. top or mc frames."
+msgstr "服务器在 UTF-8 模式下仍通过 ESC(0 或 SO/SI 切换字符集时（如 top、mc 的边框），正确显示线框图形。"
+
 msgid "Local (-L)"
 msgstr "本地 -L"
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -3630,6 +3630,7 @@ fn wire_session_callbacks(
             w.set_dialog_parity("none".into());
             w.set_dialog_flow("none".into());
             w.set_dialog_encoding("UTF-8".into());
+            w.set_dialog_vt100_drawing(false);
             w.set_dialog_disable_shell_integration(false);
             w.set_dialog_note("".into());
             w.set_dialog_editing(false);
@@ -3864,6 +3865,7 @@ fn wire_session_callbacks(
                 w.set_dialog_parity(session.parity.clone().into());
                 w.set_dialog_flow(session.flow_control.clone().into());
                 w.set_dialog_encoding(session.encoding.clone().into());
+                w.set_dialog_vt100_drawing(session.vt100_drawing);
                 w.set_dialog_disable_shell_integration(session.disable_shell_integration);
                 w.set_dialog_note(session.note.clone().into());
                 w.set_dialog_editing(true);
@@ -4265,6 +4267,7 @@ fn wire_session_callbacks(
                 parity: draft.parity.to_string(),
                 flow_control: draft.flow_control.to_string(),
                 encoding: draft.encoding.to_string(),
+                vt100_drawing: draft.vt100_drawing,
                 forwards,
                 triggers,
                 disable_shell_integration: draft.disable_shell_integration,
@@ -4727,6 +4730,8 @@ fn wire_session_callbacks(
                     output_highlight,
                     custom_highlight_rules,
                     json_format_output: store.borrow().json_format_output(),
+                    vt100_drawing: session.vt100_drawing,
+                    charset: crate::terminal::CharsetTracker::default(),
                     interactive_echo_until: std::time::Instant::now(),
                     sel_anchor: None,
                     sel_focus: None,

--- a/src/app/session_models.rs
+++ b/src/app/session_models.rs
@@ -466,6 +466,7 @@ pub(super) fn session_from_draft(
         parity: draft.parity.to_string(),
         flow_control: draft.flow_control.to_string(),
         encoding: draft.encoding.to_string(),
+        vt100_drawing: draft.vt100_drawing,
         forwards,
         triggers,
         disable_shell_integration: draft.disable_shell_integration,

--- a/src/app/terminal_ui.rs
+++ b/src/app/terminal_ui.rs
@@ -73,21 +73,20 @@ pub(super) fn validate_output_highlight_rule(
     Ok(())
 }
 
-/// Build the filtered history-view rows for the dropdown, newest first. The
-/// command-history model itself remains oldest first so ↑/↓ recall keeps its
-/// existing shell-like navigation semantics (#55, #101, #331).
+/// Build the filtered history-view rows for the dropdown, oldest first with the
+/// newest command at the bottom (#55, #101). The command-history model shares
+/// the same storage order so ↑/↓ recall keeps its shell-like semantics.
 pub(super) fn history_view_rows(history: &[String], query: &str) -> Vec<SharedString> {
     let q = query.trim().to_lowercase();
     history
         .iter()
-        .rev()
         .filter(|command| q.is_empty() || command.to_lowercase().contains(&q))
         .map(|command| command.clone().into())
         .collect()
 }
 
 /// Build the filtered history-view model for the dropdown: case-insensitive
-/// substring matches of `query`, ordered from newest to oldest (#101, #331).
+/// substring matches of `query`, ordered from oldest to newest (#101).
 pub(super) fn history_view_model(store: &ConfigStore, query: &str) -> ModelRc<SharedString> {
     let rows = history_view_rows(store.command_history(), query);
     ModelRc::from(Rc::new(VecModel::from(rows)))

--- a/src/config/struct/session.rs
+++ b/src/config/struct/session.rs
@@ -59,6 +59,10 @@ fn default_encoding() -> String {
     "UTF-8".to_string()
 }
 
+fn default_vt100_drawing() -> bool {
+    false
+}
+
 /// How a session authenticates.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
@@ -152,6 +156,12 @@ pub struct Session {
     #[serde(default = "default_encoding")]
     pub encoding: String,
 
+    /// Honor VT100 line drawing (DEC Special Graphics via `ESC ( 0` and SO/SI)
+    /// even when the encoding is UTF-8 (#376). PuTTY's "Enable VT100 line
+    /// drawing even in UTF-8 mode"; opt-in, off for new/existing sessions.
+    #[serde(default = "default_vt100_drawing")]
+    pub vt100_drawing: bool,
+
     // --- SSH port forwarding / tunnels (#56) --------------------------------
     /// Tunnels established automatically when this SSH session connects.
     #[serde(default)]
@@ -237,6 +247,7 @@ impl Session {
             parity: default_parity(),
             flow_control: default_flow(),
             encoding: default_encoding(),
+            vt100_drawing: default_vt100_drawing(),
             forwards: Vec::new(),
             triggers: Vec::new(),
             disable_shell_integration: false,

--- a/src/terminal/impls/charset.rs
+++ b/src/terminal/impls/charset.rs
@@ -1,0 +1,175 @@
+//! VT100 character-set (SCS) support (#376): tracks G0/G1 designations
+//! (`ESC ( X`, `ESC ) X`) and SO/SI shifts, and maps DEC Special Graphics
+//! codes to their Unicode box-drawing equivalents. This mirrors PuTTY's
+//! "Enable VT100 line drawing even in UTF-8 mode": the `vt100` crate has no
+//! charset support, so designated bytes are translated to Unicode *before*
+//! they reach the parser, which also keeps the reflow replay ring correct.
+
+/// Character sets selectable through an SCS designator.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Charset {
+    UsAscii,
+    DecSpecialGraphics,
+}
+
+/// Per-terminal G0/G1 charset state plus the SO/SI shift flag.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct CharsetTracker {
+    g0: Charset,
+    g1: Charset,
+    /// SO (0x0E) shifted output to G1 until SI (0x0F).
+    shifted: bool,
+}
+
+impl Default for CharsetTracker {
+    fn default() -> Self {
+        Self {
+            g0: Charset::UsAscii,
+            g1: Charset::UsAscii,
+            shifted: false,
+        }
+    }
+}
+
+impl CharsetTracker {
+    /// Apply an SCS designation. `set` is the designator intro byte (`(` = G0,
+    /// `)` = G1); `final_byte` selects the charset (`0` = DEC Special Graphics,
+    /// `B` = US ASCII). Unknown set/final combinations are ignored, matching
+    /// real VT100s that only reject unsupported pairs.
+    pub(crate) fn designate(&mut self, set: u8, final_byte: u8) {
+        let charset = match final_byte {
+            b'0' => Charset::DecSpecialGraphics,
+            b'B' => Charset::UsAscii,
+            _ => return,
+        };
+        match set {
+            b'(' => self.g0 = charset,
+            b')' => self.g1 = charset,
+            // G2/G3 (`*`, `+`) need single-shift (SS2/SS3) support; nothing in
+            // the vt100 crate consumes those, so the designation is ignored.
+            _ => {}
+        }
+    }
+
+    pub(crate) fn shift_out(&mut self) {
+        self.shifted = true;
+    }
+
+    pub(crate) fn shift_in(&mut self) {
+        self.shifted = false;
+    }
+
+    /// Map a display byte through the active charset. Returns `None` when the
+    /// byte passes through unchanged (i.e. US-ASCII is active or the byte is
+    /// outside the DEC Special Graphics range).
+    pub(crate) fn map(&self, byte: u8) -> Option<char> {
+        let active = if self.shifted { self.g1 } else { self.g0 };
+        if active != Charset::DecSpecialGraphics || !(0x60..=0x7e).contains(&byte) {
+            return None;
+        }
+        Some(DEC_SPECIAL_GRAPHICS[(byte - 0x60) as usize])
+    }
+}
+
+/// DEC Special Graphics, 0x60–0x7e in order (VT100 user guide, table 3-9).
+/// Bytes in this range are always standalone ASCII in a UTF-8 stream, so the
+/// byte→char mapping can never split a multi-byte sequence.
+const DEC_SPECIAL_GRAPHICS: [char; 31] = [
+    '◆', // 0x60 `
+    '▒', // 0x61 a
+    '␉', // 0x62 b
+    '␌', // 0x63 c
+    '␍', // 0x64 d
+    '␊', // 0x65 e
+    '°', // 0x66 f
+    '±', // 0x67 g
+    '␤', // 0x68 h
+    '␋', // 0x69 i
+    '┘', // 0x6a j
+    '┐', // 0x6b k
+    '┌', // 0x6c l
+    '└', // 0x6d m
+    '┼', // 0x6e n
+    '⎺', // 0x6f o
+    '⎻', // 0x70 p
+    '─', // 0x71 q
+    '⎼', // 0x72 r
+    '⎽', // 0x73 s
+    '├', // 0x74 t
+    '┤', // 0x75 u
+    '┴', // 0x76 v
+    '┬', // 0x77 w
+    '│', // 0x78 x
+    '≤', // 0x79 y
+    '≥', // 0x7a z
+    'π', // 0x7b {
+    '≠', // 0x7c |
+    '£', // 0x7d }
+    '·', // 0x7e ~
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn esc_paren_zero_selects_dec_graphics_and_maps_box_chars() {
+        let mut t = CharsetTracker::default();
+        t.designate(b'(', b'0');
+        assert_eq!(t.map(b'l'), Some('┌'));
+        assert_eq!(t.map(b'q'), Some('─'));
+        assert_eq!(t.map(b'k'), Some('┐'));
+        assert_eq!(t.map(b'x'), Some('│'));
+        // Below/above the special-graphics range passes through.
+        assert_eq!(t.map(0x5f), None);
+        assert_eq!(t.map(0x7f), None);
+    }
+
+    #[test]
+    fn esc_paren_b_restores_ascii() {
+        let mut t = CharsetTracker::default();
+        t.designate(b'(', b'0');
+        t.designate(b'(', b'B');
+        assert_eq!(t.map(b'q'), None);
+    }
+
+    #[test]
+    fn unknown_designator_final_is_ignored() {
+        let mut t = CharsetTracker::default();
+        t.designate(b'(', b'Z');
+        assert_eq!(t.map(b'q'), None);
+        t.designate(b'(', b'0');
+        t.designate(b'*', b'0'); // G2 has no effect without SS2/SS3
+        assert_eq!(t.map(b'q'), Some('─'));
+    }
+
+    #[test]
+    fn so_si_shift_between_g0_and_g1() {
+        let mut t = CharsetTracker::default();
+        t.designate(b')', b'0'); // G1 = DEC Special Graphics
+        assert_eq!(t.map(b'q'), None); // G0 still US-ASCII
+        t.shift_out();
+        assert_eq!(t.map(b'q'), Some('─')); // G1 active
+        t.shift_in();
+        assert_eq!(t.map(b'q'), None);
+    }
+
+    #[test]
+    fn g1_designation_does_not_affect_g0() {
+        let mut t = CharsetTracker::default();
+        t.designate(b'(', b'0');
+        t.designate(b')', b'B');
+        t.shift_out();
+        assert_eq!(t.map(b'q'), None); // G1 = US-ASCII
+    }
+
+    #[test]
+    fn graphics_table_is_contiguous_vt100_set() {
+        // Spot-check the visual-critical box corners against U+25xx.
+        assert_eq!(DEC_SPECIAL_GRAPHICS[0x6a - 0x60], '┘');
+        assert_eq!(DEC_SPECIAL_GRAPHICS[0x6c - 0x60], '┌');
+        assert_eq!(DEC_SPECIAL_GRAPHICS[0x71 - 0x60], '─');
+        assert_eq!(DEC_SPECIAL_GRAPHICS[0x78 - 0x60], '│');
+        assert_eq!(DEC_SPECIAL_GRAPHICS[0x7e - 0x60], '·');
+    }
+}

--- a/src/terminal/impls/term_buffer.rs
+++ b/src/terminal/impls/term_buffer.rs
@@ -314,6 +314,23 @@ impl TermBuffer {
                         self.csi_pending.clear();
                         self.csi_pending.push(byte);
                         self.csi_state = CsiState::Esc;
+                    } else if self.vt100_drawing && byte == 0x0e {
+                        // SO: shift output to G1 (#376). Swallowed before the
+                        // parser, which has no charset support.
+                        self.charset.shift_out();
+                    } else if self.vt100_drawing && byte == 0x0f {
+                        // SI: back to G0.
+                        self.charset.shift_in();
+                    } else if self.vt100_drawing {
+                        // DEC Special Graphics maps 0x60–0x7e (always standalone
+                        // ASCII in a UTF-8 stream) to box-drawing Unicode (#376).
+                        match self.charset.map(byte) {
+                            Some(ch) => {
+                                let mut buf = [0u8; 4];
+                                display.extend_from_slice(ch.encode_utf8(&mut buf).as_bytes());
+                            }
+                            None => display.push(byte),
+                        }
                     } else {
                         display.push(byte);
                     }
@@ -322,6 +339,16 @@ impl TermBuffer {
                     if byte == b'[' {
                         self.csi_pending.push(byte);
                         self.csi_state = CsiState::Csi;
+                    } else if byte == b']' {
+                        // OSC: keep buffering so its payload is never
+                        // charset-translated while DEC graphics is active.
+                        self.csi_pending.push(byte);
+                        self.csi_state = CsiState::Osc;
+                    } else if matches!(byte, b'(' | b')' | b'*' | b'+') {
+                        // SCS designator intro (`ESC ( 0`, …); the final byte
+                        // completes it (#376).
+                        self.csi_pending.push(byte);
+                        self.csi_state = CsiState::Designate(byte);
                     } else {
                         display.extend(self.csi_pending.drain(..));
                         if byte == 0x1b {
@@ -330,6 +357,46 @@ impl TermBuffer {
                             display.push(byte);
                             self.csi_state = CsiState::Normal;
                         }
+                    }
+                }
+                CsiState::Designate(set) => {
+                    if byte == 0x1b {
+                        // Malformed: a new escape interrupts the designator.
+                        // Pass the buffered bytes through and start over.
+                        display.extend(self.csi_pending.drain(..));
+                        self.csi_pending.push(byte);
+                        self.csi_state = CsiState::Esc;
+                    } else {
+                        self.csi_pending.push(byte);
+                        if self.vt100_drawing {
+                            self.charset.designate(set, byte);
+                        }
+                        display.extend(self.csi_pending.drain(..));
+                        self.csi_state = CsiState::Normal;
+                    }
+                }
+                CsiState::Osc => {
+                    self.csi_pending.push(byte);
+                    if byte == 0x07 {
+                        display.extend(self.csi_pending.drain(..));
+                        self.csi_state = CsiState::Normal;
+                    } else if byte == 0x1b {
+                        self.csi_state = CsiState::OscEsc;
+                    } else if self.csi_pending.len() > 4096 {
+                        // Malformed/unbounded OSC: stop buffering, same escape
+                        // hatch as the CSI arm below.
+                        display.extend(self.csi_pending.drain(..));
+                        self.csi_state = CsiState::Normal;
+                    }
+                }
+                CsiState::OscEsc => {
+                    self.csi_pending.push(byte);
+                    if byte == b'\\' {
+                        // ST terminator.
+                        display.extend(self.csi_pending.drain(..));
+                        self.csi_state = CsiState::Normal;
+                    } else {
+                        self.csi_state = CsiState::Osc;
                     }
                 }
                 CsiState::Csi => {

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -5,6 +5,8 @@ mod state;
 mod input;
 #[path = "impls/json_output.rs"]
 mod json_output;
+#[path = "impls/charset.rs"]
+mod charset;
 #[path = "impls/encoding.rs"]
 mod encoding;
 #[path = "impls/local.rs"]
@@ -36,6 +38,7 @@ pub(crate) use input::{
     should_drop_bare_ctrl_marker,
     terminal_uses_bracketed_paste,
 };
+pub(crate) use charset::CharsetTracker;
 pub(crate) use encoding::TerminalEncoding;
 pub(crate) use json_output::format_json_output;
 #[cfg(any(target_os = "windows", test))]

--- a/src/terminal/struct/state.rs
+++ b/src/terminal/struct/state.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Condvar, Mutex};
 
+use crate::terminal::charset::CharsetTracker;
 use crate::ui::TermSpan;
 
 #[cfg(any(target_os = "windows", test))]
@@ -18,6 +19,10 @@ pub(crate) struct TermBuffer {
     pub(crate) output_highlight: OutputHighlightPreset,
     pub(crate) custom_highlight_rules: Vec<CompiledOutputRule>,
     pub(crate) json_format_output: bool,
+    /// Honor VT100 line-drawing (DEC Special Graphics) via SCS designators and
+    /// SO/SI even when the session encoding is UTF-8 (#376, PuTTY's option).
+    pub(crate) vt100_drawing: bool,
+    pub(crate) charset: CharsetTracker,
     pub(crate) interactive_echo_until: std::time::Instant,
     pub(crate) sel_anchor: Option<(usize, u16)>,
     pub(crate) sel_focus: Option<(usize, u16)>,
@@ -41,6 +46,13 @@ pub(crate) enum CsiState {
     Normal,
     Esc,
     Csi,
+    /// Buffering an SCS designator (`ESC ( X`, `ESC ) X`, …); payload holds the
+    /// designator intro byte. Bytes still pass through to the display verbatim.
+    Designate(u8),
+    /// Buffering an OSC string (`ESC ] … BEL/ST`) so its payload is never
+    /// charset-translated. Bytes still pass through to the display verbatim.
+    Osc,
+    OscEsc,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/tests/app/command_history/mod.rs
+++ b/tests/app/command_history/mod.rs
@@ -1,7 +1,7 @@
 use super::history_view_rows;
 
 #[test]
-fn lists_and_filters_commands_newest_first() {
+fn lists_and_filters_commands_newest_last() {
     let history = vec![
         "git status".to_string(),
         "cargo check".to_string(),
@@ -12,11 +12,11 @@ fn lists_and_filters_commands_newest_first() {
         .into_iter()
         .map(Into::into)
         .collect();
-    assert_eq!(all, ["git log", "cargo check", "git status"]);
+    assert_eq!(all, ["git status", "cargo check", "git log"]);
 
     let filtered: Vec<String> = history_view_rows(&history, "GIT")
         .into_iter()
         .map(Into::into)
         .collect();
-    assert_eq!(filtered, ["git log", "git status"]);
+    assert_eq!(filtered, ["git status", "git log"]);
 }

--- a/tests/app/terminal_rendering/charset/mod.rs
+++ b/tests/app/terminal_rendering/charset/mod.rs
@@ -1,0 +1,77 @@
+use super::*;
+
+#[test]
+fn esc_paren_zero_draws_box_lines_even_in_utf8_mode() {
+    let mut buffer = make_buf(4, 40, &[], &[], 0);
+    let _ = buffer.ingest(b"\x1b(0lqqk\x1b(B");
+    buffer.render();
+
+    assert_eq!(buffer.displayed_text[0], "┌──┐");
+    // The reflow replay ring stores the already-translated UTF-8, so a resize
+    // re-renders the same glyphs without charset state.
+    assert_eq!(
+        buffer.raw.iter().copied().collect::<Vec<_>>(),
+        "\x1b(0┌──┐\x1b(B".as_bytes()
+    );
+}
+
+#[test]
+fn so_si_shifts_output_to_g1_and_back() {
+    let mut buffer = make_buf(4, 40, &[], &[], 0);
+    let _ = buffer.ingest(b"\x1b)0\x0eq\x0f q");
+    buffer.render();
+
+    assert_eq!(buffer.displayed_text[0], "─ q");
+}
+
+#[test]
+fn charset_designator_survives_split_output_chunks() {
+    let mut buffer = make_buf(4, 40, &[], &[], 0);
+    let _ = buffer.ingest(b"\x1b");
+    let _ = buffer.ingest(b"(0");
+    let _ = buffer.ingest(b"lqk");
+    buffer.render();
+
+    assert_eq!(buffer.displayed_text[0], "┌─┐");
+}
+
+#[test]
+fn esc_paren_b_restores_plain_ascii() {
+    let mut buffer = make_buf(4, 40, &[], &[], 0);
+    let _ = buffer.ingest(b"\x1b(0q\x1b(Bq");
+    buffer.render();
+
+    assert_eq!(buffer.displayed_text[0], "─q");
+}
+
+#[test]
+fn disabled_vt100_drawing_passes_letters_through() {
+    let mut buffer = make_buf(4, 40, &[], &[], 0);
+    buffer.vt100_drawing = false;
+    let _ = buffer.ingest(b"\x1b(0lqqk\x1b(B");
+    buffer.render();
+
+    assert_eq!(buffer.displayed_text[0], "lqqk");
+}
+
+#[test]
+fn osc_payload_is_never_charset_translated() {
+    let mut buffer = make_buf(4, 40, &[], &[], 0);
+    // Window-title OSC emitted while DEC Special Graphics is active: its
+    // payload must reach the parser verbatim; only the trailing q maps.
+    let _ = buffer.ingest(b"\x1b(0\x1b]2;top - user\x07q");
+    buffer.render();
+
+    assert_eq!(buffer.displayed_text[0], "─");
+}
+
+#[test]
+fn resize_reflow_replay_keeps_translated_box_lines() {
+    let mut buffer = make_buf(4, 40, &[], &[], 0);
+    let _ = buffer.ingest(b"\x1b(0lqqk\x1b(B\r\nsecond line");
+    buffer.reflow(4, 20);
+    buffer.render();
+
+    assert_eq!(buffer.displayed_text[0], "┌──┐");
+    assert_eq!(buffer.displayed_text[1], "second line");
+}

--- a/tests/app/terminal_rendering/mod.rs
+++ b/tests/app/terminal_rendering/mod.rs
@@ -24,6 +24,8 @@ fn make_buf(
         output_highlight: OutputHighlightPreset::Log,
         custom_highlight_rules: Vec::new(),
         json_format_output: false,
+        vt100_drawing: true,
+        charset: crate::terminal::CharsetTracker::default(),
         interactive_echo_until: std::time::Instant::now(),
         sel_anchor: None,
         sel_focus: None,
@@ -45,6 +47,7 @@ fn settings_modal_yields_macos_wheel_to_its_own_scroll_view() {
     assert!(!macos_terminal_wheel_can_target_terminal(true));
 }
 
+mod charset;
 mod colors;
 mod protocol;
 mod selection;

--- a/ui/app.slint
+++ b/ui/app.slint
@@ -505,7 +505,7 @@ export component AppWindow inherits Window {
     property <bool> quick-external-send-enter;
     property <int> quick-external-sequence;
     in property <[string]> command-history;          // oldest first (newest last, #113)
-    in property <[string]> history-view;             // filtered dropdown, newest first (#101, #331)
+    in property <[string]> history-view;             // filtered dropdown, oldest first (newest last, #101)
     callback run-command(string /* tab-id */, string /* cmd */, bool /* to-all */);
     callback copy-text(string);                 // copy a history command (#96)
     callback delete-history(int /* index */);   // remove a history entry (#96)

--- a/ui/app.slint
+++ b/ui/app.slint
@@ -856,6 +856,7 @@ export component AppWindow inherits Window {
     in-out property <string> dialog-parity: "none";
     in-out property <string> dialog-flow: "none";
     in-out property <string> dialog-encoding: "UTF-8";
+    in-out property <bool> dialog-vt100-drawing: false;
     in-out property <bool> dialog-disable-shell-integration: false;
     in-out property <string> dialog-note;
     in-out property <string> dialog-test-status;
@@ -4241,6 +4242,7 @@ export component AppWindow inherits Window {
         draft-parity <=> root.dialog-parity;
         draft-flow <=> root.dialog-flow;
         draft-encoding <=> root.dialog-encoding;
+        draft-vt100-drawing <=> root.dialog-vt100-drawing;
         draft-disable-shell-integration <=> root.dialog-disable-shell-integration;
         draft-note <=> root.dialog-note;
         test-status <=> root.dialog-test-status;

--- a/ui/session_dialog.slint
+++ b/ui/session_dialog.slint
@@ -42,6 +42,9 @@ export struct SessionDraft {
     parity: string,        // "none" | "odd" | "even"
     flow-control: string,  // "none" | "hardware" | "software"
     encoding: string,
+    // Honor VT100 line drawing (DEC Special Graphics) even in UTF-8 mode (#376),
+    // like PuTTY's Window → Translation option. On by default.
+    vt100-drawing: bool,
     // Skip the POSIX shell-integration setup (cwd-follow hook + monitor) for
     // Windows / pwsh servers where it breaks the shell (#140).
     disable-shell-integration: bool,
@@ -481,6 +484,7 @@ export component SessionDialog inherits Rectangle {
     in-out property <string> draft-parity: "none";
     in-out property <string> draft-flow: "none";
     in-out property <string> draft-encoding: "UTF-8";
+    in-out property <bool> draft-vt100-drawing: false;
     in-out property <bool> draft-disable-shell-integration: false;
     in-out property <string> draft-note;
     in-out property <string> test-status;
@@ -974,6 +978,45 @@ export component SessionDialog inherits Rectangle {
                 Rectangle { height: 6px; }
             }
 
+            // ── VT100 line drawing (all session kinds) (#376) ───────────────
+            // Mirror of PuTTY's "Enable VT100 line drawing even in UTF-8 mode":
+            // honor ESC(0 / SO-SI charset switches and map DEC Special Graphics
+            // to box-drawing glyphs even when the encoding is UTF-8.
+            if root.show-advanced : VerticalLayout {
+                spacing: 6px;
+
+                HorizontalLayout {
+                    spacing: 8px;
+                    Rectangle {
+                        width: 18px; height: 18px; y: 1px;
+                        border-radius: 4px;
+                        border-width: 1px;
+                        border-color: root.draft-vt100-drawing ? Theme.accent : Theme.border-strong;
+                        background: root.draft-vt100-drawing ? Theme.accent : transparent;
+                        Text {
+                            text: root.draft-vt100-drawing ? "\u{E5CA}" : "";
+                            font-family: "Material Icons"; color: white; font-size: 14px;
+                            width: 100%; height: 100%;
+                            horizontal-alignment: center; vertical-alignment: center;
+                        }
+                        TouchArea {
+                            mouse-cursor: pointer;
+                            clicked => { root.draft-vt100-drawing = !root.draft-vt100-drawing; }
+                        }
+                    }
+                    Text {
+                        text: @tr("Enable VT100 line drawing even in UTF-8 mode");
+                        color: Theme.text-primary; font-size: Theme.fs-sm;
+                        vertical-alignment: center; horizontal-stretch: 1;
+                    }
+                }
+                Text {
+                    text: @tr("Show box-drawing output from servers that switch charsets (ESC(0, SO/SI) while staying in UTF-8, e.g. top or mc frames.");
+                    color: Theme.text-muted; font-size: Theme.fs-xs; wrap: word-wrap;
+                }
+                Rectangle { height: 6px; }
+            }
+
             // ── Optional outbound proxy (SSH / Telnet only) ─────────────────
             if root.show-advanced && root.draft-kind != "serial" : VerticalLayout {
                 spacing: 4px;
@@ -1141,6 +1184,7 @@ export component SessionDialog inherits Rectangle {
                             parity: root.draft-parity,
                             flow-control: root.draft-flow,
                             encoding: root.draft-encoding,
+                            vt100-drawing: root.draft-vt100-drawing,
                             disable-shell-integration: root.draft-disable-shell-integration,
                             note: root.draft-note,
                             jump-session-id: (root.draft-jump-index > 0 && root.draft-jump-index < root.jump-ids.length)
@@ -1193,6 +1237,7 @@ export component SessionDialog inherits Rectangle {
                             parity: root.draft-parity,
                             flow-control: root.draft-flow,
                             encoding: root.draft-encoding,
+                            vt100-drawing: root.draft-vt100-drawing,
                             disable-shell-integration: root.draft-disable-shell-integration,
                             note: root.draft-note,
                             jump-session-id: (root.draft-jump-index > 0 && root.draft-jump-index < root.jump-ids.length)

--- a/ui/terminal_view.slint
+++ b/ui/terminal_view.slint
@@ -304,7 +304,7 @@ export component TerminalView inherits Rectangle {
     // fed from Rust); send-to-all is a per-tab toggle.
     in property <[QuickCmd]> quick-commands;
     in property <[string]> command-history;   // oldest first (newest last, #113)
-    in property <[string]> history-view;       // filtered dropdown, newest first (#101, #331)
+    in property <[string]> history-view;       // filtered dropdown, oldest first (newest last, #101)
     property <bool> send-to-all: false;
     in property <bool> cmd-bar-hidden: false;  // toolbar toggle hides the whole bar
     // Effective terminal font size in px: per-session zoom override when > 0,
@@ -491,7 +491,9 @@ export component TerminalView inherits Rectangle {
     changed history-open => {
         if (root.history-open) {
             if (!root.history-autocomplete) { root.search-history(""); }
-            root.history-selected = 0;
+            // List is oldest→newest (#101): default-select the newest entry.
+            root.history-selected = root.history-view.length > 0
+                ? root.history-view.length - 1 : 0;
         } else {
             root.history-autocomplete = false;
         }
@@ -1326,6 +1328,9 @@ export component TerminalView inherits Rectangle {
                             root.history-autocomplete = self.text != "";
                             root.search-history(self.text);
                             root.history-open = root.history-autocomplete;
+                            // Oldest→newest list: default-select the newest match.
+                            root.history-selected = root.history-view.length > 0
+                                ? root.history-view.length - 1 : 0;
                         }
                         key-pressed(e) => {
                             if (e.text == Key.Return && !e.modifiers.shift) {
@@ -1864,7 +1869,7 @@ export component TerminalView inherits Rectangle {
                                     // half-built layout, panicking with "Recursion
                                     // detected" (#349 / #343).
                                     init => { root.history-search-focus-pending = true; }
-                                    edited => { root.search-history(self.text); root.history-selected = 0; }
+                                    edited => { root.search-history(self.text); root.history-selected = root.history-view.length > 0 ? root.history-view.length - 1 : 0; }
                                     // ↑/↓ move the selection, Enter runs it, Esc
                                     // closes and returns focus to the terminal (#140).
                                     key-pressed(e) => {


### PR DESCRIPTION
实现[vt100绘制图形功能](https://github.com/yituorou/meatshell/issues/376)&&[历史命令排序不正常](https://github.com/yituorou/meatshell/issues/384)