### PR TITLE
feat(terminal): forward mouse events to mouse-tracking TUI apps

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -176,10 +176,10 @@ use crate::ssh::{
 use crate::terminal::c0_letter_key_down;
 use crate::terminal::{
     bare_ctrl_marker_workaround_enabled, cell_prefix, compile_output_rules,
-    encode_command_bar_input, encode_pasted_text, is_terminal_interrupt, key_to_pty_bytes,
-    paste_requires_large_review, should_drop_bare_ctrl_marker, terminal_uses_bracketed_paste,
-    CsiState, OutputHighlightPreset,
-    RenderGates, TabRenderGate, TermBuffer, TermBufferHandle, TermBuffers,
+    encode_command_bar_input, encode_mouse_event, encode_pasted_text, is_terminal_interrupt,
+    key_to_pty_bytes, paste_requires_large_review, should_drop_bare_ctrl_marker,
+    terminal_uses_bracketed_paste, CsiState, OutputHighlightPreset, RenderGates, TabRenderGate,
+    TermBuffer, TermBufferHandle, TermBuffers,
 };
 #[cfg(test)]
 use crate::terminal::{
@@ -4676,6 +4676,7 @@ fn wire_session_callbacks(
                 scroll_max: 0,
                 scroll_offset: 0,
                 is_alt_screen: false,
+                mouse_tracked: false,
                 find_matches: ModelRc::from(std::rc::Rc::new(VecModel::<TermMatch>::default())),
                 selection: ModelRc::from(std::rc::Rc::new(VecModel::<TermMatch>::default())),
                 sftp_path: "/".into(),
@@ -4731,6 +4732,7 @@ fn wire_session_callbacks(
                     sel_anchor: None,
                     sel_focus: None,
                     sel_ranges: Vec::new(),
+                    mouse_tracked: false,
                     history: VecDeque::new(),
                     prev: Vec::new(),
                     view_offset: 0,
@@ -6454,6 +6456,57 @@ fn wire_key_input(
                 rebuild_tab_display(&win, &bufs_sel, &tid);
             }
         });
+    }
+
+    // Mouse events forwarded to the PTY for mouse-tracking TUI apps (btop,
+    // htop, mc). The Slint side only calls this when the remote enabled a mouse
+    // protocol (mouse_protocol_mode != None), so a click inside e.g. btop
+    // highlights/activates the widget under the pointer instead of starting a
+    // local drag-selection. Returns true when bytes were actually written, so
+    // the caller can skip its own local handling.
+    {
+        let bufs_mouse = bufs.clone();
+        let handles_mouse = handles.clone();
+        window.on_terminal_mouse(
+            move |tab_id: SharedString, kind: i32, button: i32, row: i32, col: i32| -> bool {
+                let tid = tab_id.to_string();
+                let Some(bytes) = term_buf(&bufs_mouse, &tid).map(|h| {
+                    let buf = h.lock().unwrap();
+                    let screen = buf.parser.screen();
+                    let (rows, cols) = screen.size();
+                    if buf.mouse_tracked {
+                        let encoding = screen.mouse_protocol_encoding();
+                        let (btn, release) = match kind {
+                            1 => (button as u8, true), // release
+                            2 => (35, false),          // drag motion with button held
+                            _ => (button as u8, false), // press
+                        };
+                        Some(encode_mouse_event(
+                            btn,
+                            release,
+                            col,
+                            row,
+                            cols,
+                            rows,
+                            encoding,
+                        ))
+                    } else {
+                        None
+                    }
+                }) else {
+                    return false;
+                };
+                let Some(bytes) = bytes else {
+                    return false;
+                };
+                if let Some(h) = handles_mouse.borrow().get(&tid) {
+                    h.send_raw(bytes);
+                    true
+                } else {
+                    false
+                }
+            },
+        );
     }
 }
 

--- a/src/app/terminal_ui.rs
+++ b/src/app/terminal_ui.rs
@@ -196,6 +196,7 @@ pub(super) fn rebuild_tab_display(win: &AppWindow, bufs: &TermBuffers, tab_id: &
         row.cursor_col = cc;
         row.rows_used = ru;
         row.is_alt_screen = alt;
+        row.mouse_tracked = b.mouse_tracked;
         row.find_matches = fm.clone();
         row.selection = sm.clone();
         row.scroll_max = smax;

--- a/src/terminal/impls/input.rs
+++ b/src/terminal/impls/input.rs
@@ -8,6 +8,46 @@ pub(crate) fn normalize_pasted_newlines(text: &str) -> String {
     text.replace("\r\n", "\r").replace('\n', "\r")
 }
 
+/// Encode a terminal mouse event for the PTY using the encoding the remote
+/// application requested (X10 / SGR) — so btop, htop, mc and other mouse-aware
+/// TUI apps get click/drag/wheel events (see #terminal-mouse).
+///
+/// `btn` follows the xterm conventions (a vt100 `CellMouseButton`):
+///   0/1/2 = left / middle / right button press,
+///   32    = motion with no button,
+///   35    = motion with a button held,
+///   64/65 = wheel up / down.
+/// `release` marks a button-release event (only meaningful for `btn` 0–2):
+/// X10 encodes it as `btn + 3`, SGR keeps the same code but ends the report
+/// with a lowercase `m`.
+///
+/// Coordinates are 1-based grid cells clamped to the screen, matching how the
+/// remote draws its UI. `cols`/`rows` are the *screen* dimensions (not the
+/// visible viewport) so the report always points at the same cell the program
+/// rendered.
+pub(crate) fn encode_mouse_event(
+    btn: u8,
+    release: bool,
+    col: i32,
+    row: i32,
+    cols: u16,
+    rows: u16,
+    encoding: vt100::MouseProtocolEncoding,
+) -> Vec<u8> {
+    let c = (col.clamp(0, cols.saturating_sub(1) as i32) as u16 + 1).clamp(1, 223);
+    let r = (row.clamp(0, rows.saturating_sub(1) as i32) as u16 + 1).clamp(1, 223);
+    match encoding {
+        vt100::MouseProtocolEncoding::Sgr => {
+            let final_byte = if release { b'm' } else { b'M' };
+            format!("\x1b[<{btn};{c};{r}{}", final_byte as char).into_bytes()
+        }
+        _ => {
+            let cb = btn as u16 + if release { 3 } else { 0 } + 32;
+            vec![0x1b, b'[', b'M', cb as u8, (c + 32) as u8, (r + 32) as u8]
+        }
+    }
+}
+
 /// Encode a command-bar submission and return the optional non-empty history
 /// entry separately. An empty bar still represents an Enter key press (#307),
 /// but must not add a blank command to persistent history.
@@ -232,4 +272,67 @@ pub(crate) fn c0_letter_key_down(codepoint: u32) -> bool {
         fn GetKeyState(nVirtKey: i32) -> i16;
     }
     unsafe { (GetKeyState(virtual_key) as u16) & 0x8000 != 0 }
+}
+
+#[cfg(test)]
+mod mouse_encoding_tests {
+    use super::*;
+
+    #[test]
+    fn x10_left_press() {
+        // Left press (0) at cell (1,1) → Cb=32+0=32 → ESC [ M sp ! !
+        let bytes = encode_mouse_event(0, false, 0, 0, 80, 24, vt100::MouseProtocolEncoding::Default);
+        assert_eq!(bytes, vec![0x1b, b'[', b'M', 32, 33, 33]);
+    }
+
+    #[test]
+    fn x10_left_release() {
+        // Release adds 3 to the button code → Cb=32+3=35.
+        let bytes = encode_mouse_event(0, true, 0, 0, 80, 24, vt100::MouseProtocolEncoding::Default);
+        assert_eq!(bytes, vec![0x1b, b'[', b'M', 35, 33, 33]);
+    }
+
+    #[test]
+    fn x10_second_column_and_row() {
+        // Cell (1,2) → Cx=33+... wait 2 → 34; row 1 → 33.
+        let bytes = encode_mouse_event(0, false, 1, 0, 80, 24, vt100::MouseProtocolEncoding::Default);
+        assert_eq!(bytes, vec![0x1b, b'[', b'M', 32, 34, 33]);
+    }
+
+    #[test]
+    fn sgr_left_press() {
+        let bytes = encode_mouse_event(0, false, 0, 0, 80, 24, vt100::MouseProtocolEncoding::Sgr);
+        assert_eq!(bytes, b"\x1b[<0;1;1M");
+    }
+
+    #[test]
+    fn sgr_left_release_uses_lowercase_m() {
+        let bytes = encode_mouse_event(0, true, 0, 0, 80, 24, vt100::MouseProtocolEncoding::Sgr);
+        assert_eq!(bytes, b"\x1b[<0;1;1m");
+    }
+
+    #[test]
+    fn x10_wheel() {
+        let bytes = encode_mouse_event(64, false, 5, 3, 80, 24, vt100::MouseProtocolEncoding::Default);
+        assert_eq!(bytes, vec![0x1b, b'[', b'M', 64 + 32, 5 + 1 + 32, 3 + 1 + 32]);
+    }
+
+    #[test]
+    fn sgr_wheel() {
+        let bytes = encode_mouse_event(64, false, 5, 3, 80, 24, vt100::MouseProtocolEncoding::Sgr);
+        assert_eq!(bytes, b"\x1b[<64;6;4M");
+    }
+
+    #[test]
+    fn coordinates_clamped_to_screen() {
+        // Negative / out-of-range columns clamp into the grid.
+        let bytes = encode_mouse_event(0, false, -5, 999, 80, 24, vt100::MouseProtocolEncoding::Sgr);
+        assert_eq!(bytes, b"\x1b[<0;1;24M");
+    }
+
+    #[test]
+    fn x10_drag_motion() {
+        let bytes = encode_mouse_event(32, false, 2, 2, 80, 24, vt100::MouseProtocolEncoding::Default);
+        assert_eq!(bytes, vec![0x1b, b'[', b'M', 32 + 32, 2 + 1 + 32, 2 + 1 + 32]);
+    }
 }

--- a/src/terminal/impls/term_buffer.rs
+++ b/src/terminal/impls/term_buffer.rs
@@ -484,6 +484,15 @@ impl TermBuffer {
         self.feed_batched(&stream);
     }
 
+    /// Refresh the cached `mouse_tracked` flag from the parser's current mouse
+    /// protocol state (the remote app enables it with e.g. `\x1b[?1000h` /
+    /// `\x1b[?1002h`).  Kept as a cached bool so the UI hot path doesn't need
+    /// to lock the parser to decide how a click behaves.
+    fn sync_mouse_tracked(&mut self) {
+        self.mouse_tracked =
+            self.parser.screen().mouse_protocol_mode() != vt100::MouseProtocolMode::None;
+    }
+
     /// Process one bounded batch and capture any lines that scrolled off the top
     /// (skipped for alt-screen programs like vim/nano).
     fn ingest_chunk(&mut self, bytes: &[u8]) {
@@ -498,6 +507,7 @@ impl TermBuffer {
         let is_fullscreen_refresh = has_cursor_home && has_erase_display;
 
         self.parser.process(bytes);
+        self.sync_mouse_tracked();
         let (is_alt, rows, cols) = {
             let s = self.parser.screen();
             let (r, c) = s.size();
@@ -590,6 +600,7 @@ impl TermBuffer {
                 cursor_col: cur_col as i32,
                 rows_used,
                 is_alt,
+                mouse_tracked: self.mouse_tracked,
                 scroll_max: if is_alt { 0 } else { self.history.len() as i32 },
                 scroll_offset: 0,
             };
@@ -640,6 +651,7 @@ impl TermBuffer {
             cursor_col: 0,
             rows_used: win as i32,
             is_alt: false,
+            mouse_tracked: self.mouse_tracked,
             scroll_max: self.history.len() as i32,
             scroll_offset: self.view_offset as i32,
         }

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -31,8 +31,8 @@ pub(crate) use input::c0_letter_key_down;
 #[cfg(test)]
 pub(crate) use input::normalize_pasted_newlines;
 pub(crate) use input::{
-    bare_ctrl_marker_workaround_enabled, encode_command_bar_input, encode_pasted_text,
-    is_terminal_interrupt, key_to_pty_bytes, paste_requires_large_review,
+    bare_ctrl_marker_workaround_enabled, encode_command_bar_input, encode_mouse_event,
+    encode_pasted_text, is_terminal_interrupt, key_to_pty_bytes, paste_requires_large_review,
     should_drop_bare_ctrl_marker,
     terminal_uses_bracketed_paste,
 };

--- a/src/terminal/struct/state.rs
+++ b/src/terminal/struct/state.rs
@@ -22,6 +22,11 @@ pub(crate) struct TermBuffer {
     pub(crate) sel_anchor: Option<(usize, u16)>,
     pub(crate) sel_focus: Option<(usize, u16)>,
     pub(crate) sel_ranges: Vec<((usize, u16), (usize, u16))>,
+    /// Whether the remote application is tracking the mouse (vt100
+    /// `mouse_protocol_mode() != None`). When true, clicks and drags are
+    /// forwarded to the PTY instead of starting a local drag-selection, so
+    /// btop/htop/mc can be operated with the mouse (#terminal-mouse).
+    pub(crate) mouse_tracked: bool,
     pub(crate) history: VecDeque<Line>,
     pub(crate) prev: Vec<Line>,
     pub(crate) view_offset: usize,
@@ -97,6 +102,7 @@ pub(crate) struct BuiltScreen {
     pub(crate) cursor_col: i32,
     pub(crate) rows_used: i32,
     pub(crate) is_alt: bool,
+    pub(crate) mouse_tracked: bool,
     pub(crate) scroll_max: i32,
     pub(crate) scroll_offset: i32,
 }

--- a/tests/app/terminal_rendering/mod.rs
+++ b/tests/app/terminal_rendering/mod.rs
@@ -28,6 +28,7 @@ fn make_buf(
         sel_anchor: None,
         sel_focus: None,
         sel_ranges: Vec::new(),
+        mouse_tracked: false,
         history: history.iter().map(|s| hist_line(s)).collect(),
         prev: Vec::new(),
         view_offset,

--- a/ui/app.slint
+++ b/ui/app.slint
@@ -58,6 +58,7 @@ export struct TerminalState {
     scroll-max: int,       // scrollback depth (max offset) — terminal scrollbar (#103)
     scroll-offset: int,    // current scrollback offset (0 = live bottom)
     is-alt-screen: bool,
+    mouse-tracked: bool,     // remote app wants mouse events (btop/htop/mc)
     find-matches: [TermMatch], // search-highlight rectangles
     selection: [TermMatch],    // drag-selection highlight rectangles
 
@@ -1032,6 +1033,8 @@ export component AppWindow inherits Window {
     // Wheel forwarded to an alt-screen program (#170): tab-id, dir (+1 up/-1 down), col, row.
     callback terminal-wheel(string, int, int, int);
     callback terminal-scroll-to(string /* tab-id */, int /* offset */); // scrollbar drag (#103)
+    // Mouse event forwarded to a mouse-tracking TUI app (#terminal-mouse).
+    callback terminal-mouse(string /* tab-id */, int /* kind */, int /* button */, int /* row */, int /* col */) -> bool;
     // Drag-selection lifecycle (grid row/col coordinates).
     callback term-select-start(string /* tab-id */, int /* row */, int /* col */, bool /* ctrl */, bool /* shift */);
     callback term-select-update(string /* tab-id */, int /* row */, int /* col */);
@@ -1812,6 +1815,7 @@ export component AppWindow inherits Window {
                         scroll-max: term.scroll-max;
                         scroll-offset: term.scroll-offset;
                         is-alt-screen: term.is-alt-screen;
+                        mouse-tracked: term.mouse-tracked;
                         find-matches: term.find-matches;
                         selection: term.selection;
                         sftp-panel-height: term.sftp-panel-height;
@@ -1964,6 +1968,7 @@ export component AppWindow inherits Window {
                         terminal-scroll(d) => { root.terminal-scroll(term.id, d); }
                         terminal-wheel(d, c, r) => { root.terminal-wheel(term.id, d, c, r); }
                         terminal-scroll-to(o) => { root.terminal-scroll-to(term.id, o); }
+                        terminal-mouse(kind, btn, r, c) => { root.terminal-mouse(term.id, kind, btn, r, c); }
                         select-start(r, c, ctrl, shift) => { root.term-select-start(term.id, r, c, ctrl, shift); }
                         select-update(r, c) => { root.term-select-update(term.id, r, c); }
                         select-end() => { root.term-select-end(term.id); }

--- a/ui/terminal_view.slint
+++ b/ui/terminal_view.slint
@@ -255,6 +255,7 @@ export component TerminalView inherits Rectangle {
     in property <int> scroll-max;       // scrollback depth (max offset) (#103)
     in property <int> scroll-offset;    // current offset (0 = live bottom) (#103)
     in property <bool>   is-alt-screen;
+    in property <bool>   mouse-tracked;   // remote app wants mouse events (btop/htop/mc)
     in property <[TermMatch]> find-matches; // search-highlight rectangles
     in property <[TermMatch]> selection;    // drag-selection highlight rectangles
 
@@ -390,6 +391,11 @@ export component TerminalView inherits Rectangle {
     // arrow keys (alternate-scroll).
     callback terminal-wheel(int /* dir */, int /* col */, int /* row */);
     callback terminal-scroll-to(int);       // jump to an absolute scrollback offset (#103)
+    // Forward a mouse button event to the PTY for mouse-tracking TUI apps
+    // (btop/htop/mc). kind: 0=press 1=release 2=drag-motion; button: 0=left
+    // 1=middle 2=right; col/row are grid cells. Returns true when the event was
+    // sent to the remote (the caller then skips its own local handling).
+    callback terminal-mouse(int /* kind */, int /* button */, int /* col */, int /* row */) -> bool;
     callback select-start(int, int, bool, bool); // row, col, ctrl, shift
     callback select-update(int, int);       // extend drag-selection to (row, col)
     callback select-end();                  // finish selection → copy to clipboard
@@ -678,6 +684,11 @@ export component TerminalView inherits Rectangle {
                                         root.ctx-x = self.mouse-x;
                                         root.ctx-y = self.mouse-y;
                                         ctx-menu.show();
+                                    } else if (ev.button == PointerEventButton.left
+                                            && root.mouse-tracked && !ev.modifiers.shift) {
+                                        root.terminal-mouse(0, 0,
+                                            floor(self.mouse-y / root.cell-h),
+                                            floor(self.mouse-x / root.cell-w));
                                     } else if (ev.button == PointerEventButton.left) {
                                         root.selecting = true;
                                         root.select-start(
@@ -691,6 +702,11 @@ export component TerminalView inherits Rectangle {
                                         root.paste-from-clipboard();
                                         ime-input.focus();
                                     } else if (ev.button == PointerEventButton.left
+                                            && root.mouse-tracked && !ev.modifiers.shift) {
+                                        root.terminal-mouse(1, 0,
+                                            floor(self.mouse-y / root.cell-h),
+                                            floor(self.mouse-x / root.cell-w));
+                                    } else if (ev.button == PointerEventButton.left
                                             && root.selecting) {
                                         root.selecting = false;
                                         root.autoscroll-dir = 0;
@@ -699,9 +715,14 @@ export component TerminalView inherits Rectangle {
                                 }
                             }
                             double-clicked => {
-                                root.select-word(
-                                    floor(self.mouse-y / root.cell-h),
-                                    floor(self.mouse-x / root.cell-w));
+                                if (root.mouse-tracked) {
+                                    // Mouse-tracking TUI: double-click = two forwarded
+                                    // presses, not a local word-select (#terminal-mouse).
+                                } else {
+                                    root.select-word(
+                                        floor(self.mouse-y / root.cell-h),
+                                        floor(self.mouse-x / root.cell-w));
+                                }
                             }
                             moved => {
                                 if (root.selecting) {
@@ -729,6 +750,10 @@ export component TerminalView inherits Rectangle {
                                             root.autoscroll-dir = 0;
                                         }
                                     }
+                                } else if (root.mouse-tracked && self.pressed) {
+                                    root.terminal-mouse(2, 0,
+                                        floor(self.mouse-y / root.cell-h),
+                                        floor(self.mouse-x / root.cell-w));
                                 }
                             }
                             scroll-event(ev) => {
@@ -860,6 +885,14 @@ export component TerminalView inherits Rectangle {
                                         root.ctx-x = self.mouse-x;
                                         root.ctx-y = self.mouse-y;
                                         ctx-menu.show();
+                                    } else if (ev.button == PointerEventButton.left
+                                            && root.mouse-tracked && !ev.modifiers.shift) {
+                                        // Mouse-tracking TUI (btop/htop/mc): forward the
+                                        // press so the remote acts on it (#terminal-mouse).
+                                        // Shift+click still selects locally (xterm-style).
+                                        root.terminal-mouse(0, 0,
+                                            floor(self.mouse-y / root.cell-h),
+                                            floor(self.mouse-x / root.cell-w));
                                     } else if (ev.button == PointerEventButton.left) {
                                         root.selecting = true;
                                         root.select-start(
@@ -873,6 +906,11 @@ export component TerminalView inherits Rectangle {
                                         root.paste-from-clipboard();
                                         ime-input.focus();
                                     } else if (ev.button == PointerEventButton.left
+                                            && root.mouse-tracked && !ev.modifiers.shift) {
+                                        root.terminal-mouse(1, 0,
+                                            floor(self.mouse-y / root.cell-h),
+                                            floor(self.mouse-x / root.cell-w));
+                                    } else if (ev.button == PointerEventButton.left
                                             && root.selecting) {
                                         root.selecting = false;
                                         root.autoscroll-dir = 0;
@@ -881,9 +919,14 @@ export component TerminalView inherits Rectangle {
                                 }
                             }
                             double-clicked => {
-                                root.select-word(
-                                    floor(self.mouse-y / root.cell-h),
-                                    floor(self.mouse-x / root.cell-w));
+                                if (root.mouse-tracked) {
+                                    // Mouse-tracking TUI: double-click = two forwarded
+                                    // presses, not a local word-select (#terminal-mouse).
+                                } else {
+                                    root.select-word(
+                                        floor(self.mouse-y / root.cell-h),
+                                        floor(self.mouse-x / root.cell-w));
+                                }
                             }
                             moved => {
                                 if (root.selecting) {
@@ -900,6 +943,12 @@ export component TerminalView inherits Rectangle {
                                             root.autoscroll-dir = 0;
                                         }
                                     }
+                                } else if (root.mouse-tracked && self.pressed) {
+                                    // Drag-motion while a button is held → forward to the
+                                    // remote so btop/htop graphs/hover regions track it.
+                                    root.terminal-mouse(2, 0,
+                                        floor(self.mouse-y / root.cell-h),
+                                        floor(self.mouse-x / root.cell-w));
                                 }
                             }
                             scroll-event(ev) => {


### PR DESCRIPTION
## Summary

btop, htop, mc and other TUIs that enable a terminal mouse protocol (`\x1b[?1000h` / `\x1b[?1002h`) can now be operated with the mouse. Clicks, drags and releases are forwarded to the remote PTY instead of starting a local drag-selection.

## Changes

- **Mouse encoding helper** (`src/terminal/impls/input.rs`): new `encode_mouse_event()` supporting both X10 and SGR encodings, with 9 unit tests.
- **Mouse-tracking state**: `TermBuffer.mouse_tracked` caches `screen.mouse_protocol_mode() != None` and is surfaced to the UI as `TerminalState.mouse-tracked`.
- **UI forwarding** (`ui/terminal_view.slint`): `body-touch-overlay` forwards press/release/drag-motion via a new `terminal-mouse` callback when the remote tracks the mouse.
- **PTY write** (`src/app.rs`): `on_terminal_mouse` encodes and sends the event to the session handle.

## Behavior details

- Shift+click still selects text locally (xterm convention).
- Double-click no longer triggers local word-select while the TUI tracks the mouse.
- Wheel still uses the existing alt-screen forwarding path (`terminal-wheel`).

## Verification

- `cargo test --bin meatshell`: 212 passed (incl. 9 new mouse-encoding tests).
- `cargo build --release` succeeds.