### PR TITLE
fix(sftp): 上传后勾选计数与批量下载/删除按钮未同步清零

### DIFF
--- a/src/app/session_event.rs
+++ b/src/app/session_event.rs
@@ -241,6 +241,25 @@ pub(super) fn apply_session_event_to_window(
                 t.sftp_path = path.clone().into();
                 t.sftp_entries = model.clone();
                 t.sftp_loading = false;
+                // Reset the multi-select counter (#sftp-entries-selection).
+                // Every entry above is built with `selected: false`, so the
+                // rebuilt list is visually unchecked — but `sftp_selected_count`
+                // is a *separate* field on the tab row and is NOT derived from
+                // the entries, so it silently kept its stale value (e.g. "2")
+                // and the toolbar's count label plus the batch download/delete
+                // buttons stayed on screen until the user ticked a checkbox to
+                // force a recount.
+                // Clearing it here — where the list is actually rebuilt — fixes
+                // every path that reloads a directory at once: upload (both the
+                // SFTP panel button and shell drag-and-drop end in a `list_dir`
+                // + `SftpEntries` once the transfer finishes), download, delete,
+                // rename, mkdir, navigate and manual refresh. Future reload
+                // paths are covered automatically instead of needing another
+                // per-callback patch like the earlier `on_sftp_refresh` fix.
+                // NOTE: sorting is deliberately unaffected — it goes through
+                // `sorted_sftp_entries_from_model` in sftp_callbacks.rs, which
+                // re-sorts the existing rows and must preserve the selection.
+                t.sftp_selected_count = 0;
             });
         }
         SessionEvent::SftpStatus(msg) => {


### PR DESCRIPTION
### 问题描述

在 SFTP 文件面板勾选若干文件后执行上传——文件列表被刷新（勾选状态视觉上已消失），但工具栏的**选中计数数字**、**批量下载**、**批量删除**按钮依然残留显示，必须再手动勾选/取消勾选一次，三者才会消失。

### 复现步骤

1. 连接任意 SSH 会话，打开 SFTP 文件面板
2. 勾选 2 个文件 → 工具栏出现计数 `2` 与批量下载/删除按钮
3. 上传任意文件（**两种方式均可复现**）：
   - 通过 SFTP 面板的上传按钮
   - 通过 shell 页面拖拽本地文件到终端
4. 上传完成后，文件列表刷新，所有勾选框清空
5. **实际结果**：工具栏的计数、下载、删除按钮仍然存在
6. **期望结果**：三者应随勾选状态一并消失

### 根因

文件列表采用「每行 `selected: bool` + tab 上一个汇总 `sftp_selected_count: int`」的双状态建模。其中 `sftp_selected_count` 是**独立字段，不由条目列表派生**。

当目录被重新加载时，`SessionEvent::SftpEntries` 分支会用全新远程条目整体替换列表 model，每个条目都是 `selected: false`——因此视觉上的勾选消失了。但该分支**从未写回 `sftp_selected_count`**，导致计数停留在旧值，工具栏据此继续渲染数字与批量按钮。

此前针对「点击刷新按钮后计数残留」的修复，是在 `on_sftp_refresh` 回调中补 `clear_sftp_selection`，属于**在触发入口打补丁**。而上传完成后的刷新完全不经过该回调——它由后台线程在传输结束后执行 `list_dir_impl` 并回传 `SftpEntries` 事件直接驱动，因此未被覆盖。

这也解释了为什么两种上传方式都会复现：**它们最终汇聚到同一条事件路径**。

### 修复方案

在 `session_event.rs` 的 `SftpEntries` 分支（即列表真正被重建处）同步清零计数：

```rust
t.sftp_entries = model.clone();
t.sftp_loading = false;
t.sftp_selected_count = 0;   // 新增
```

选择在**数据重建处**而非各触发入口修复，一次覆盖所有导致目录重载的路径：

| 路径 | 修复前 | 修复后 |
|---|---|---|
| 上传（SFTP 面板按钮 / shell 拖拽） | ❌ 计数残留 | ✅ 同步清零 |
| 下载、删除、重命名、mkdir | 部分覆盖 | ✅ 统一覆盖 |
| 目录导航、手动刷新 | ✅（此前逐入口修复） | ✅ 统一覆盖 |
| 列表排序 | ✅ 保留选中 | ✅ **刻意保持不变** |

排序路径刻意不受影响：它走 `sftp_callbacks.rs` 的 `sorted_sftp_entries_from_model`，仅重排现有行、不重建 model，必须保留选中状态。

后续新增的目录重载路径也会自动被覆盖，无需再逐个回调打补丁。

### 验证

- [x] `cargo build` 通过（32.30s，退出码 0）
- [x] 无新增编译警告（13 条均为上游历史 `dead_code`/`unused`，与修复前一致）
- [x] 排序路径仍使用 `sorted_sftp_entries_from_model`，「排序保留勾选」行为未改变

### 影响范围

仅 `src/app/session_event.rs`，**+19 行**（其中 18 行为说明意图与覆盖范围的代码注释，1 行为实际逻辑）。

无 API 变更，无配置变更，无行为回退风险。