### PR TITLE
fix(sftp): 批量下载软链变空连接 + 复制路径卡死等修复

### DIFF
--- a/src/app/session_event.rs
+++ b/src/app/session_event.rs
@@ -241,6 +241,25 @@ pub(super) fn apply_session_event_to_window(
                 t.sftp_path = path.clone().into();
                 t.sftp_entries = model.clone();
                 t.sftp_loading = false;
+                // Reset the multi-select counter (#sftp-entries-selection).
+                // Every entry above is built with `selected: false`, so the
+                // rebuilt list is visually unchecked — but `sftp_selected_count`
+                // is a *separate* field on the tab row and is NOT derived from
+                // the entries, so it silently kept its stale value (e.g. "2")
+                // and the toolbar's count label plus the batch download/delete
+                // buttons stayed on screen until the user ticked a checkbox to
+                // force a recount.
+                // Clearing it here — where the list is actually rebuilt — fixes
+                // every path that reloads a directory at once: upload (both the
+                // SFTP panel button and shell drag-and-drop end in a `list_dir`
+                // + `SftpEntries` once the transfer finishes), download, delete,
+                // rename, mkdir, navigate and manual refresh. Future reload
+                // paths are covered automatically instead of needing another
+                // per-callback patch like the earlier `on_sftp_refresh` fix.
+                // NOTE: sorting is deliberately unaffected — it goes through
+                // `sorted_sftp_entries_from_model` in sftp_callbacks.rs, which
+                // re-sorts the existing rows and must preserve the selection.
+                t.sftp_selected_count = 0;
             });
         }
         SessionEvent::SftpStatus(msg) => {

--- a/src/app/sftp_callbacks.rs
+++ b/src/app/sftp_callbacks.rs
@@ -643,8 +643,14 @@ pub(super) fn wire_sftp_callbacks(
         );
     }
     {
+        // Run on a spawned thread, NOT the Slint UI thread. clipboard_set_text
+        // (arboard) can block when the OS clipboard is held by another process
+        // (Windows OpenClipboard / Wayland wait()); doing it synchronously here
+        // freezes the whole UI event loop (#sftp-copy-path-freeze). Every other
+        // caller in app.rs wraps clipboard writes in std::thread::spawn — this
+        // one was the only outlier.
         window.on_sftp_copy_path(move |path: SharedString| {
-            clipboard_set_text(path.to_string());
+            std::thread::spawn(move || clipboard_set_text(path.to_string()));
         });
     }
 

--- a/src/sftp/impls/sftp.rs
+++ b/src/sftp/impls/sftp.rs
@@ -772,8 +772,12 @@ async fn run_sftp(
                     emit_transfer(&events, &id, &arc_name, false, 0, 0, 3, "");
                     // Plain tar (no gzip): the user prefers speed over a smaller file.
                     // Server-supplied names are untrusted → quote every argument.
+                    // -h (--dereference): archive the *target* of a symlink instead of
+                    // the link itself. Without it, remote .pem files that are symlinks
+                    // are stored as link entries (0 bytes) and extract as broken/empty
+                    // links on the local side (#sftp-batch-download-symlink).
                     let mut cmd =
-                        format!("tar -cf {} -C {}", sh_quote(&tmp), sh_quote(&remote_dir));
+                        format!("tar -chf {} -C {}", sh_quote(&tmp), sh_quote(&remote_dir));
                     for nm in &names {
                         cmd.push(' ');
                         cmd.push_str(&sh_quote(nm));

--- a/ui/sftp_panel.slint
+++ b/ui/sftp_panel.slint
@@ -190,7 +190,10 @@ export component SftpPanel inherits Rectangle {
 
                 HorizontalLayout {
                 height: 34px;
-                padding-left: 6px;
+                // Pushed the left padding from 6px to 10px so the dock drag grip
+                // sits a bit further from the panel edge and the Files tab no longer
+                // feels crowded against it (#toolbar-shadow-overlap).
+                padding-left: 10px;
                 padding-right: 6px;
                 padding-top: 6px;
                 padding-bottom: 6px;
@@ -223,6 +226,16 @@ export component SftpPanel inherits Rectangle {
                         width: parent.width;
                         height: parent.height;
                     }
+                }
+
+                // Small transparent spacer between the dock drag grip and the Files
+                // tab. Without it the grip's hover state visually bleeds into the
+                // tab's background, making the two look like a single overlapping
+                // shape (#toolbar-shadow-overlap).
+                Rectangle {
+                    width: 6px;
+                    height: 22px;
+                    background: transparent;
                 }
 
                 Rectangle {
@@ -285,6 +298,11 @@ export component SftpPanel inherits Rectangle {
                 // jump there; copy / paste-jump buttons sit right after it (#54).
                 Rectangle {
                     visible: root.panel-mode == "files" && !root.narrow-toolbar;
+                    // Floor the path field at 100px so switching to Files mode
+                    // (which reveals copy/paste/up/upload next to it) doesn't
+                    // squeeze the input down to an unreadable strip in
+                    // mid-width panels (~380–480px) (#toolbar-input-shrink).
+                    min-width: 100px;
                     horizontal-stretch: 1;
                     height: 22px;
                     border-radius: Theme.radius-sm;


### PR DESCRIPTION
## 摘要
本 PR 修复 SFTP 模块的两处问题，均已通过 GitHub Actions 在 fork 上临时产出的 `.deb`（run `33370483226`，ubuntu-22.04 构建，glibc 基线低于 Debian 13.6）在 **Debian 13.6 KDE** 上安装验证通过。

> 注：验证用的 CI 工作流仅用于本次出包验证，**不纳入本 PR**。

## 改动
- **批量下载软链文件变空连接** (#sftp-batch-download-symlink)
  `src/sftp/impls/sftp.rs` 打包命令由 `tar -cf` 改为 `tar -chf`（`--dereference`），归档软链接的**目标内容**而非链接本身，避免 `.pem` 等软链文件在本地解压为 0 字节空连接。
  注：单文件下载走 SFTP 协议（跟随软链）本就正常，问题仅出在批量下载的 `tar` 路径。

- **多选复制路径卡死 UI** (#sftp-copy-path-freeze)
  `src/app/sftp_callbacks.rs` 的 `on_sftp_copy_path` 回调将 `clipboard_set_text`（arboard）改在 `std::thread::spawn` 派生线程执行，避免 OS 剪贴板被占用时阻塞 Slint UI 事件循环导致卡死（此前是唯一未包裹线程的调用点）。

- **工具栏拖拽手柄与 Files 标签视觉重叠 + 路径输入框过窄** (#sftp-toolbar-shadow-overlap)

- **上传后勾选计数与批量下载/删除按钮未同步清零** (#sftp-upload-count)

## 验证
- fork 上临时 CI 构建产物 `.deb`，在 Debian 13.6 KDE 安装并验证上述修复生效。

## 关联提交
- `66041af` 批量下载软链 + 复制路径卡死（本提交仅含两处代码修复）
- `7e6c43e` 工具栏视觉重叠
- `f103365` 上传后计数清零
