### PR TITLE
fix(linux): 修复 Wayland 启动后任务栏出现三个窗口

### DIFF
--- a/src/app/resource_ui.rs
+++ b/src/app/resource_ui.rs
@@ -554,9 +554,7 @@ pub(super) fn sync_system_info_theme(main: &AppWindow, sys: &SystemInfoWindow) {
 }
 
 pub(super) fn place_system_info_window(main: &AppWindow, sys: &SystemInfoWindow) {
-    use i_slint_backend_winit::winit::dpi::{LogicalPosition, LogicalSize};
-
-    let Some((mon_x, mon_y, mon_w, mon_h, scale)) = main
+    let Some((mon_x, mon_y, mon_w, mon_h)) = main
         .window()
         .with_winit_window(|ww| {
             let scale = ww.scale_factor().max(0.01);
@@ -568,7 +566,6 @@ pub(super) fn place_system_info_window(main: &AppWindow, sys: &SystemInfoWindow)
                 pos.y as f64 / scale,
                 size.width as f64 / scale,
                 size.height as f64 / scale,
-                scale,
             ))
         })
         .flatten()
@@ -581,11 +578,14 @@ pub(super) fn place_system_info_window(main: &AppWindow, sys: &SystemInfoWindow)
     let x = mon_x + (mon_w - target_w).max(0.0) / 2.0;
     let y = mon_y + (mon_h - target_h).max(0.0) / 2.0;
 
-    sys.window().with_winit_window(|ww| {
-        let _ = ww.request_inner_size(LogicalSize::new(target_w, target_h));
-        ww.set_outer_position(LogicalPosition::new(x, y));
-        let _ = scale; // documents that all values above are already logical.
-    });
+    // Use the Slint window API instead of the winit handle: hidden windows are
+    // no longer materialized eagerly (they map on Wayland and pollute the
+    // taskbar — see the vendor patch in i-slint-backend-winit), so the first
+    // open may run before the native window exists. In that state the Slint
+    // API stores the size/position on the adapter and applies it at creation;
+    // with a live window it behaves like the winit calls did.
+    sys.window().set_size(slint::LogicalSize::new(target_w as f32, target_h as f32));
+    sys.window().set_position(slint::LogicalPosition::new(x as f32, y as f32));
 }
 
 /// Center the process monitor on the same physical monitor as the main window.
@@ -593,8 +593,6 @@ pub(super) fn place_system_info_window(main: &AppWindow, sys: &SystemInfoWindow)
 /// displays use different DPI scale factors. Keep the user's current process
 /// window size; opening it should reposition, not reset a manual resize.
 pub(super) fn place_process_window(main: &AppWindow, process: &ProcWindow) {
-    use i_slint_backend_winit::winit::dpi::PhysicalPosition;
-
     let monitor = main
         .window()
         .with_winit_window(|ww| ww.current_monitor().or_else(|| ww.primary_monitor()))
@@ -603,10 +601,16 @@ pub(super) fn place_process_window(main: &AppWindow, process: &ProcWindow) {
     let origin = monitor.position();
     let monitor_size = monitor.size();
 
-    process.window().with_winit_window(|ww| {
-        let window_size = ww.outer_size();
-        let x = origin.x + monitor_size.width.saturating_sub(window_size.width) as i32 / 2;
-        let y = origin.y + monitor_size.height.saturating_sub(window_size.height) as i32 / 2;
-        ww.set_outer_position(PhysicalPosition::new(x, y));
-    });
+    // The winit window may not exist yet on the first open (deferred creation,
+    // see place_system_info_window); fall back to a zero size, which anchors
+    // the window's top-left at the monitor center until the next open.
+    // Wayland ignores client-side positioning entirely, so this only affects
+    // X11/Windows first-open placement.
+    let window_size = process
+        .window()
+        .with_winit_window(|ww| ww.outer_size())
+        .unwrap_or_default();
+    let x = origin.x + monitor_size.width.saturating_sub(window_size.width) as i32 / 2;
+    let y = origin.y + monitor_size.height.saturating_sub(window_size.height) as i32 / 2;
+    process.window().set_position(slint::PhysicalPosition::new(x, y));
 }

--- a/vendor/i-slint-backend-winit/lib.rs
+++ b/vendor/i-slint-backend-winit/lib.rs
@@ -693,8 +693,17 @@ impl SharedBackendData {
         let mut inactive_windows = self.inactive_windows.take();
         let mut result = Ok(());
         while let Some(window_weak) = inactive_windows.pop() {
-            if let Some(err) = window_weak.upgrade().and_then(|w| w.ensure_window(event_loop).err())
-            {
+            let Some(window) = window_weak.upgrade() else { continue };
+            // Skip windows the application never showed. Materializing their
+            // winit window here is unnecessary on X11/Windows (created hidden),
+            // but on Wayland winit cannot create a window that is not visible,
+            // so the hidden window would be mapped immediately and show up in
+            // the taskbar. When the application shows such a window later,
+            // set_visibility() registers it here again for deferred creation.
+            if window.winit_window().is_none() && window.visibility() == WindowVisibility::Hidden {
+                continue;
+            }
+            if let Some(err) = window.ensure_window(event_loop).err() {
                 result = Err(err);
                 break;
             }


### PR DESCRIPTION
Slint/winit 后端在事件循环启动时会为所有已注册的窗口适配器实体化
原生窗口，而 winit 在 Wayland 上创建窗口即映射，导致启动时提前构建
的进程监视器与系统信息两个隐藏窗口也被映射出来，任务栏出现三个
meatshell 窗口。

- vendor 补丁：create_inactive_windows 跳过从未 show 过的窗口， 辅助窗口延迟到首次打开时才创建
- 窗口定位改用 Slint 窗口 API，在原生窗口尚未创建时也能生效

解决[linux启动后任务栏看到存在三个窗口](https://github.com/yituorou/meatshell/issues/395)