### PR TITLE
feat(sftp): fall back to SCP when the sftp subsystem is unavailable

### DIFF
--- a/src/sftp/impls/scp.rs
+++ b/src/sftp/impls/scp.rs
@@ -1,0 +1,869 @@
+//! SCP wire-protocol engine.
+//!
+//! When an SFTP-only attempt fails (the `sftp` subsystem is missing/refused,
+//! common on ultra-minimal BusyBox routers and network gear) we fall back to
+//! the classic `scp` protocol: an SSH exec channel running the remote `scp`
+//! binary in `-f` (sender) or `-t` (receiver) mode, speaking the rcp/SCP
+//! framing protocol over the channel's stdin/stdout.
+//!
+//! This module implements BOTH directions over a single authenticated russh
+//! handle: directory listings (a throwaway `ls -l`), file download, file
+//! upload, recursive directory download/upload, read/write of small text
+//! files, plus the shell commands used for file-system operations that the
+//! SCP protocol has no primitive for (delete / mkdir / rename / chmod /
+//! touch). Everything is shell-quoted because remote names are untrusted.
+//!
+//! # Wire protocol (from OpenSSH scp.c)
+//!
+//! Both ends open with a single `\0` greeting byte (BusyBox may omit it, so we
+//! probe with a short timeout on the receive side and always send it on the
+//! send side). Every command line / control record / payload chunk is then
+//! acknowledged by a single `\0` byte (or `\01`/`\02` followed by a message for
+//! an error) on the reverse direction.
+//!
+//! The sender (`scp -f`) writes:
+//!
+//! ```text
+//! C<mode:4o> <size> <basename>\n     file start
+//! <size bytes of data>                payload
+//! \0                                  end-of-file marker (must be ACKed)
+//! D<mode:4o> 0 <basename>\n          directory start
+//! ... nested C / D records ...
+//! E\n                                 directory end
+//! ```
+
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use anyhow::{anyhow, Context, Result};
+use russh::client::Msg;
+use russh::{Channel, ChannelMsg};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::time::timeout;
+
+use crate::i18n::t;
+use crate::ssh::{RemoteEntry, SessionEvent};
+use crate::sftp::sftp::{base_name, local_file_name_utf8, sanitize_filename};
+use crate::sftp::emit_transfer;
+
+pub(crate) type SftpHandle = russh::client::Handle<crate::sftp::SftpClientHandler>;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Single-quote a string for safe interpolation into a remote `/bin/sh`
+/// command. Remote names come from the *server's* listing and are therefore
+/// untrusted.
+pub(crate) fn sh_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+/// Parse `ls -l` output into [`RemoteEntry`]s.
+///
+/// The `-l` format is the most portable across GNU and BusyBox. Each entry is:
+/// `<mode> <links> <owner> <group> <size> <month> <day> <time|year> <name>`,
+/// so the name is everything after the first eight tokens. A directory path is
+/// passed so full remote paths can be reconstructed exactly.
+fn parse_ls(lines: &str, dir: &str) -> Vec<RemoteEntry> {
+    let mut out = Vec::new();
+    let base = dir.trim_end_matches('/');
+    for line in lines.lines() {
+        if line.is_empty() {
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("total ") {
+            if rest.chars().all(|c| c.is_ascii_digit()) {
+                continue;
+            }
+        }
+        let fields: Vec<&str> = line.split_whitespace().collect();
+        if fields.len() < 8 {
+            continue;
+        }
+        let mode = fields[0];
+        let size_s = fields[4];
+        let name = fields[8..].join(" ");
+        if name.is_empty() || name == "." || name == ".." {
+            continue;
+        }
+        // Symlink: `name -> target`. Keep the base name (deref is dangerous).
+        let name = name.split(" -> ").next().unwrap_or(&name).to_string();
+        let is_dir = mode.starts_with('d');
+        let is_link = mode.starts_with('l');
+        let size = if is_dir {
+            0
+        } else {
+            size_s.parse::<u64>().unwrap_or(0)
+        };
+        let full_path = if base.is_empty() {
+            format!("/{name}")
+        } else {
+            format!("{base}/{name}")
+        };
+        out.push(RemoteEntry {
+            name,
+            full_path,
+            is_dir: is_dir || is_link,
+            size,
+            modified: 0,
+            mode: 0,
+        });
+    }
+    out.sort_by(|a, b| match (a.is_dir, b.is_dir) {
+        (true, false) => std::cmp::Ordering::Less,
+        (false, true) => std::cmp::Ordering::Greater,
+        _ => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
+    });
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Channel I/O
+// ---------------------------------------------------------------------------
+
+/// Minimal buffered reader over an SSH exec channel, so the SCP protocol can
+/// read byte/line/stream without holding the whole payload in memory.
+struct ScpIo {
+    ch: Channel<Msg>,
+    pending: Vec<u8>,
+    eof_seen: bool,
+    exit_code: Option<u32>,
+    /// When set, stderr (ExtendedData) is folded into the data stream. Used
+    /// only by shell capture (`ls`), where the error text lives on stderr. For
+    /// the SCP protocol it stays false so informational stderr can't corrupt
+    /// the byte stream.
+    include_stderr: bool,
+}
+
+impl ScpIo {
+    fn new(ch: Channel<Msg>) -> Self {
+        Self {
+            ch,
+            pending: Vec::new(),
+            eof_seen: false,
+            exit_code: None,
+            include_stderr: false,
+        }
+    }
+
+    fn capture(mut self) -> Self {
+        self.include_stderr = true;
+        self
+    }
+
+    async fn write_all(&mut self, bytes: &[u8]) -> Result<()> {
+        self.ch.data(bytes).await.context("scp channel write")?;
+        Ok(())
+    }
+
+    async fn eof(&mut self) -> Result<()> {
+        self.ch.eof().await.context("scp channel eof")?;
+        Ok(())
+    }
+
+    async fn close(&mut self) {
+        let _ = self.ch.close().await;
+    }
+
+    async fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        loop {
+            if !self.pending.is_empty() {
+                let n = buf.len().min(self.pending.len());
+                buf[..n].copy_from_slice(&self.pending[..n]);
+                self.pending.drain(..n);
+                return Ok(n);
+            }
+            if self.eof_seen {
+                return Ok(0);
+            }
+            match self.ch.wait().await {
+                None => {
+                    self.eof_seen = true;
+                    return Ok(0);
+                }
+                Some(ChannelMsg::Data { data }) => {
+                    if data.is_empty() {
+                        continue;
+                    }
+                    let n = buf.len().min(data.len());
+                    buf[..n].copy_from_slice(&data[..n]);
+                    if n < data.len() {
+                        self.pending.extend_from_slice(&data[n..]);
+                    }
+                    return Ok(n);
+                }
+                Some(ChannelMsg::ExtendedData { data, .. }) => {
+                    if self.include_stderr && !data.is_empty() {
+                        let n = buf.len().min(data.len());
+                        buf[..n].copy_from_slice(&data[..n]);
+                        if n < data.len() {
+                            self.pending.extend_from_slice(&data[n..]);
+                        }
+                        return Ok(n);
+                    }
+                    continue;
+                }
+                Some(ChannelMsg::ExitStatus { exit_status }) => {
+                    self.exit_code = Some(exit_status);
+                    continue;
+                }
+                Some(ChannelMsg::Close) => {
+                    self.eof_seen = true;
+                    return Ok(0);
+                }
+                Some(_) => continue,
+            }
+        }
+    }
+
+    /// Read exactly `n` bytes; error on EOF mid-read.
+    async fn read_exact(&mut self, n: usize) -> Result<Vec<u8>> {
+        let mut out = Vec::with_capacity(n);
+        let mut buf = [0u8; 64 * 1024];
+        while out.len() < n {
+            let want = (n - out.len()).min(buf.len());
+            let got = self.read(&mut buf[..want]).await?;
+            if got == 0 {
+                return Err(anyhow!(
+                    "SCP: file ended early ({} of {} bytes)",
+                    out.len(),
+                    n
+                ));
+            }
+            out.extend_from_slice(&buf[..got]);
+        }
+        Ok(out)
+    }
+
+    /// Read a single ACK byte; returns Ok(()) on `\0`, or Err carrying the
+    /// remote's message on `\01`/`\02`.
+    async fn read_ack(&mut self, max_msg: usize) -> Result<()> {
+        let mut resp = [0u8; 1];
+        match self.read(&mut resp).await {
+            Ok(0) => Err(anyhow!("SCP: peer closed while awaiting ACK")),
+            Ok(_) => match resp[0] {
+                0 => Ok(()),
+                1 | 2 => {
+                    let mut msg = Vec::with_capacity(128);
+                    loop {
+                        if msg.len() >= max_msg {
+                            break;
+                        }
+                        let mut b = [0u8; 1];
+                        match self.read(&mut b).await {
+                            Ok(0) => break,
+                            Ok(_) => {
+                                if b[0] == b'\n' {
+                                    break;
+                                }
+                                msg.push(b[0]);
+                            }
+                            Err(e) => return Err(anyhow!("scp error ack read: {e}")),
+                        }
+                    }
+                    let msg = String::from_utf8_lossy(&msg).trim().to_string();
+                    let msg = if msg.is_empty() {
+                        t("远端 SCP 错误", "remote scp error").to_string()
+                    } else {
+                        msg
+                    };
+                    Err(anyhow!("{msg}"))
+                }
+                other => Err(anyhow!("SCP: unexpected response byte 0x{other:02x}")),
+            },
+            Err(e) => Err(anyhow!("scp ack read: {e}")),
+        }
+    }
+
+    /// Read one SCP control line (terminated by `\n`).
+    async fn read_ctl_line(&mut self, max: usize) -> Result<String> {
+        let mut buf = Vec::with_capacity(64);
+        loop {
+            if buf.len() >= max {
+                return Err(anyhow!("SCP control line too long"));
+            }
+            let mut b = [0u8; 1];
+            match self.read(&mut b).await {
+                Ok(0) => return Err(anyhow!("SCP: unexpected EOF in control stream")),
+                Ok(_) => {
+                    if b[0] == b'\n' {
+                        break;
+                    }
+                    buf.push(b[0]);
+                }
+                Err(e) => return Err(anyhow!("scp control read: {e}")),
+            }
+        }
+        String::from_utf8(buf).context("non-UTF-8 SCP control line")
+    }
+}
+
+/// Open an exec channel and run a remote command, returning its buffered I/O.
+async fn exec_scp(handle: &SftpHandle, cmd: &str) -> Result<ScpIo> {
+    let ch = handle
+        .channel_open_session()
+        .await
+        .context("open exec channel")?;
+    ch.exec(true, cmd.as_bytes())
+        .await
+        .with_context(|| format!("exec remote command: {cmd}"))?;
+    Ok(ScpIo::new(ch))
+}
+
+// ---------------------------------------------------------------------------
+// One-shot shell commands
+// ---------------------------------------------------------------------------
+
+/// Run a remote shell command and capture stdout plus the exit code.
+pub(crate) async fn run_shell_capture(handle: &SftpHandle, cmd: &str) -> Result<(String, u32)> {
+    let io = exec_scp(handle, cmd).await?;
+    let mut io = io.capture();
+    let mut stdout = Vec::new();
+    let mut buf = [0u8; 8192];
+    loop {
+        let n = io.read(&mut buf).await?;
+        if n == 0 {
+            break;
+        }
+        stdout.extend_from_slice(&buf[..n]);
+    }
+    let code = io.exit_code.unwrap_or(0);
+    Ok((String::from_utf8_lossy(&stdout).into_owned(), code))
+}
+
+/// Run a remote command and return `Ok(())` only on exit status 0.
+pub(crate) async fn run_shell(handle: &SftpHandle, cmd: &str) -> Result<()> {
+    let (out, code) = run_shell_capture(handle, cmd).await?;
+    if code == 0 {
+        Ok(())
+    } else {
+        let msg = out.trim();
+        Err(anyhow!(if msg.is_empty() {
+            format!("remote command failed (exit {code})")
+        } else {
+            format!("remote command failed (exit {code}): {msg}")
+        }))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Listing
+// ---------------------------------------------------------------------------
+
+/// List a remote directory over `ls -l` (portable to GNU and BusyBox).
+pub(crate) async fn scp_list_dir(handle: &SftpHandle, path: &str) -> Result<Vec<RemoteEntry>> {
+    let cmd = format!("ls -l {}", sh_quote(path));
+    let (out, code) = run_shell_capture(handle, &cmd).await?;
+    if code != 0 {
+        let msg = out.trim();
+        return Err(anyhow!(if msg.is_empty() {
+            t("无法列出目录", "cannot list directory").to_string()
+        } else {
+            msg.to_string()
+        }));
+    }
+    Ok(parse_ls(&out, path))
+}
+
+/// List only the subdirectories of `path` (used for the left tree).
+pub(crate) async fn scp_list_dirs_only(
+    handle: &SftpHandle,
+    path: &str,
+) -> Result<Vec<(String, String)>> {
+    let entries = scp_list_dir(handle, path).await?;
+    Ok(entries
+        .into_iter()
+        .filter(|e| e.is_dir)
+        .map(|e| (e.name, e.full_path))
+        .collect())
+}
+
+/// Test whether a remote path is a directory (`test -d`).
+pub(crate) async fn scp_is_dir(handle: &SftpHandle, path: &str) -> Result<bool> {
+    let (_, code) = run_shell_capture(handle, &format!("test -d {}", sh_quote(path))).await?;
+    Ok(code == 0)
+}
+
+/// Test whether a remote path exists (`test -e`).
+pub(crate) async fn scp_exists(handle: &SftpHandle, path: &str) -> Result<bool> {
+    let (_, code) = run_shell_capture(handle, &format!("test -e {}", sh_quote(path))).await?;
+    Ok(code == 0)
+}
+
+// ---------------------------------------------------------------------------
+// Download / upload over the SCP sender / receiver
+// ---------------------------------------------------------------------------
+
+/// Download a remote file to `local` using `scp -f`. Emits transfer progress.
+pub(crate) async fn scp_download(
+    handle: &SftpHandle,
+    remote: &str,
+    local: &str,
+    name: &str,
+    id: &str,
+    events: &tokio::sync::mpsc::UnboundedSender<SessionEvent>,
+    cancel: &Arc<AtomicBool>,
+) -> Result<bool> {
+    let cmd = format!("scp -f -- {}", sh_quote(remote));
+    let mut io = exec_scp(handle, &cmd).await?;
+
+    // The `-f` sender waits for our greeting before sending anything.
+    io.write_all(&[0u8]).await?;
+
+    // First record must be `C<mode> <size> <name>\n`. If the remote scp hit an
+    // error (e.g. permission denied) it sends `\x01scp: ...\n` instead.
+    let line = io.read_ctl_line(4096).await?;
+    if line.starts_with('\u{1}') || line.starts_with('\u{2}') {
+        let msg = line.chars().skip(1).collect::<String>().trim().to_string();
+        return Err(anyhow!(if msg.is_empty() {
+            t("远端 SCP 错误", "remote scp error").to_string()
+        } else {
+            msg
+        }));
+    }
+    if !line.starts_with('C') {
+        return Err(anyhow!(
+            "{}",
+            t("远端未运行 SCP(可能不是 SCP 服务器)", "remote is not an SCP server")
+        ));
+    }
+    let size: u64 = line
+        .split_whitespace()
+        .nth(1)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    io.write_all(&[0u8]).await?; // ACK the control record
+
+    let mut local_file = tokio::fs::File::create(local)
+        .await
+        .with_context(|| format!("create local {local}"))?;
+    emit_transfer(events, id, name, false, 0, size, 0, "");
+    let mut done = 0u64;
+    let mut last = Instant::now();
+    let mut cancelled = false;
+    let mut err: Option<anyhow::Error> = None;
+
+    while done < size {
+        if cancel.load(Ordering::Relaxed) {
+            cancelled = true;
+            break;
+        }
+        let want = ((size - done) as usize).min(64 * 1024);
+        match io.read_exact(want).await {
+            Ok(data) => {
+                local_file
+                    .write_all(&data)
+                    .await
+                    .context("write local file")?;
+                done += data.len() as u64;
+            }
+            Err(e) => {
+                err = Some(e);
+                break;
+            }
+        }
+        if last.elapsed() >= Duration::from_millis(150) {
+            last = Instant::now();
+            emit_transfer(events, id, name, false, done, size, 0, "");
+        }
+    }
+    if err.is_none() && !cancelled && done == size {
+        // Trailing `\0` end-of-file marker, then ACK the completed payload.
+        let mut eof = [0u8; 1];
+        match io.read(&mut eof).await {
+            Ok(0) => {}
+            Ok(_) if eof[0] == 0 => {}
+            _ => err = Some(anyhow!("SCP: missing end-of-file marker")),
+        }
+        if err.is_none() {
+            let _ = io.write_all(&[0u8]).await;
+        }
+    }
+
+    let _ = io.eof().await;
+    io.close().await;
+
+    if let Some(e) = err {
+        let _ = tokio::fs::remove_file(local).await;
+        return Err(e);
+    }
+    if cancelled {
+        let _ = tokio::fs::remove_file(local).await;
+        emit_transfer(events, id, name, false, done, size, 4, t("已取消", "Cancelled"));
+        return Ok(false);
+    }
+    emit_transfer(events, id, name, false, done, size, 1, "");
+    Ok(true)
+}
+
+/// Recursively download a remote directory tree into `local_parent` via
+/// `scp -r -f`. Mirrors the SFTP `download_dir` behaviour (root dir named after
+/// the remote basename under `local_parent`).
+pub(crate) async fn scp_download_dir(
+    handle: &SftpHandle,
+    remote_root: &str,
+    local_parent: &str,
+    events: &tokio::sync::mpsc::UnboundedSender<SessionEvent>,
+) -> Result<()> {
+    let cmd = format!("scp -r -f -- {}", sh_quote(remote_root));
+    let mut io = exec_scp(handle, &cmd).await?;
+    io.write_all(&[0u8]).await?; // greeting
+
+    let root_name = sanitize_filename(&base_name(remote_root));
+    let root_local = format!("{}/{}", local_parent.trim_end_matches('/'), root_name);
+    tokio::fs::create_dir_all(&root_local)
+        .await
+        .with_context(|| format!("create local dir {root_local}"))?;
+
+    // Stack of open local directories; index 0 is the root.
+    let mut stack: Vec<String> = vec![root_local];
+    loop {
+        let line = match io.read_ctl_line(4096).await {
+            Ok(l) => l,
+            Err(_) => break, // channel closed by peer (End)
+        };
+        if line.is_empty() {
+            break;
+        }
+        let c = line.as_bytes()[0];
+        match c {
+            b'C' => {
+                let mut parts = line.split_whitespace();
+                let _ = parts.next();
+                let size: u64 = parts
+                    .next()
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(0);
+                let name = parts.collect::<Vec<_>>().join(" ");
+                let name = name.split(" -> ").next().unwrap_or(&name).to_string();
+                io.write_all(&[0u8]).await?; // ACK C record
+                let cur = stack.last().cloned().unwrap_or_default();
+                let local = format!("{}/{}", cur, sanitize_filename(&name));
+                let id = Uuid::new_v4().to_string();
+                let data = match io.read_exact(size as usize).await {
+                    Ok(d) => d,
+                    Err(e) => {
+                        return Err(e);
+                    }
+                };
+                let mut f = tokio::fs::File::create(&local)
+                    .await
+                    .with_context(|| format!("create local {local}"))?;
+                f.write_all(&data).await.context("write local file")?;
+                f.flush().await.ok();
+                let name_local = sanitize_filename(&name);
+                emit_transfer(events, &id, &name_local, false, data.len() as u64, size, 1, "");
+                // Trailing EOF marker + final ACK.
+                let mut eof = [0u8; 1];
+                let _ = io.read(&mut eof).await;
+                let _ = io.write_all(&[0u8]).await;
+            }
+            b'D' => {
+                let mut parts = line.split_whitespace();
+                let _ = parts.next();
+                let _ = parts.next();
+                let name = parts.collect::<Vec<_>>().join(" ");
+                io.write_all(&[0u8]).await?; // ACK D record
+                let cur = stack.last().cloned().unwrap_or_default();
+                let local = format!("{}/{}", cur, sanitize_filename(&name));
+                tokio::fs::create_dir_all(&local)
+                    .await
+                    .with_context(|| format!("create local dir {local}"))?;
+                stack.push(local);
+            }
+            b'E' => {
+                io.write_all(&[0u8]).await?; // ACK E record
+                if stack.len() > 1 {
+                    stack.pop();
+                } else {
+                    break;
+                }
+            }
+            b'T' => {
+                // Timestamps (only sent with -p); ACK and skip.
+                io.write_all(&[0u8]).await?;
+            }
+            _ => {
+                return Err(anyhow!("unexpected SCP record: {line}"));
+            }
+        }
+    }
+    let _ = io.eof().await;
+    io.close().await;
+    Ok(())
+}
+
+/// Upload a local file to `remote` using `scp -t`. Emits transfer progress.
+pub(crate) async fn scp_upload(
+    handle: &SftpHandle,
+    local: &Path,
+    remote: &str,
+    name: &str,
+    id: &str,
+    events: &tokio::sync::mpsc::UnboundedSender<SessionEvent>,
+    cancel: &Arc<AtomicBool>,
+) -> Result<bool> {
+    let cmd = format!("scp -t -- {}", sh_quote(remote));
+    let mut io = exec_scp(handle, &cmd).await?;
+
+    let total = tokio::fs::metadata(local)
+        .await
+        .map(|m| m.len())
+        .unwrap_or(0);
+    let mut local_file = tokio::fs::File::open(local)
+        .await
+        .with_context(|| format!("open local {}", local.display()))?;
+
+    // OpenSSH's receiver greets with a `\0`; BusyBox's may not. Probe briefly.
+    match timeout(Duration::from_millis(250), io.read_ack(4096)).await {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => return Err(e),
+        Err(_) => {}
+    }
+
+    let mode = 0o644u32;
+    let header = format!("C{mode:04o} {total} {}\n", sh_quote(name));
+    io.write_all(header.as_bytes()).await?;
+    io.read_ack(4096).await?;
+
+    emit_transfer(events, id, name, true, 0, total, 0, "");
+    let mut done = 0u64;
+    let mut last = Instant::now();
+    let mut err: Option<anyhow::Error> = None;
+    let mut cancelled = false;
+
+    let mut buf = vec![0u8; 64 * 1024];
+    loop {
+        if cancel.load(Ordering::Relaxed) {
+            cancelled = true;
+            break;
+        }
+        let n = local_file.read(&mut buf).await.context("read local file")?;
+        if n == 0 {
+            break;
+        }
+        io.write_all(&buf[..n]).await?;
+        done += n as u64;
+        if last.elapsed() >= Duration::from_millis(150) {
+            last = Instant::now();
+            emit_transfer(events, id, name, true, done, total, 0, "");
+        }
+    }
+    if err.is_none() && !cancelled {
+        io.write_all(&[0u8]).await?; // EOF marker
+        if let Err(e) = io.read_ack(4096).await {
+            err = Some(e);
+        }
+    }
+
+    let _ = io.eof().await;
+    io.close().await;
+
+    if let Some(e) = err {
+        return Err(e);
+    }
+    if cancelled {
+        emit_transfer(events, id, name, true, done, total, 4, t("已取消", "Cancelled"));
+        return Ok(false);
+    }
+    emit_transfer(events, id, name, true, done, total, 1, "");
+    Ok(true)
+}
+
+/// Recursively upload a local directory tree into `remote_parent` over SCP:
+/// shell `mkdir -p` for every directory, then `scp -t` per file (mirrors the
+/// SFTP `upload_dir`).
+pub(crate) async fn scp_upload_dir(
+    handle: &SftpHandle,
+    local_root: &Path,
+    remote_parent: &str,
+    events: &tokio::sync::mpsc::UnboundedSender<SessionEvent>,
+) -> Result<()> {
+    let root_name = local_file_name_utf8(local_root)?;
+    let remote_root = format!("{}/{}", remote_parent.trim_end_matches('/'), root_name);
+
+    // Pass 1: discover + mkdir every directory (best-effort per dir).
+    let mut dirs: Vec<String> = vec![remote_root.clone()];
+    let mut stack: Vec<(std::path::PathBuf, String)> = vec![(local_root.to_path_buf(), remote_root.clone())];
+    while let Some((ldir, rdir)) = stack.pop() {
+        let mut rd = tokio::fs::read_dir(&ldir)
+            .await
+            .with_context(|| format!("read local dir {}", ldir.display()))?;
+        while let Some(entry) = rd.next_entry().await.context("read dir entry")? {
+            let lpath = entry.path();
+            let name = local_file_name_utf8(&lpath)?;
+            let rchild = format!("{}/{}", rdir, name);
+            if entry.file_type().await.context("file type")?.is_dir() {
+                dirs.push(rchild.clone());
+                stack.push((lpath, rchild));
+            }
+        }
+    }
+    for d in &dirs {
+        let _ = scp_mkdir(handle, d).await;
+    }
+
+    // Pass 2: upload every file.
+    let no_cancel = Arc::new(AtomicBool::new(false));
+    let mut stack: Vec<(std::path::PathBuf, String)> = vec![(local_root.to_path_buf(), remote_root)];
+    while let Some((ldir, rdir)) = stack.pop() {
+        let mut rd = tokio::fs::read_dir(&ldir)
+            .await
+            .with_context(|| format!("read local dir {}", ldir.display()))?;
+        while let Some(entry) = rd.next_entry().await.context("read dir entry")? {
+            let lpath = entry.path();
+            let name = local_file_name_utf8(&lpath)?;
+            let rchild = format!("{}/{}", rdir, name);
+            let ft = entry.file_type().await.context("file type")?;
+            if ft.is_dir() {
+                stack.push((lpath, rchild));
+            } else if ft.is_file() {
+                let id = Uuid::new_v4().to_string();
+                scp_upload(handle, &lpath, &rchild, &name, &id, events, &no_cancel).await?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Read a remote file's raw bytes via `scp -f` (used by the built-in editor).
+pub(crate) async fn scp_read_text(handle: &SftpHandle, remote: &str) -> Result<Vec<u8>> {
+    let cmd = format!("scp -f -- {}", sh_quote(remote));
+    let mut io = exec_scp(handle, &cmd).await?;
+
+    io.write_all(&[0u8]).await?; // greeting
+
+    let line = io.read_ctl_line(4096).await?;
+    if line.starts_with('\u{1}') || line.starts_with('\u{2}') {
+        let msg = line.chars().skip(1).collect::<String>().trim().to_string();
+        return Err(anyhow!(if msg.is_empty() {
+            t("远端 SCP 错误", "remote scp error").to_string()
+        } else {
+            msg
+        }));
+    }
+    if !line.starts_with('C') {
+        return Err(anyhow!(
+            "{}",
+            t("远端未运行 SCP(可能不是 SCP 服务器)", "remote is not an SCP server")
+        ));
+    }
+    let size: u64 = line
+        .split_whitespace()
+        .nth(1)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    if size > 4 * 1024 * 1024 {
+        return Err(anyhow!(
+            "{}",
+            t("文件过大,无法通过 SCP 读取", "file too large to read over SCP")
+        ));
+    }
+    io.write_all(&[0u8]).await?;
+    let data = io.read_exact(size as usize).await?;
+    let mut eof = [0u8; 1];
+    let _ = io.read(&mut eof).await;
+    let _ = io.write_all(&[0u8]).await;
+    let _ = io.eof().await;
+    io.close().await;
+    Ok(data)
+}
+
+/// Write a text blob to a remote file via `scp -t` (used by the editor).
+pub(crate) async fn scp_write_text(handle: &SftpHandle, remote: &str, content: &str) -> Result<()> {
+    let cmd = format!("scp -t -- {}", sh_quote(remote));
+    let mut io = exec_scp(handle, &cmd).await?;
+
+    match timeout(Duration::from_millis(250), io.read_ack(4096)).await {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => return Err(e),
+        Err(_) => {}
+    }
+    let name = base_name(remote);
+    let data = content.as_bytes();
+    let header = format!("C{:04o} {} {}\n", 0o644u32, data.len(), sh_quote(&name));
+    io.write_all(header.as_bytes()).await?;
+    io.read_ack(4096).await?;
+    io.write_all(data).await?;
+    io.write_all(&[0u8]).await?;
+    io.read_ack(4096).await?;
+    let _ = io.eof().await;
+    io.close().await;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Shell-based FS operations (SCP has no delete/mkdir/rename/chmod primitive)
+// ---------------------------------------------------------------------------
+
+pub(crate) async fn scp_delete(handle: &SftpHandle, path: &str) -> Result<()> {
+    run_shell(handle, &format!("rm -rf -- {}", sh_quote(path))).await
+}
+
+pub(crate) async fn scp_mkdir(handle: &SftpHandle, path: &str) -> Result<()> {
+    run_shell(handle, &format!("mkdir -p -- {}", sh_quote(path))).await
+}
+
+pub(crate) async fn scp_touch(handle: &SftpHandle, path: &str) -> Result<()> {
+    run_shell(handle, &format!("touch -- {}", sh_quote(path))).await
+}
+
+pub(crate) async fn scp_rename(handle: &SftpHandle, from: &str, to: &str) -> Result<()> {
+    run_shell(handle, &format!("mv -f -- {} {}", sh_quote(from), sh_quote(to))).await
+}
+
+pub(crate) async fn scp_chmod(handle: &SftpHandle, path: &str, mode: u32) -> Result<()> {
+    run_shell(handle, &format!("chmod {mode:o} -- {}", sh_quote(path))).await
+}
+
+// Import Uuid used in the transfer-id helpers above.
+use uuid::Uuid;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_ls_dirs_and_files() {
+        let lines = "total 8\n\
+            drwxr-xr-x 2 1000 1000 4096 Jan  1 00:00 bin\n\
+            -rw-r--r-- 1 1000 1000    123 Jan  1 00:00 file.txt\n\
+            -rw-r--r-- 1 1000 1000      0 Jan  1 00:00 empty\n\
+            lrwxrwxrwx 1 1000 1000      4 Jan  1 00:00 link -> bin\n";
+        let entries = parse_ls(lines, "/home/u");
+        assert_eq!(entries.len(), 4);
+        let dir = entries.iter().find(|e| e.name == "bin").unwrap();
+        assert!(dir.is_dir);
+        assert_eq!(dir.full_path, "/home/u/bin");
+        let file = entries.iter().find(|e| e.name == "file.txt").unwrap();
+        assert!(!file.is_dir);
+        assert_eq!(file.size, 123);
+        let link = entries.iter().find(|e| e.name == "link").unwrap();
+        assert!(link.is_dir); // symlink to a dir counts as a dir for navigation
+    }
+
+    #[test]
+    fn parse_ls_filters_dot_entries() {
+        let lines = ".  ..  file\n";
+        let entries = parse_ls(lines, "/");
+        assert!(entries.iter().all(|e| e.name != "." && e.name != ".."));
+    }
+
+    #[test]
+    fn sh_quote_escapes_single_quotes() {
+        assert_eq!(sh_quote("a'b"), "'a'\\''b'");
+        assert_eq!(sh_quote("plain"), "'plain'");
+    }
+
+    #[test]
+    fn parse_ls_handles_names_with_spaces() {
+        let lines = "-rw-r--r-- 1 1000 1000 9 Jan  1 00:00 my file.txt\n";
+        let entries = parse_ls(lines, "/");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "my file.txt");
+        assert_eq!(entries[0].full_path, "/my file.txt");
+    }
+}

--- a/src/sftp/impls/sftp.rs
+++ b/src/sftp/impls/sftp.rs
@@ -33,7 +33,264 @@ use crate::config::{AuthMethod, Session};
 use crate::i18n::t;
 use crate::ssh::{format_mtime, format_size, RemoteEntry, RemoteTreeNode, SessionEvent};
 
+use super::scp::{
+    run_shell_capture as scp_run_shell_capture, scp_chmod, scp_delete, scp_download,
+    scp_download_dir, scp_exists, scp_is_dir, scp_list_dir, scp_list_dirs_only, scp_mkdir,
+    scp_read_text, scp_rename, scp_touch, scp_upload, scp_upload_dir, scp_write_text,
+};
 use super::transfer::{DownloadConflict, SftpCommand, SftpHandle};
+
+// ---------------------------------------------------------------------------
+// Transport: either a live SFTP subsystem session or a pure-SCP fallback over
+// exec channels. The command loop below dispatches every file operation through
+// this so a router that refuses the `sftp` subsystem still gets a working
+// (SCP-based) panel instead of a permanently blank listing.
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+pub(crate) enum Transport {
+    Sftp {
+        sftp: Arc<SftpSession>,
+        handle: Arc<client::Handle<SftpClientHandler>>,
+    },
+    Scp {
+        handle: Arc<client::Handle<SftpClientHandler>>,
+    },
+}
+
+impl Transport {
+    async fn list_dir(&self, path: &str) -> Result<Vec<RemoteEntry>> {
+        match self {
+            Transport::Sftp { sftp, .. } => list_dir_impl(sftp, path).await,
+            Transport::Scp { handle } => scp_list_dir(handle.as_ref(), path).await,
+        }
+    }
+
+    async fn list_dirs_only(&self, path: &str) -> Result<Vec<(String, String)>> {
+        match self {
+            Transport::Sftp { sftp, .. } => list_dirs_only_impl(sftp, path).await,
+            Transport::Scp { handle } => scp_list_dirs_only(handle.as_ref(), path).await,
+        }
+    }
+
+    async fn is_dir(&self, path: &str) -> bool {
+        match self {
+            Transport::Sftp { sftp, .. } => sftp
+                .metadata(path)
+                .await
+                .ok()
+                .map(|m| (m.permissions.unwrap_or(0) & 0o170_000) == 0o040_000)
+                .unwrap_or(false),
+            Transport::Scp { handle } => scp_is_dir(handle.as_ref(), path).await.unwrap_or(false),
+        }
+    }
+
+    async fn download(
+        &self,
+        remote: &str,
+        local: &str,
+        name: &str,
+        id: &str,
+        events: &UnboundedSender<SessionEvent>,
+        cancel: &Arc<AtomicBool>,
+    ) -> Result<bool> {
+        match self {
+            Transport::Sftp { handle, .. } => {
+                download_impl(handle.as_ref(), remote, local, name, id, events, cancel).await
+            }
+            Transport::Scp { handle } => {
+                scp_download(handle.as_ref(), remote, local, name, id, events, cancel).await
+            }
+        }
+    }
+
+    async fn download_dir(
+        &self,
+        remote_root: &str,
+        local_parent: &str,
+        events: &UnboundedSender<SessionEvent>,
+    ) -> Result<()> {
+        match self {
+            Transport::Sftp { sftp, handle, .. } => {
+                download_dir(sftp, handle.as_ref(), remote_root, local_parent, events).await
+            }
+            Transport::Scp { handle } => {
+                scp_download_dir(handle.as_ref(), remote_root, local_parent, events).await
+            }
+        }
+    }
+
+    async fn upload(
+        &self,
+        local: &Path,
+        remote: &str,
+        name: &str,
+        id: &str,
+        events: &UnboundedSender<SessionEvent>,
+        cancel: &Arc<AtomicBool>,
+    ) -> Result<bool> {
+        match self {
+            Transport::Sftp { handle, .. } => {
+                upload_pipelined(handle.as_ref(), local, remote, name, id, events, cancel).await
+            }
+            Transport::Scp { handle } => {
+                scp_upload(handle.as_ref(), local, remote, name, id, events, cancel).await
+            }
+        }
+    }
+
+    async fn upload_dir(
+        &self,
+        local: &Path,
+        remote_parent: &str,
+        events: &UnboundedSender<SessionEvent>,
+    ) -> Result<()> {
+        match self {
+            Transport::Sftp { handle, sftp, .. } => {
+                upload_dir(handle.as_ref(), sftp, local, remote_parent, events).await
+            }
+            Transport::Scp { handle } => {
+                scp_upload_dir(handle.as_ref(), local, remote_parent, events).await
+            }
+        }
+    }
+
+    async fn read_text(&self, remote: &str) -> std::result::Result<String, String> {
+        match self {
+            Transport::Sftp { sftp, .. } => read_text_guarded(sftp, remote).await,
+            Transport::Scp { handle } => {
+                let bytes = scp_read_text(handle.as_ref(), remote)
+                    .await
+                    .map_err(|e| format!("{}: {e}", t("打开失败", "Open failed")))?;
+                validate_editor_text(bytes).map_err(editor_rejection_message)
+            }
+        }
+    }
+
+    async fn write_text(&self, remote: &str, content: &str) -> Result<()> {
+        match self {
+            Transport::Sftp { sftp, .. } => write_text_file(sftp, remote, content).await,
+            Transport::Scp { handle } => scp_write_text(handle.as_ref(), remote, content).await,
+        }
+    }
+
+    async fn delete(&self, path: &str) -> Result<()> {
+        match self {
+            Transport::Sftp { sftp, .. } => {
+                let is_dir = sftp
+                    .metadata(path)
+                    .await
+                    .ok()
+                    .map(|m| (m.permissions.unwrap_or(0) & 0o170_000) == 0o040_000)
+                    .unwrap_or(false);
+                if is_dir {
+                    remove_dir_recursive(sftp, path).await
+                } else {
+                    sftp.remove_file(path)
+                        .await
+                        .map(|_| ())
+                        .map_err(|e| anyhow::anyhow!("{e}"))
+                }
+            }
+            Transport::Scp { handle } => scp_delete(handle.as_ref(), path).await,
+        }
+    }
+
+    async fn rename(&self, from: &str, to: &str) -> Result<()> {
+        match self {
+            Transport::Sftp { sftp, .. } => sftp.rename(from, to).await.map(|_| ()).map_err(|e| anyhow::anyhow!("{e}")),
+            Transport::Scp { handle } => scp_rename(handle.as_ref(), from, to).await,
+        }
+    }
+
+    async fn chmod(&self, path: &str, mode: u32) -> Result<()> {
+        match self {
+            Transport::Sftp { sftp, .. } => {
+                let attrs = FileAttributes {
+                    permissions: Some(mode),
+                    ..Default::default()
+                };
+                sftp.set_metadata(path, attrs)
+                    .await
+                    .map(|_| ())
+                    .map_err(|e| anyhow::anyhow!("{e}"))
+            }
+            Transport::Scp { handle } => scp_chmod(handle.as_ref(), path, mode).await,
+        }
+    }
+
+    async fn mkdir(&self, path: &str) -> Result<()> {
+        match self {
+            Transport::Sftp { sftp, .. } => sftp.create_dir(path).await.map(|_| ()).map_err(|e| anyhow::anyhow!("{e}")),
+            Transport::Scp { handle } => scp_mkdir(handle.as_ref(), path).await,
+        }
+    }
+
+    /// Create an empty file; returns `true` if newly created, `false` if it
+    /// already exists.
+    async fn touch(&self, path: &str) -> Result<bool> {
+        match self {
+            Transport::Sftp { sftp, .. } => {
+                if sftp.metadata(path).await.is_ok() {
+                    Ok(false)
+                } else {
+                    sftp.create(path)
+                        .await
+                        .map(|_| true)
+                        .map_err(|e| anyhow::anyhow!("{e}"))
+                }
+            }
+            Transport::Scp { handle } => {
+                let exists = scp_exists(handle.as_ref(), path).await.unwrap_or(false);
+                if exists {
+                    Ok(false)
+                } else {
+                    scp_touch(handle.as_ref(), path).await.map(|_| true)
+                }
+            }
+        }
+    }
+
+    /// Run a one-shot remote command (used for the multi-select tar archive).
+    async fn exec_remote(&self, cmd: &str) -> Result<u32> {
+        match self {
+            Transport::Sftp { handle, .. } | Transport::Scp { handle } => {
+                exec_remote(handle.as_ref(), cmd).await
+            }
+        }
+    }
+
+    /// Resolve the remote home directory.
+    async fn home(&self) -> String {
+        match self {
+            Transport::Sftp { sftp, .. } => {
+                sftp.canonicalize(".").await.unwrap_or_else(|_| "/".to_string())
+            }
+            Transport::Scp { handle } => {
+                let (out, _) = scp_run_shell_capture(handle.as_ref(), "pwd")
+                    .await
+                    .unwrap_or_default();
+                let out = out.trim().to_string();
+                if out.is_empty() {
+                    "/".to_string()
+                } else {
+                    out
+                }
+            }
+        }
+    }
+
+    async fn disconnect(&self) {
+        match self {
+            Transport::Sftp { handle, .. } | Transport::Scp { handle } => {
+                let _ = handle
+                    .as_ref()
+                    .disconnect(Disconnect::ByApplication, "bye", "")
+                    .await;
+            }
+        }
+    }
+}
 
 impl SftpHandle {
     pub fn list_dir(&self, path: String) {
@@ -235,12 +492,12 @@ fn emit_tree(
 /// This is how create/delete/rename keep the left tree in sync without a
 /// reconnect (#189).
 async fn sync_tree_dir(
-    sftp: &SftpSession,
+    transport: &Transport,
     dir: &str,
     tree_dirs: &mut std::collections::HashMap<String, Vec<(String, String)>>,
 ) {
     if tree_dirs.contains_key(dir) {
-        let dirs = list_dirs_only_impl(sftp, dir).await.unwrap_or_default();
+        let dirs = transport.list_dirs_only(dir).await.unwrap_or_default();
         tree_dirs.insert(dir.to_string(), dirs);
     }
 }
@@ -442,21 +699,27 @@ async fn run_sftp(
     }
 
     // --- Open the sftp subsystem channel -----------------------------------
-    let channel = handle
-        .channel_open_session()
-        .await
-        .context("open sftp channel")?;
-    channel
-        .request_subsystem(true, "sftp")
-        .await
-        .context("request sftp subsystem")?;
-    let sftp = SftpSession::new(channel.into_stream())
-        .await
-        .context("sftp handshake")?;
-    // Share the session + connection so transfers can run on their own task,
-    // leaving the command loop free to list/switch directories meanwhile (#116-2).
-    let sftp = std::sync::Arc::new(sftp);
-    let handle = std::sync::Arc::new(handle);
+    // Try the `sftp` subsystem first; if the server refuses it (BusyBox routers,
+    // minimal distros without an SFTP server), fall back to the SCP protocol on
+    // the same authenticated connection so the panel isn't a blank void (#scp).
+    let handle = Arc::new(handle);
+    let transport = match open_sftp_subsystem(&handle).await {
+        Ok(sftp) => Transport::Sftp {
+            sftp: Arc::new(sftp),
+            handle: handle.clone(),
+        },
+        Err(e) => {
+            tracing::warn!(
+                "sftp subsystem unavailable on {}:{} — falling back to SCP: {e:#}",
+                session.host,
+                session.port
+            );
+            let _ = events.send(SessionEvent::SftpStatus(
+                t("SFTP 子系统不可用,已回退到 SCP", "SFTP subsystem unavailable — using SCP instead").into(),
+            ));
+            Transport::Scp { handle }
+        }
+    };
 
     // Per-transfer cancel flags, keyed by transfer id. A download task registers
     // its flag here; a CancelTransfer command flips it; the task removes it on
@@ -465,16 +728,13 @@ async fn run_sftp(
         Arc::new(Mutex::new(HashMap::new()));
 
     // Resolve the home directory and do an initial listing.
-    let home = sftp
-        .canonicalize(".")
-        .await
-        .unwrap_or_else(|_| "/".to_string());
+    let home = transport.home().await;
     let _ = events.send(SessionEvent::SftpStatus(format!(
         "{} {}...",
         t("SFTP 加载", "SFTP loading"),
         home
     )));
-    match list_dir_impl(&sftp, &home).await {
+    match transport.list_dir(&home).await {
         Ok(entries) => {
             let _ = events.send(SessionEvent::SftpEntries {
                 path: home.clone(),
@@ -495,7 +755,7 @@ async fn run_sftp(
     let mut tree_expanded: std::collections::HashSet<String> = std::collections::HashSet::new();
 
     // Fetch root "/" subdirs, then expand path down to home.
-    let root_dirs = list_dirs_only_impl(&sftp, "/").await.unwrap_or_default();
+    let root_dirs = transport.list_dirs_only("/").await.unwrap_or_default();
     tree_dirs.insert("/".to_string(), root_dirs);
     tree_expanded.insert("/".to_string());
 
@@ -515,7 +775,7 @@ async fn run_sftp(
             if !found {
                 break;
             }
-            let dirs = list_dirs_only_impl(&sftp, &child).await.unwrap_or_default();
+            let dirs = transport.list_dirs_only(&child).await.unwrap_or_default();
             tree_dirs.insert(child.clone(), dirs);
             tree_expanded.insert(child.clone());
             current = child;
@@ -538,7 +798,7 @@ async fn run_sftp(
                     t("加载", "Loading"),
                     path
                 )));
-                match list_dir_impl(&sftp, &path).await {
+                match transport.list_dir(&path).await {
                     Ok(entries) => {
                         let _ = events.send(SessionEvent::SftpEntries {
                             path: path.clone(),
@@ -559,7 +819,7 @@ async fn run_sftp(
                     t("加载", "Loading"),
                     path
                 )));
-                match list_dir_impl(&sftp, &path).await {
+                match transport.list_dir(&path).await {
                     Ok(entries) => {
                         let _ = events.send(SessionEvent::SftpEntries {
                             path: path.clone(),
@@ -577,7 +837,7 @@ async fn run_sftp(
                 // build_tree_nodes, so they drop out on the rebuild.
                 let expanded: Vec<String> = tree_expanded.iter().cloned().collect();
                 for dir in expanded {
-                    let dirs = list_dirs_only_impl(&sftp, &dir).await.unwrap_or_default();
+                    let dirs = transport.list_dirs_only(&dir).await.unwrap_or_default();
                     tree_dirs.insert(dir, dirs);
                 }
                 emit_tree(&tree_dirs, &tree_expanded, &events);
@@ -591,7 +851,7 @@ async fn run_sftp(
                 } else {
                     // Expand: fetch children if not yet cached.
                     if !tree_dirs.contains_key(&path) {
-                        let dirs = list_dirs_only_impl(&sftp, &path).await.unwrap_or_default();
+                        let dirs = transport.list_dirs_only(&path).await.unwrap_or_default();
                         tree_dirs.insert(path.clone(), dirs);
                     }
                     tree_expanded.insert(path.clone());
@@ -608,8 +868,7 @@ async fn run_sftp(
             } => {
                 // Run on its own task so the command loop stays free to list /
                 // switch directories during the transfer (#116-2).
-                let sftp = sftp.clone();
-                let handle = handle.clone();
+                let transport = transport.clone();
                 let events = events.clone();
                 // Register a cancel flag up-front under the file id, so a
                 // CancelTransfer arriving mid-download can flip it (#100).
@@ -622,17 +881,13 @@ async fn run_sftp(
                 let cancels_done = cancels.clone();
                 tokio::spawn(async move {
                     // A directory target → recursively mirror the whole tree (#50).
-                    let is_dir = sftp
-                        .metadata(&remote)
-                        .await
-                        .ok()
-                        .map(|m| (m.permissions.unwrap_or(0) & 0o170_000) == 0o040_000)
-                        .unwrap_or(false);
+                    let is_dir = transport.is_dir(&remote).await;
                     if is_dir {
                         let dirname = base_name(&remote);
                         // #100.3: an empty folder downloads nothing — just say so
                         // rather than silently creating an empty local directory.
-                        let empty = list_dir_impl(&sftp, &remote)
+                        let empty = transport
+                            .list_dir(&remote)
                             .await
                             .map(|e| e.is_empty())
                             .unwrap_or(false);
@@ -649,7 +904,7 @@ async fn run_sftp(
                             t("下载文件夹", "Downloading folder"),
                             dirname
                         )));
-                        match download_dir(&sftp, &handle, &remote, &local_dir, &events).await {
+                        match transport.download_dir(&remote, &local_dir, &events).await {
                             Ok(_) => {
                                 let _ = events.send(SessionEvent::SftpStatus(format!(
                                     "{}: {}",
@@ -682,16 +937,9 @@ async fn run_sftp(
                             t("下载", "Downloading"),
                             filename
                         )));
-                        match download_impl(
-                            &handle,
-                            &remote,
-                            &local_path_text,
-                            &filename,
-                            &id,
-                            &events,
-                            &cancel,
-                        )
-                        .await
+                        match transport
+                            .download(&remote, &local_path_text, &filename, &id, &events, &cancel)
+                            .await
                         {
                             Ok(true) => {
                                 let _ = events.send(SessionEvent::SftpStatus(format!(
@@ -737,8 +985,7 @@ async fn run_sftp(
                 // #100: multi-select download. Instead of N concurrent transfers
                 // (which raced and dropped files), tar everything into ONE archive
                 // on the remote, pull that single file, then delete the temp.
-                let sftp = sftp.clone();
-                let handle = handle.clone();
+                let transport = transport.clone();
                 let events = events.clone();
                 // Register a cancel flag up-front so CancelTransfer can flip it (#100).
                 let id = Uuid::new_v4().to_string();
@@ -778,19 +1025,19 @@ async fn run_sftp(
                         cmd.push(' ');
                         cmd.push_str(&sh_quote(nm));
                     }
-                    let _ = &sftp; // listing session kept alive; transfer uses `handle`
                     let res: Result<bool> = async {
-                        let st = exec_remote(&handle, &cmd).await.context("tar on remote")?;
+                        let st = transport.exec_remote(&cmd).await.context("tar on remote")?;
                         if st != 0 {
                             return Err(anyhow!(t("远端 tar 打包失败", "remote tar failed")));
                         }
-                        download_impl(&handle, &tmp, &local_path, &arc_name, &id, &events, &cancel)
+                        transport
+                            .download(&tmp, &local_path, &arc_name, &id, &events, &cancel)
                             .await
                     }
                     .await;
                     // Best-effort cleanup of the remote temp tar — success, failure
                     // or cancel all reach here, so no junk is left on the server (#100).
-                    let _ = exec_remote(&handle, &format!("rm -f {}", sh_quote(&tmp))).await;
+                    let _ = transport.exec_remote(&format!("rm -f {}", sh_quote(&tmp))).await;
                     match res {
                         Ok(true) => {
                             let _ = events.send(SessionEvent::SftpStatus(format!(
@@ -831,8 +1078,7 @@ async fn run_sftp(
             } => {
                 // Run on its own task so the command loop stays free to list /
                 // switch directories during the transfer (#116-2).
-                let sftp = sftp.clone();
-                let handle = handle.clone();
+                let transport = transport.clone();
                 let events = events.clone();
                 // Register a cancel flag up-front under the file id so a
                 // CancelTransfer arriving mid-upload can flip it (#100).
@@ -869,8 +1115,8 @@ async fn run_sftp(
                             t("上传文件夹", "Uploading folder"),
                             dirname
                         )));
-                        let res = upload_dir(&handle, &sftp, &local, &remote_dir, &events).await;
-                        if let Ok(entries) = list_dir_impl(&sftp, &remote_dir).await {
+                        let res = transport.upload_dir(&local, &remote_dir, &events).await;
+                        if let Ok(entries) = transport.list_dir(&remote_dir).await {
                             let _ = events.send(SessionEvent::SftpEntries {
                                 path: remote_dir.clone(),
                                 entries,
@@ -914,19 +1160,12 @@ async fn run_sftp(
                             t("上传", "Uploading"),
                             filename
                         )));
-                        match upload_pipelined(
-                            &handle,
-                            &local,
-                            &remote_path,
-                            &filename,
-                            &id,
-                            &events,
-                            &cancel,
-                        )
-                        .await
+                        match transport
+                            .upload(&local, &remote_path, &filename, &id, &events, &cancel)
+                            .await
                         {
                             Ok(true) => {
-                                if let Ok(entries) = list_dir_impl(&sftp, &remote_dir).await {
+                                if let Ok(entries) = transport.list_dir(&remote_dir).await {
                                     let _ = events.send(SessionEvent::SftpEntries {
                                         path: remote_dir.clone(),
                                         entries,
@@ -940,7 +1179,7 @@ async fn run_sftp(
                             }
                             Ok(false) => {
                                 // Refresh the listing so the removed partial file disappears.
-                                if let Ok(entries) = list_dir_impl(&sftp, &remote_dir).await {
+                                if let Ok(entries) = transport.list_dir(&remote_dir).await {
                                     let _ = events.send(SessionEvent::SftpEntries {
                                         path: remote_dir.clone(),
                                         entries,
@@ -978,21 +1217,19 @@ async fn run_sftp(
             }
 
             SftpCommand::UploadEdited { local, remote } => {
-                let sftp = sftp.clone();
-                let handle = handle.clone();
+                let transport = transport.clone();
                 let events = events.clone();
                 tokio::spawn(async move {
                     let filename = base_name(&remote);
                     let remote_dir = parent_dir(&remote);
                     let id = Uuid::new_v4().to_string();
                     let no_cancel = Arc::new(AtomicBool::new(false));
-                    let result = upload_pipelined(
-                        &handle, &local, &remote, &filename, &id, &events, &no_cancel,
-                    )
-                    .await;
+                    let result = transport
+                        .upload(&local, &remote, &filename, &id, &events, &no_cancel)
+                        .await;
                     match result {
                         Ok(true) => {
-                            if let Ok(entries) = list_dir_impl(&sftp, &remote_dir).await {
+                            if let Ok(entries) = transport.list_dir(&remote_dir).await {
                                 let _ = events.send(SessionEvent::SftpEntries {
                                     path: remote_dir,
                                     entries,
@@ -1020,8 +1257,7 @@ async fn run_sftp(
                 target,
                 target_dir,
             } => {
-                let sftp = sftp.clone();
-                let handle = handle.clone();
+                let transport = transport.clone();
                 let events = events.clone();
                 tokio::spawn(async move {
                     let label = format!("{} {}", remotes.len(), t("项", "items"));
@@ -1031,7 +1267,7 @@ async fn run_sftp(
                         label
                     )));
                     for remote in remotes {
-                        match stage_remote_for_copy(&sftp, &handle, &remote, &events).await {
+                        match stage_remote_for_copy(&transport, &remote, &events).await {
                             Ok((local, cleanup_root)) => {
                                 let _ = target.send(SftpCommand::Upload {
                                     local,
@@ -1057,27 +1293,11 @@ async fn run_sftp(
                     t("删除", "Deleting"),
                     filename
                 )));
-                // Directories are removed recursively (a plain remove_dir only
-                // works on an empty dir, so an uploaded folder couldn't be
-                // deleted); files via remove_file.
-                let is_dir = sftp
-                    .metadata(&path)
-                    .await
-                    .ok()
-                    .map(|m| (m.permissions.unwrap_or(0) & 0o170_000) == 0o040_000)
-                    .unwrap_or(false);
-                let res: Result<()> = if is_dir {
-                    remove_dir_recursive(&sftp, &path).await
-                } else {
-                    sftp.remove_file(&path)
-                        .await
-                        .map(|_| ())
-                        .map_err(|e| anyhow::anyhow!("{e}"))
-                };
+                let res = transport.delete(&path).await;
                 match res {
                     Ok(_) => {
                         let parent = parent_dir(&path);
-                        if let Ok(entries) = list_dir_impl(&sftp, &parent).await {
+                        if let Ok(entries) = transport.list_dir(&parent).await {
                             let _ = events.send(SessionEvent::SftpEntries {
                                 path: parent.clone(),
                                 entries,
@@ -1090,7 +1310,7 @@ async fn run_sftp(
                         let prefix = format!("{}/", path.trim_end_matches('/'));
                         tree_dirs.retain(|p, _| p != &path && !p.starts_with(&prefix));
                         tree_expanded.retain(|p| p != &path && !p.starts_with(&prefix));
-                        sync_tree_dir(&sftp, &parent, &mut tree_dirs).await;
+                        sync_tree_dir(&transport, &parent, &mut tree_dirs).await;
                         emit_tree(&tree_dirs, &tree_expanded, &events);
                         let _ = events.send(SessionEvent::SftpStatus(format!(
                             "{}: {}",
@@ -1109,7 +1329,7 @@ async fn run_sftp(
 
             SftpCommand::Rename { from, to } => {
                 let refresh = parent_dir(&from);
-                match sftp.rename(&from, &to).await {
+                match transport.rename(&from, &to).await {
                     Ok(_) => {
                         let _ = events.send(SessionEvent::SftpStatus(format!(
                             "{}: {}",
@@ -1122,10 +1342,10 @@ async fn run_sftp(
                         let prefix = format!("{}/", from.trim_end_matches('/'));
                         tree_dirs.retain(|p, _| p != &from && !p.starts_with(&prefix));
                         tree_expanded.retain(|p| p != &from && !p.starts_with(&prefix));
-                        sync_tree_dir(&sftp, &refresh, &mut tree_dirs).await;
+                        sync_tree_dir(&transport, &refresh, &mut tree_dirs).await;
                         let to_parent = parent_dir(&to);
                         if to_parent != refresh {
-                            sync_tree_dir(&sftp, &to_parent, &mut tree_dirs).await;
+                            sync_tree_dir(&transport, &to_parent, &mut tree_dirs).await;
                         }
                         emit_tree(&tree_dirs, &tree_expanded, &events);
                     }
@@ -1136,7 +1356,7 @@ async fn run_sftp(
                         )));
                     }
                 }
-                if let Ok(entries) = list_dir_impl(&sftp, &refresh).await {
+                if let Ok(entries) = transport.list_dir(&refresh).await {
                     let _ = events.send(SessionEvent::SftpEntries {
                         path: refresh,
                         entries,
@@ -1146,11 +1366,7 @@ async fn run_sftp(
 
             SftpCommand::Chmod { path, mode } => {
                 let refresh = parent_dir(&path);
-                let attrs = FileAttributes {
-                    permissions: Some(mode),
-                    ..Default::default()
-                };
-                match sftp.set_metadata(&path, attrs).await {
+                match transport.chmod(&path, mode).await {
                     Ok(_) => {
                         let _ = events.send(SessionEvent::SftpStatus(format!(
                             "{}: {} → {:o}",
@@ -1166,7 +1382,7 @@ async fn run_sftp(
                         )));
                     }
                 }
-                if let Ok(entries) = list_dir_impl(&sftp, &refresh).await {
+                if let Ok(entries) = transport.list_dir(&refresh).await {
                     let _ = events.send(SessionEvent::SftpEntries {
                         path: refresh,
                         entries,
@@ -1176,7 +1392,7 @@ async fn run_sftp(
 
             SftpCommand::MkDir(path) => {
                 let refresh = parent_dir(&path);
-                match sftp.create_dir(&path).await {
+                match transport.mkdir(&path).await {
                     Ok(_) => {
                         let _ = events.send(SessionEvent::SftpStatus(format!(
                             "{}: {}",
@@ -1184,7 +1400,7 @@ async fn run_sftp(
                             base_name(&path)
                         )));
                         // Show the new folder in the left tree too (#189).
-                        sync_tree_dir(&sftp, &refresh, &mut tree_dirs).await;
+                        sync_tree_dir(&transport, &refresh, &mut tree_dirs).await;
                         emit_tree(&tree_dirs, &tree_expanded, &events);
                     }
                     Err(e) => {
@@ -1194,7 +1410,7 @@ async fn run_sftp(
                         )));
                     }
                 }
-                if let Ok(entries) = list_dir_impl(&sftp, &refresh).await {
+                if let Ok(entries) = transport.list_dir(&refresh).await {
                     let _ = events.send(SessionEvent::SftpEntries {
                         path: refresh,
                         entries,
@@ -1205,31 +1421,29 @@ async fn run_sftp(
             SftpCommand::TouchFile(path) => {
                 let refresh = parent_dir(&path);
                 // create() truncates if the file exists, so refuse to clobber.
-                let exists = sftp.metadata(&path).await.is_ok();
-                if exists {
-                    let _ = events.send(SessionEvent::SftpStatus(format!(
-                        "{}: {}",
-                        t("文件已存在", "File already exists"),
-                        base_name(&path)
-                    )));
-                } else {
-                    match sftp.create(&path).await {
-                        Ok(_) => {
-                            let _ = events.send(SessionEvent::SftpStatus(format!(
-                                "{}: {}",
-                                t("已新建文件", "File created"),
-                                base_name(&path)
-                            )));
-                        }
-                        Err(e) => {
-                            let _ = events.send(SessionEvent::SftpStatus(format!(
-                                "{}: {e}",
-                                t("新建文件失败", "Create file failed")
-                            )));
-                        }
+                match transport.touch(&path).await {
+                    Ok(false) => {
+                        let _ = events.send(SessionEvent::SftpStatus(format!(
+                            "{}: {}",
+                            t("文件已存在", "File already exists"),
+                            base_name(&path)
+                        )));
+                    }
+                    Ok(true) => {
+                        let _ = events.send(SessionEvent::SftpStatus(format!(
+                            "{}: {}",
+                            t("已新建文件", "File created"),
+                            base_name(&path)
+                        )));
+                    }
+                    Err(e) => {
+                        let _ = events.send(SessionEvent::SftpStatus(format!(
+                            "{}: {e}",
+                            t("新建文件失败", "Create file failed")
+                        )));
                     }
                 }
-                if let Ok(entries) = list_dir_impl(&sftp, &refresh).await {
+                if let Ok(entries) = transport.list_dir(&refresh).await {
                     let _ = events.send(SessionEvent::SftpEntries {
                         path: refresh,
                         entries,
@@ -1256,10 +1470,9 @@ async fn run_sftp(
                 )));
                 let xid = Uuid::new_v4().to_string();
                 let no_cancel = Arc::new(AtomicBool::new(false));
-                match download_impl(
-                    &handle, &remote, &local_str, &filename, &xid, &events, &no_cancel,
-                )
-                .await
+                match transport
+                    .download(&remote, &local_str, &filename, &xid, &events, &no_cancel)
+                    .await
                 {
                     Ok(_) => {
                         open_with_os(&local_str);
@@ -1291,7 +1504,7 @@ async fn run_sftp(
                     t("打开", "Opening"),
                     name
                 )));
-                let (content, error) = match read_text_guarded(&sftp, &remote).await {
+                let (content, error) = match transport.read_text(&remote).await {
                     Ok(text) => (text, String::new()),
                     Err(msg) => (String::new(), msg),
                 };
@@ -1305,7 +1518,7 @@ async fn run_sftp(
             }
             SftpCommand::WriteText { remote, content } => {
                 let name = base_name(&remote);
-                match write_text_file(&sftp, &remote, &content).await {
+                match transport.write_text(&remote, &content).await {
                     Ok(_) => {
                         let _ = events.send(SessionEvent::SftpStatus(format!(
                             "{}: {}",
@@ -1324,10 +1537,28 @@ async fn run_sftp(
         }
     }
 
-    let _ = handle
-        .disconnect(Disconnect::ByApplication, "bye", "")
-        .await;
+    transport.disconnect().await;
     Ok(())
+}
+
+/// Open the `sftp` subsystem on an authenticated handle and run the SFTP
+/// handshake. Errors here (subsystem refused, handshake failure) trigger the
+/// SCP fallback.
+async fn open_sftp_subsystem(
+    handle: &client::Handle<SftpClientHandler>,
+) -> Result<SftpSession> {
+    let channel = handle
+        .channel_open_session()
+        .await
+        .context("open sftp channel")?;
+    channel
+        .request_subsystem(true, "sftp")
+        .await
+        .context("request sftp subsystem")?;
+    let sftp = SftpSession::new(channel.into_stream())
+        .await
+        .context("sftp handshake")?;
+    Ok(sftp)
 }
 
 const MAX_BUILTIN_EDITOR_BYTES: usize = 512 * 1024;
@@ -1335,7 +1566,7 @@ const MAX_BUILTIN_EDITOR_LINES: usize = 20_000;
 const MAX_BUILTIN_EDITOR_LINE_BYTES: usize = 64 * 1024;
 
 #[derive(Debug, PartialEq, Eq)]
-enum EditorTextRejection {
+pub(crate) enum EditorTextRejection {
     TooLarge,
     TooManyLines,
     LineTooLong,
@@ -1343,7 +1574,7 @@ enum EditorTextRejection {
     InvalidUtf8,
 }
 
-fn validate_editor_text(bytes: Vec<u8>) -> std::result::Result<String, EditorTextRejection> {
+pub(crate) fn validate_editor_text(bytes: Vec<u8>) -> std::result::Result<String, EditorTextRejection> {
     if bytes.len() > MAX_BUILTIN_EDITOR_BYTES {
         return Err(EditorTextRejection::TooLarge);
     }
@@ -1376,7 +1607,7 @@ fn validate_editor_text(bytes: Vec<u8>) -> std::result::Result<String, EditorTex
     Ok(text)
 }
 
-fn editor_rejection_message(rejection: EditorTextRejection) -> String {
+pub(crate) fn editor_rejection_message(rejection: EditorTextRejection) -> String {
     match rejection {
         EditorTextRejection::TooLarge => t(
             "文件过大,无法在内置编辑器中打开(上限 512 KB),请使用外部打开/编辑或下载",
@@ -1450,7 +1681,7 @@ async fn write_text_file(sftp: &SftpSession, remote: &str, content: &str) -> Res
 /// File name component of a path.  Handles both remote (`/`) and local Windows
 /// (`\`) separators, so uploading `C:\…\frp.tar.gz` yields `frp.tar.gz` rather
 /// than the whole path (which previously became the remote file name).
-fn base_name(path: &str) -> String {
+pub(crate) fn base_name(path: &str) -> String {
     let sep = |c: char| c == '/' || c == '\\';
     path.trim_end_matches(sep)
         .rsplit(sep)
@@ -1459,7 +1690,7 @@ fn base_name(path: &str) -> String {
         .to_string()
 }
 
-fn local_file_name_utf8(path: &Path) -> Result<String> {
+pub(crate) fn local_file_name_utf8(path: &Path) -> Result<String> {
     path.file_name()
         .and_then(|n| n.to_str())
         .map(|s| s.to_string())
@@ -1469,7 +1700,7 @@ fn local_file_name_utf8(path: &Path) -> Result<String> {
 /// Single-quote a string for safe interpolation into a remote `/bin/sh`
 /// command. Remote names come from the *server's* listing and are therefore
 /// untrusted — without quoting, a crafted name like `; rm -rf ~` would run.
-fn sh_quote(s: &str) -> String {
+pub(crate) fn sh_quote(s: &str) -> String {
     format!("'{}'", s.replace('\'', "'\\''"))
 }
 
@@ -1495,7 +1726,7 @@ async fn exec_remote(handle: &client::Handle<SftpClientHandler>, cmd: &str) -> R
 }
 
 /// Parent directory of a remote path ("/a/b" → "/a", "/a" → "/").
-fn parent_dir(path: &str) -> String {
+pub(crate) fn parent_dir(path: &str) -> String {
     let p = path.trim_end_matches('/');
     match p.rfind('/') {
         Some(0) | None => "/".to_string(),
@@ -1559,7 +1790,7 @@ fn open_with_os(path: &str) {
 /// and neutralises reserved device names (CON, NUL, COM1…).  Normal names
 /// (letters, digits, `.`, `-`, `_`, Unicode) pass through; Unix dotfiles keep
 /// their leading dot.  Falls back to `file` when nothing usable remains.
-fn sanitize_filename(name: &str) -> String {
+pub(crate) fn sanitize_filename(name: &str) -> String {
     let cleaned: String = name
         .chars()
         .map(|c| match c {
@@ -1624,8 +1855,7 @@ pub(crate) fn download_target_path(remote: &str, local_dir: &str) -> PathBuf {
     Path::new(local_dir).join(sanitize_filename(&base_name(remote)))
 }
 
-fn available_download_path(requested: &Path) -> PathBuf {
-    if !requested.exists() {
+fn available_download_path(requested: &Path) -> PathBuf {    if !requested.exists() {
         return requested.to_path_buf();
     }
     let parent = requested.parent().unwrap_or_else(|| Path::new(""));
@@ -1677,8 +1907,7 @@ fn spawn_edit_watcher(self_tx: UnboundedSender<SftpCommand>, local: String, remo
 // SFTP helpers
 // ---------------------------------------------------------------------------
 
-async fn cleanup_import_path(path: &Path) {
-    let res = match tokio::fs::metadata(path).await {
+async fn cleanup_import_path(path: &Path) {    let res = match tokio::fs::metadata(path).await {
         Ok(meta) if meta.is_dir() => tokio::fs::remove_dir_all(path).await,
         Ok(_) => tokio::fs::remove_file(path).await,
         Err(_) => Ok(()),
@@ -1689,8 +1918,7 @@ async fn cleanup_import_path(path: &Path) {
 }
 
 async fn stage_remote_for_copy(
-    sftp: &SftpSession,
-    handle: &client::Handle<SftpClientHandler>,
+    transport: &Transport,
     remote: &str,
     events: &UnboundedSender<SessionEvent>,
 ) -> Result<(PathBuf, PathBuf)> {
@@ -1703,12 +1931,7 @@ async fn stage_remote_for_copy(
     let name = sanitize_filename(&base_name(remote));
     let local_path = cleanup_root.join(&name);
     let local_parent = cleanup_root.to_string_lossy().to_string();
-    let is_dir = sftp
-        .metadata(remote)
-        .await
-        .ok()
-        .map(|m| (m.permissions.unwrap_or(0) & 0o170_000) == 0o040_000)
-        .unwrap_or(false);
+    let is_dir = transport.is_dir(remote).await;
     let no_cancel = Arc::new(AtomicBool::new(false));
     let id = Uuid::new_v4().to_string();
 
@@ -1716,16 +1939,19 @@ async fn stage_remote_for_copy(
         tokio::fs::create_dir_all(&local_path)
             .await
             .with_context(|| format!("failed to create temp dir {}", local_path.display()))?;
-        let empty = list_dir_impl(sftp, remote)
+        let empty = transport
+            .list_dir(remote)
             .await
             .map(|entries| entries.is_empty())
             .unwrap_or(false);
         if !empty {
-            download_dir(sftp, handle, remote, &local_parent, events).await?;
+            transport.download_dir(remote, &local_parent, events).await?;
         }
     } else {
         let local = local_path.to_string_lossy().to_string();
-        download_impl(handle, remote, &local, &name, &id, events, &no_cancel).await?;
+        transport
+            .download(remote, &local, &name, &id, events, &no_cancel)
+            .await?;
     }
 
     Ok((local_path, cleanup_root))
@@ -1743,7 +1969,7 @@ fn list_error_msg(path: &str, e: &impl std::fmt::Display) -> String {
     }
 }
 
-async fn list_dir_impl(sftp: &SftpSession, path: &str) -> Result<Vec<RemoteEntry>> {
+pub(crate) async fn list_dir_impl(sftp: &SftpSession, path: &str) -> Result<Vec<RemoteEntry>> {
     let raw = sftp
         .read_dir(path)
         .await
@@ -1786,7 +2012,7 @@ async fn list_dir_impl(sftp: &SftpSession, path: &str) -> Result<Vec<RemoteEntry
 }
 
 /// List only the subdirectories of `path` (no files). Used to build the tree.
-async fn list_dirs_only_impl(sftp: &SftpSession, path: &str) -> Result<Vec<(String, String)>> {
+pub(crate) async fn list_dirs_only_impl(sftp: &SftpSession, path: &str) -> Result<Vec<(String, String)>> {
     let entries = list_dir_impl(sftp, path).await?;
     Ok(entries
         .into_iter()
@@ -1796,7 +2022,7 @@ async fn list_dirs_only_impl(sftp: &SftpSession, path: &str) -> Result<Vec<(Stri
 }
 
 /// Emit a transfer-progress event.
-fn emit_transfer(
+pub(crate) fn emit_transfer(
     events: &UnboundedSender<SessionEvent>,
     id: &str,
     name: &str,
@@ -2252,10 +2478,10 @@ async fn upload_pipelined(
 // fresh host confirmed for the shell won't prompt again for SFTP.
 // ---------------------------------------------------------------------------
 
-struct SftpClientHandler {
-    host: String,
-    port: u16,
-    events: UnboundedSender<SessionEvent>,
+pub(crate) struct SftpClientHandler {
+    pub(crate) host: String,
+    pub(crate) port: u16,
+    pub(crate) events: UnboundedSender<SessionEvent>,
 }
 
 fn sftp_handler(session: &Session, events: &UnboundedSender<SessionEvent>) -> SftpClientHandler {

--- a/src/sftp/mod.rs
+++ b/src/sftp/mod.rs
@@ -1,5 +1,7 @@
 #[path = "impls/sftp.rs"]
-mod sftp;
+pub(crate) mod sftp;
+#[path = "impls/scp.rs"]
+pub(crate) mod scp;
 #[path = "struct/transfer.rs"]
 mod transfer;
 


### PR DESCRIPTION
## Summary

Routers and ultra-minimal BusyBox Linux systems (dropbear + scp, no sftp-server) often allow an SSH shell but **refuse the `sftp` subsystem**. Previously the SFTP panel then showed a permanently blank listing — only a status-bar error, no files.

This PR makes the file panel fall back to the classic **SCP protocol** on the same authenticated SSH connection, so those hosts get a working file browser instead of a blank void.

## Changes

- **`src/sftp/impls/scp.rs`** (new): a pure-Rust SCP engine over a russh exec channel:
  - Speaks the rcp/SCP wire framing (verified against OpenSSH `scp.c`): `C`/`D`/`E`/`T` control records, per-record `\0` ACKs, bidirectional greeting.
  - **Directory listing via portable `ls -l`** — this is how SCP mode shows directories.
  - Single-file and recursive-directory download/upload, small text read/write (built-in editor), and shell-command fallbacks for delete / mkdir / rename / chmod / touch (SCP has no primitive for those).
  - All remote names shell-quoted (untrusted input).
- **`src/sftp/impls/sftp.rs`**: introduce a `Transport` enum (`Sftp {..}` / `Scp {..}`) and route the entire command loop through it. The `sftp` subsystem is still tried first; on refusal the worker logs a warning, surfaces a status hint ("SFTP subsystem unavailable — using SCP instead"), and switches to SCP on the same connection.

## Notes

- The original SFTP path is untouched when the subsystem is available.
- Transfer cancel support carried over for both transports.
- Added unit tests for the `ls -l` parser and shell quoting.

## Testing

- `cargo check` clean (only 2 pre-existing baseline warnings).
- `cargo test`: 229 passed, 0 failed (incl. 4 new SCP parser tests).
- `cargo clippy`: no warnings in changed files.
