### PR TITLE
fix(内存管理): 修复终端缓存释放并统一跨平台分配器

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2763,7 +2763,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3092,6 +3092,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
+]
+
+[[package]]
 name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3251,6 +3271,15 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "libredox"
@@ -3461,7 +3490,9 @@ dependencies = [
  "i-slint-backend-winit",
  "icu_provider",
  "image",
+ "jemallocator",
  "md5",
+ "mimalloc",
  "portable-pty",
  "rand 0.8.6",
  "raw-window-handle",
@@ -3526,6 +3557,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -4282,7 +4322,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7322,7 +7362,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2763,7 +2763,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -4322,7 +4322,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7362,7 +7362,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,11 @@ image = { version = "0.25", default-features = false, features = ["png", "jpeg",
 # Feature is additive over the base `arboard = "3"` dependency above.
 arboard = { version = "3", features = ["wayland-data-control"] }
 
+# Use jemalloc on Unix-like desktop/mobile targets. Unsupported targets keep
+# Rust's portable System allocator without pulling in platform dependencies.
+[target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "android", target_os = "ios", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd", target_os = "dragonfly"))'.dependencies]
+jemallocator = "0.5"
+
 # Compile the Skia renderer in *only* on macOS (feature is additive over the base
 # slint dependency) so users can opt into it at launch with SLINT_BACKEND=winit-skia.
 # The default stays femtovg 鈥?see the renderer history note in main.rs (#108/#129).
@@ -131,6 +136,7 @@ winresource = "0.1"
 # src/app/jump_list.rs). 0.58 matches the version already in Cargo.lock via
 # transitive deps, keeping the lock diff minimal.
 [target.'cfg(windows)'.dependencies]
+mimalloc = "0.1"
 windows = { version = "0.58", features = [
     "Win32_Foundation",
     "Win32_Storage_EnhancedStorage",

--- a/docs/superpowers/plans/2026-09-02-global-allocator.md
+++ b/docs/superpowers/plans/2026-09-02-global-allocator.md
@@ -16,17 +16,17 @@
 - 修改：`Cargo.toml`
 - 修改：`Cargo.lock`
 
-- [ ] **步骤 1：** 在 Windows target dependencies 添加 `mimalloc = "0.1"`，在 Linux、macOS、Android、iOS 和 BSD target dependencies 添加 `jemallocator = "0.5"`。
-- [ ] **步骤 2：** 运行 `cargo check --example allocator_demo`，确认依赖解析可用；若 example 尚未实现则允许因源码缺失失败。
+- [x] **步骤 1：** 在 Windows target dependencies 添加 `mimalloc = "0.1"`，在 Linux、macOS、Android、iOS 和 BSD target dependencies 添加 `jemallocator = "0.5"`。
+- [x] **步骤 2：** 运行 `cargo check --example allocator_demo`，确认依赖解析可用；若 example 尚未实现则允许因源码缺失失败。
 
 ### 任务 2：实现并验证 allocator example
 
 **文件：**
 - 修改：`examples/allocator_demo.rs`
 
-- [ ] **步骤 1：** 保留平台名称测试，补充统一 `Allocator` 类型、`GLOBAL` 全局分配器、`allocator_name()` 和 1024 元素 `Vec` 分配。
-- [ ] **步骤 2：** 运行 `cargo test --example allocator_demo`，预期测试通过。
-- [ ] **步骤 3：** 运行 `cargo run --example allocator_demo`，预期输出 jemalloc（Linux）及 4096 bytes。
+- [x] **步骤 1：** 保留平台名称测试，补充统一 `Allocator` 类型、`GLOBAL` 全局分配器、`allocator_name()` 和 1024 元素 `Vec` 分配。
+- [x] **步骤 2：** 运行 `cargo test --example allocator_demo`，预期测试通过。
+- [x] **步骤 3：** 运行 `cargo run --example allocator_demo`，预期输出 jemalloc（Linux）及 4096 bytes。
 
 ### 任务 3：接入 meatshell 主程序
 
@@ -34,14 +34,14 @@
 - 创建：`src/allocator.rs`
 - 修改：`src/main.rs`
 
-- [ ] **步骤 1：** 将平台 cfg 和 `#[global_allocator]` 集中到 `src/allocator.rs`，主程序以 `mod allocator;` 引入。
-- [ ] **步骤 2：** 运行 `cargo check`，确认主程序只有一个全局分配器且各模块编译通过。
+- [x] **步骤 1：** 将平台 cfg 和 `#[global_allocator]` 集中到 `src/allocator.rs`，主程序以 `mod allocator;` 引入。
+- [x] **步骤 2：** 运行 `cargo check`，确认主程序只有一个全局分配器且各模块编译通过。
 
 ### 任务 4：回归验证和提交
 
 **文件：** 无新增文件。
 
-- [ ] **步骤 1：** 运行 `cargo test --example allocator_demo` 和 `cargo test`。
-- [ ] **步骤 2：** 运行 `cargo build --release`，确认 Linux 构建成功。
-- [ ] **步骤 3：** 检查 `git diff` 和 `git status`，确认无临时文件或无关改动。
-- [ ] **步骤 4：** 提交：`feat(构建): 按平台启用全局内存分配器`。
+- [x] **步骤 1：** 运行 `cargo test --example allocator_demo` 和 `cargo test`。
+- [x] **步骤 2：** 运行 `cargo build --release`，确认 Linux 构建成功。
+- [x] **步骤 3：** 检查 `git diff` 和 `git status`，确认无临时文件或无关改动。
+- [x] **步骤 4：** 提交：`feat(构建): 按平台启用全局内存分配器`。

--- a/docs/superpowers/plans/2026-09-02-global-allocator.md
+++ b/docs/superpowers/plans/2026-09-02-global-allocator.md
@@ -1,0 +1,47 @@
+# 全局内存分配器实现计划
+
+> **面向 AI 代理的工作者：** 必需子技能：使用 `superpowers:executing-plans` 在独立工作树中逐任务执行此计划。
+
+**目标：** 为 meatshell 按目标平台启用 mimalloc 或 jemallocator，并用 example 验证选择逻辑和实际堆分配。
+
+**架构：** 平台选择集中在 `src/allocator.rs`，主程序通过 `mod allocator` 注册唯一全局分配器。`examples/allocator_demo.rs` 独立复用同样的条件映射，用单元测试验证平台名称并执行 `Vec` 分配。
+
+**技术栈：** Rust `#[cfg]`、`#[global_allocator]`、`mimalloc 0.1`、`jemallocator 0.5`、Cargo 条件依赖。
+
+---
+
+### 任务 1：配置平台依赖
+
+**文件：**
+- 修改：`Cargo.toml`
+- 修改：`Cargo.lock`
+
+- [ ] **步骤 1：** 在 Windows target dependencies 添加 `mimalloc = "0.1"`，在 Linux、macOS、Android、iOS 和 BSD target dependencies 添加 `jemallocator = "0.5"`。
+- [ ] **步骤 2：** 运行 `cargo check --example allocator_demo`，确认依赖解析可用；若 example 尚未实现则允许因源码缺失失败。
+
+### 任务 2：实现并验证 allocator example
+
+**文件：**
+- 修改：`examples/allocator_demo.rs`
+
+- [ ] **步骤 1：** 保留平台名称测试，补充统一 `Allocator` 类型、`GLOBAL` 全局分配器、`allocator_name()` 和 1024 元素 `Vec` 分配。
+- [ ] **步骤 2：** 运行 `cargo test --example allocator_demo`，预期测试通过。
+- [ ] **步骤 3：** 运行 `cargo run --example allocator_demo`，预期输出 jemalloc（Linux）及 4096 bytes。
+
+### 任务 3：接入 meatshell 主程序
+
+**文件：**
+- 创建：`src/allocator.rs`
+- 修改：`src/main.rs`
+
+- [ ] **步骤 1：** 将平台 cfg 和 `#[global_allocator]` 集中到 `src/allocator.rs`，主程序以 `mod allocator;` 引入。
+- [ ] **步骤 2：** 运行 `cargo check`，确认主程序只有一个全局分配器且各模块编译通过。
+
+### 任务 4：回归验证和提交
+
+**文件：** 无新增文件。
+
+- [ ] **步骤 1：** 运行 `cargo test --example allocator_demo` 和 `cargo test`。
+- [ ] **步骤 2：** 运行 `cargo build --release`，确认 Linux 构建成功。
+- [ ] **步骤 3：** 检查 `git diff` 和 `git status`，确认无临时文件或无关改动。
+- [ ] **步骤 4：** 提交：`feat(构建): 按平台启用全局内存分配器`。

--- a/docs/superpowers/specs/2026-09-02-global-allocator-design.md
+++ b/docs/superpowers/specs/2026-09-02-global-allocator-design.md
@@ -1,0 +1,26 @@
+# 全局内存分配器设计
+
+## 背景
+
+为改善 meatshell 在不同平台上的堆内存分配性能，需要按目标平台选择专用分配器，同时保留不支持平台的可移植性。
+
+## 方案
+
+- Windows 目标使用 `mimalloc`。
+- Linux、macOS、Android、iOS 及 FreeBSD、NetBSD、OpenBSD、DragonFly 目标使用 `jemallocator`。
+- 其他目标使用标准库 `System` 分配器兜底。
+- 依赖在 `Cargo.toml` 中按 `cfg` 条件声明，避免非目标平台编译无关依赖。
+- 分配器选择集中在独立模块中，主程序只通过模块加载，确保全工程只有一个 `#[global_allocator]` 声明。
+
+## Example 与测试
+
+新增 `examples/allocator_demo.rs`，复用同一套平台选择逻辑，执行 1024 个 `i32` 的堆分配并输出分配器类别与大小。测试覆盖：
+
+1. 当前目标平台的分配器类别符合映射。
+2. `Vec` 分配、写入和释放正常完成。
+
+先运行测试确认缺少实现时失败，再实现最小代码使其通过，随后运行项目测试和 Linux 构建验证回归。
+
+## 兼容性
+
+jemalloc 依赖仅对明确列出的 Unix-like 目标启用；Android 和 iOS 使用与其他 Unix-like 目标相同的配置。WASM、嵌入式等目标继续使用 `System`，不新增依赖。

--- a/examples/allocator_demo.rs
+++ b/examples/allocator_demo.rs
@@ -1,0 +1,61 @@
+#[path = "../src/allocator.rs"]
+mod allocator;
+
+use allocator::allocator_name;
+
+#[cfg(test)]
+mod tests {
+    use super::allocator_name;
+
+    #[cfg(target_os = "windows")]
+    const EXPECTED: &str = "mimalloc";
+
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "macos",
+        target_os = "android",
+        target_os = "ios",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "dragonfly"
+    ))]
+    const EXPECTED: &str = "jemalloc";
+
+    #[cfg(not(any(
+        target_os = "windows",
+        target_os = "linux",
+        target_os = "macos",
+        target_os = "android",
+        target_os = "ios",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "dragonfly"
+    )))]
+    const EXPECTED: &str = "system";
+
+    #[test]
+    fn selects_allocator_for_target_platform() {
+        assert_eq!(allocator_name(), EXPECTED);
+    }
+
+    #[test]
+    fn allocates_and_releases_memory() {
+        let mut values = Vec::with_capacity(1024);
+        values.extend(0..1024);
+        assert_eq!(values.len() * std::mem::size_of::<i32>(), 4096);
+        assert_eq!(values[0], 0);
+        assert_eq!(values[1023], 1023);
+    }
+}
+
+fn main() {
+    let mut values = Vec::with_capacity(1024);
+    values.extend(0..1024);
+    println!("allocator={}", allocator_name());
+    println!(
+        "allocated_bytes={}",
+        values.len() * std::mem::size_of::<i32>()
+    );
+}

--- a/examples/allocator_demo.rs
+++ b/examples/allocator_demo.rs
@@ -1,61 +1,108 @@
-#[path = "../src/allocator.rs"]
+// Examples are separate crates, so include the shared allocator type and wrap
+// it with byte counters. The global allocator declaration below belongs only
+// to this example binary; the application declares its own in main.rs.
+use std::alloc::{GlobalAlloc, Layout};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[path = "../src/allocator/mod.rs"]
 mod allocator;
 
-use allocator::allocator_name;
+use allocator::{allocator_name, Allocator as SelectedAllocator};
+
+struct TrackingAllocator<A>(A);
+
+static LIVE_BYTES: AtomicUsize = AtomicUsize::new(0);
+static TOTAL_ALLOCATED: AtomicUsize = AtomicUsize::new(0);
+static TOTAL_DEALLOCATED: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl<A: GlobalAlloc> GlobalAlloc for TrackingAllocator<A> {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = unsafe { self.0.alloc(layout) };
+        if !ptr.is_null() {
+            LIVE_BYTES.fetch_add(layout.size(), Ordering::Relaxed);
+            TOTAL_ALLOCATED.fetch_add(layout.size(), Ordering::Relaxed);
+        }
+        ptr
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        let ptr = unsafe { self.0.alloc_zeroed(layout) };
+        if !ptr.is_null() {
+            LIVE_BYTES.fetch_add(layout.size(), Ordering::Relaxed);
+            TOTAL_ALLOCATED.fetch_add(layout.size(), Ordering::Relaxed);
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { self.0.dealloc(ptr, layout) };
+        LIVE_BYTES.fetch_sub(layout.size(), Ordering::Relaxed);
+        TOTAL_DEALLOCATED.fetch_add(layout.size(), Ordering::Relaxed);
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let new_ptr = unsafe { self.0.realloc(ptr, layout, new_size) };
+        if !new_ptr.is_null() {
+            match new_size.cmp(&layout.size()) {
+                std::cmp::Ordering::Greater => {
+                    let delta = new_size - layout.size();
+                    LIVE_BYTES.fetch_add(delta, Ordering::Relaxed);
+                    TOTAL_ALLOCATED.fetch_add(delta, Ordering::Relaxed);
+                }
+                std::cmp::Ordering::Less => {
+                    let delta = layout.size() - new_size;
+                    LIVE_BYTES.fetch_sub(delta, Ordering::Relaxed);
+                    TOTAL_DEALLOCATED.fetch_add(delta, Ordering::Relaxed);
+                }
+                std::cmp::Ordering::Equal => {}
+            }
+        }
+        new_ptr
+    }
+}
+
+#[global_allocator]
+static GLOBAL: TrackingAllocator<SelectedAllocator> = TrackingAllocator(SelectedAllocator);
+
+fn tracked_bytes() -> usize {
+    LIVE_BYTES.load(Ordering::Relaxed)
+}
 
 #[cfg(test)]
 mod tests {
-    use super::allocator_name;
-
-    #[cfg(target_os = "windows")]
-    const EXPECTED: &str = "mimalloc";
-
-    #[cfg(any(
-        target_os = "linux",
-        target_os = "macos",
-        target_os = "android",
-        target_os = "ios",
-        target_os = "freebsd",
-        target_os = "netbsd",
-        target_os = "openbsd",
-        target_os = "dragonfly"
-    ))]
-    const EXPECTED: &str = "jemalloc";
-
-    #[cfg(not(any(
-        target_os = "windows",
-        target_os = "linux",
-        target_os = "macos",
-        target_os = "android",
-        target_os = "ios",
-        target_os = "freebsd",
-        target_os = "netbsd",
-        target_os = "openbsd",
-        target_os = "dragonfly"
-    )))]
-    const EXPECTED: &str = "system";
-
-    #[test]
-    fn selects_allocator_for_target_platform() {
-        assert_eq!(allocator_name(), EXPECTED);
-    }
+    use super::{TOTAL_ALLOCATED, TOTAL_DEALLOCATED};
+    use std::sync::atomic::Ordering;
 
     #[test]
     fn allocates_and_releases_memory() {
+        let allocated_before = TOTAL_ALLOCATED.load(Ordering::Relaxed);
+        let deallocated_before = TOTAL_DEALLOCATED.load(Ordering::Relaxed);
         let mut values = Vec::with_capacity(1024);
         values.extend(0..1024);
-        assert_eq!(values.len() * std::mem::size_of::<i32>(), 4096);
         assert_eq!(values[0], 0);
         assert_eq!(values[1023], 1023);
+        let allocated = TOTAL_ALLOCATED.load(Ordering::Relaxed) - allocated_before;
+        assert!(allocated >= 4096);
+        drop(values);
+        let deallocated = TOTAL_DEALLOCATED.load(Ordering::Relaxed) - deallocated_before;
+        assert!(deallocated >= 4096);
     }
 }
 
 fn main() {
+    let before = tracked_bytes();
+    let allocated_before = TOTAL_ALLOCATED.load(Ordering::Relaxed);
     let mut values = Vec::with_capacity(1024);
     values.extend(0..1024);
+    let during = tracked_bytes();
+    let allocated = TOTAL_ALLOCATED.load(Ordering::Relaxed) - allocated_before;
+    drop(values);
+    let after_drop = tracked_bytes();
+    let released = TOTAL_DEALLOCATED.load(Ordering::Relaxed);
     println!("allocator={}", allocator_name());
-    println!(
-        "allocated_bytes={}",
-        values.len() * std::mem::size_of::<i32>()
-    );
+    println!("live_bytes_before={before}");
+    println!("live_bytes_during={during}");
+    println!("live_bytes_after_drop={after_drop}");
+    println!("allocated_bytes={allocated}");
+    println!("total_released_bytes={released}");
 }

--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -1,0 +1,69 @@
+//! Platform-selected global heap allocator.
+
+#[cfg(target_os = "windows")]
+use mimalloc::MiMalloc as Allocator;
+
+#[cfg(any(
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "android",
+    target_os = "ios",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd",
+    target_os = "dragonfly"
+))]
+use jemallocator::Jemalloc as Allocator;
+
+#[cfg(not(any(
+    target_os = "windows",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "android",
+    target_os = "ios",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd",
+    target_os = "dragonfly"
+)))]
+use std::alloc::System as Allocator;
+
+#[global_allocator]
+static GLOBAL: Allocator = Allocator;
+
+#[allow(dead_code)]
+pub(crate) fn allocator_name() -> &'static str {
+    #[cfg(target_os = "windows")]
+    {
+        "mimalloc"
+    }
+
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "macos",
+        target_os = "android",
+        target_os = "ios",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "dragonfly"
+    ))]
+    {
+        "jemalloc"
+    }
+
+    #[cfg(not(any(
+        target_os = "windows",
+        target_os = "linux",
+        target_os = "macos",
+        target_os = "android",
+        target_os = "ios",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "dragonfly"
+    )))]
+    {
+        "system"
+    }
+}

--- a/src/allocator/mod.rs
+++ b/src/allocator/mod.rs
@@ -1,7 +1,7 @@
-//! Platform-selected global heap allocator.
+//! Platform-selected heap allocator type.
 
 #[cfg(target_os = "windows")]
-use mimalloc::MiMalloc as Allocator;
+pub(crate) use mimalloc::MiMalloc as Allocator;
 
 #[cfg(any(
     target_os = "linux",
@@ -13,7 +13,7 @@ use mimalloc::MiMalloc as Allocator;
     target_os = "openbsd",
     target_os = "dragonfly"
 ))]
-use jemallocator::Jemalloc as Allocator;
+pub(crate) use jemallocator::Jemalloc as Allocator;
 
 #[cfg(not(any(
     target_os = "windows",
@@ -26,10 +26,7 @@ use jemallocator::Jemalloc as Allocator;
     target_os = "openbsd",
     target_os = "dragonfly"
 )))]
-use std::alloc::System as Allocator;
-
-#[global_allocator]
-static GLOBAL: Allocator = Allocator;
+pub(crate) use std::alloc::System as Allocator;
 
 #[allow(dead_code)]
 pub(crate) fn allocator_name() -> &'static str {
@@ -65,5 +62,41 @@ pub(crate) fn allocator_name() -> &'static str {
     )))]
     {
         "system"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::allocator_name;
+
+    #[test]
+    fn selects_allocator_for_target_platform() {
+        #[cfg(target_os = "windows")]
+        assert_eq!(allocator_name(), "mimalloc");
+
+        #[cfg(any(
+            target_os = "linux",
+            target_os = "macos",
+            target_os = "android",
+            target_os = "ios",
+            target_os = "freebsd",
+            target_os = "netbsd",
+            target_os = "openbsd",
+            target_os = "dragonfly"
+        ))]
+        assert_eq!(allocator_name(), "jemalloc");
+
+        #[cfg(not(any(
+            target_os = "windows",
+            target_os = "linux",
+            target_os = "macos",
+            target_os = "android",
+            target_os = "ios",
+            target_os = "freebsd",
+            target_os = "netbsd",
+            target_os = "openbsd",
+            target_os = "dragonfly"
+        )))]
+        assert_eq!(allocator_name(), "system");
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -5634,16 +5634,7 @@ fn wire_key_input(
                     {
                         if let Some(h) = term_buf(&ctx.bufs, tab_id.as_str()) {
                             let mut b = h.lock().unwrap();
-                            let (rows, cols) = b.parser.screen().size();
-                            b.parser = vt100::Parser::new(rows, cols, 5000);
-                            b.history.clear();
-                            b.prev.clear();
-                            b.displayed_text.clear();
-                            b.view_offset = 0;
-                            b.sel_anchor = None;
-                            b.sel_focus = None;
-                            b.sel_ranges.clear();
-                            b.raw.clear();
+                            b.release_scrollback();
                         }
                     }
                     if let Some(st) =
@@ -6103,17 +6094,7 @@ fn wire_key_input(
             let tid = tab_id.to_string();
             if let Some(h) = term_buf(&bufs_clear, &tid) {
                 let mut buf = h.lock().unwrap();
-                let (rows, cols) = buf.parser.screen().size();
-                buf.parser = vt100::Parser::new(rows, cols, 5000);
-                buf.find_query.clear();
-                buf.history = VecDeque::new(); // recycle the session scrollback
-                buf.prev = Vec::new();
-                buf.view_offset = 0;
-                buf.sel_anchor = None;
-                buf.sel_focus = None;
-                buf.sel_ranges.clear();
-                buf.displayed_text = Vec::new();
-                buf.raw.clear();
+                buf.release_scrollback();
             }
             if let Some(win) = weak.upgrade() {
                 set_terminal_row(&win, &tid, |row| {

--- a/src/app/session_event.rs
+++ b/src/app/session_event.rs
@@ -93,6 +93,13 @@ pub(super) fn apply_session_event_to_window(
             }
         }
         SessionEvent::Closed(reason) => {
+            // A disconnected tab remains open for Enter-to-reconnect, but it
+            // must not retain the old firehose scrollback while idle. Keep the
+            // tab and its status, release the heavy terminal state, then paint
+            // only the reconnect hint below.
+            if let Some(h) = crate::app::term_buf(bufs, tab_id) {
+                h.lock().unwrap().release_scrollback();
+            }
             // Print the hint into the terminal itself (FinalShell-style), via a
             // synthetic Output event so it reuses the normal render path (#79).
             apply_session_event_to_window(

--- a/src/app/session_runtime.rs
+++ b/src/app/session_runtime.rs
@@ -1,5 +1,18 @@
 use super::*;
 
+/// When a firehose queue contains stale output ahead of its terminal `Closed`
+/// event, keep the close notification and discard the obsolete output. The
+/// disconnected tab is going to be reset anyway; replaying those bytes only
+/// delays cleanup and can temporarily retain hundreds of megabytes.
+pub(super) fn take_closed_event(events: &mut Vec<SessionEvent>) -> Option<SessionEvent> {
+    let index = events
+        .iter()
+        .position(|event| matches!(event, SessionEvent::Closed(_)))?;
+    let closed = events.swap_remove(index);
+    events.clear();
+    Some(closed)
+}
+
 pub(super) fn resolve_jump(store: &Rc<RefCell<ConfigStore>>, session: &Session) -> Option<Session> {
     if session.kind != SessionKind::Ssh || session.jump_session_id.trim().is_empty() {
         return None;
@@ -156,6 +169,33 @@ pub(super) fn start_session_in_tab(tab_id: &str, session: Session, ctx: &Connect
                 let Ok(rt) = route_pump.lock().map(|g| g.clone()) else {
                     continue;
                 };
+
+                // A close marker can sit behind a large burst of Output events
+                // in the unbounded channel. Handle it before ingesting anything
+                // from this batch so stale scrollback is released immediately.
+                if let Some(closed) = take_closed_event(&mut drained) {
+                    if let Some(h) = crate::app::term_buf(&rt.bufs, &tab_id_pump) {
+                        h.lock().unwrap().release_scrollback();
+                    }
+                    let rt_evt = rt.clone();
+                    let tid = tab_id_pump.clone();
+                    let _ = slint::invoke_from_event_loop(move || {
+                        if let Some(win) = rt_evt.window.upgrade() {
+                            apply_session_event_to_window(
+                                &win,
+                                rt_evt.window_id,
+                                &tid,
+                                closed,
+                                &rt_evt.bufs,
+                                &rt_evt.gates,
+                                &rt_evt.statuses,
+                                &rt_evt.local_snap,
+                                &rt_evt.net_hist,
+                            );
+                        }
+                    });
+                    break;
+                }
 
                 // Run CwdChanged side-effects here (off the UI thread), drop the
                 // swallowed ones, and concatenate runs of Output into a single chunk

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+mod allocator;
 mod app;
 mod automation;
 mod cli;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,9 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 mod allocator;
+
+#[global_allocator]
+static GLOBAL: allocator::Allocator = allocator::Allocator;
 mod app;
 mod automation;
 mod cli;

--- a/src/terminal/impls/term_buffer.rs
+++ b/src/terminal/impls/term_buffer.rs
@@ -23,6 +23,28 @@ fn terminal_query(sequence: &[u8]) -> Option<TerminalQuery> {
 }
 
 impl TermBuffer {
+    /// Release all retained terminal output and recreate the parser at the
+    /// current size. This is used when a session is disconnected or the user
+    /// explicitly clears the terminal, so a dead tab does not keep a large
+    /// scrollback allocation alive until it is closed.
+    pub(crate) fn release_scrollback(&mut self) {
+        let (rows, cols) = self.parser.screen().size();
+        self.parser = vt100::Parser::new(rows, cols, 5000);
+        self.find_query.clear();
+        self.history = std::collections::VecDeque::new();
+        self.prev = Vec::new();
+        self.view_offset = 0;
+        self.sel_anchor = None;
+        self.sel_focus = None;
+        self.sel_ranges.clear();
+        self.displayed_text = Vec::new();
+        self.csi_state = CsiState::Normal;
+        self.csi_pending = Vec::new();
+        self.raw = std::collections::VecDeque::new();
+        self.charset = crate::terminal::CharsetTracker::default();
+        self.mouse_tracked = false;
+    }
+
     // ---- Absolute-coordinate selection helpers (#18 follow-up) -------------
     //
     // The "combined" buffer is `history` (oldest first) followed by the live

--- a/tests/app/terminal_ingest/mod.rs
+++ b/tests/app/terminal_ingest/mod.rs
@@ -1,4 +1,6 @@
-use super::{event_requires_immediate_ui, record_ingested_chunk, INGEST_FRAME_BUDGET};
+use super::{
+    event_requires_immediate_ui, record_ingested_chunk, take_closed_event, INGEST_FRAME_BUDGET,
+};
 use crate::ssh::SessionEvent;
 
 fn count_requests(chunk_lengths: &[usize]) -> (usize, usize) {
@@ -62,4 +64,19 @@ fn routine_shell_metadata_does_not_disable_tail_pacing() {
     assert!(event_requires_immediate_ui(&SessionEvent::Closed(
         "connection lost".into()
     )));
+}
+
+#[test]
+fn closed_event_discards_stale_output_backlog() {
+    let mut events = vec![
+        SessionEvent::Output("old-1".into()),
+        SessionEvent::Output("old-2".into()),
+        SessionEvent::Closed("connection closed".into()),
+        SessionEvent::Output("stale-after-close".into()),
+    ];
+
+    let closed = take_closed_event(&mut events);
+
+    assert!(matches!(closed, Some(SessionEvent::Closed(reason)) if reason == "connection closed"));
+    assert!(events.is_empty());
 }

--- a/tests/app/terminal_rendering/mod.rs
+++ b/tests/app/terminal_rendering/mod.rs
@@ -48,6 +48,31 @@ fn settings_modal_yields_macos_wheel_to_its_own_scroll_view() {
     assert!(!macos_terminal_wheel_can_target_terminal(true));
 }
 
+#[test]
+fn releasing_scrollback_drops_retained_history_and_replay_bytes() {
+    let mut buffer = make_buf(5, 20, &["old-1", "old-2"], &["live"], 2);
+    buffer.prev = vec![hist_line("previous")];
+    buffer.raw.extend([1, 2, 3, 4]);
+    buffer.displayed_text.push("visible".to_string());
+    buffer.sel_anchor = Some((0, 0));
+    buffer.sel_focus = Some((1, 1));
+    buffer.sel_ranges.push(((0, 0), (1, 1)));
+
+    buffer.release_scrollback();
+
+    assert!(buffer.history.is_empty());
+    assert_eq!(buffer.history.capacity(), 0);
+    assert!(buffer.prev.is_empty());
+    assert_eq!(buffer.prev.capacity(), 0);
+    assert!(buffer.raw.is_empty());
+    assert_eq!(buffer.raw.capacity(), 0);
+    assert!(buffer.displayed_text.is_empty());
+    assert!(buffer.sel_anchor.is_none());
+    assert!(buffer.sel_focus.is_none());
+    assert!(buffer.sel_ranges.is_empty());
+    assert_eq!(buffer.view_offset, 0);
+}
+
 mod charset;
 mod colors;
 mod protocol;


### PR DESCRIPTION
## 摘要

本 PR 汇总终端缓存释放修复和跨平台全局内存分配器改动，目标是降低 `tail -f` 等高频输出场景下的内存滞留，并统一不同平台的 allocator 选择。

## 主要改动

- 断开 SSH/终端连接时立即释放终端 parser、滚动历史、原始输出和选择状态，避免已关闭连接继续持有大量内存。
- 处理 shell 事件批次时优先识别 `Closed` 事件，丢弃无界队列中的过期输出，避免关闭事件被大量输出阻塞。
- 将清空终端操作统一复用 `release_scrollback`，减少重复清理逻辑。
- Windows 使用 mimalloc；Linux、macOS、Android、iOS 及 BSD 使用 jemalloc；其他目标回退到 Rust System allocator。
- 将 allocator 模块整理到 `src/allocator/mod.rs`，避免直接堆放在 `src` 根目录，并让示例复用同一平台选择逻辑。
- 增强 `examples/allocator_demo.rs`，统计分配、释放和当前存活字节数。
- 新增关闭事件积压和滚动缓存释放回归测试。

## 验证

- `cargo test --locked --offline --example allocator_demo`（2 passed）
- `cargo test --locked --offline`（225 passed）
- `cargo build --release --locked --offline`

## 兼容性说明

- 未升级或降级现有 Windows 依赖版本。
- 未改变 Windows “禁用 Shell 集成”配置行为；该选项仍仅控制辅助 Shell 通道。
