### PR TITLE
fix: 修复标签页右键重命名导致程序闪退的问题

### DIFF
--- a/vendor/i-slint-backend-winit/winitwindowadapter.rs
+++ b/vendor/i-slint-backend-winit/winitwindowadapter.rs
@@ -1581,7 +1581,14 @@ impl WindowAdapterInternal for WinitWindowAdapter {
     #[cfg(enable_accesskit)]
     fn handle_focus_change(&self, _old: Option<ItemRc>, _new: Option<ItemRc>) {
         let Some(accesskit_adapter_cell) = self.accesskit_adapter() else { return };
-        accesskit_adapter_cell.borrow_mut().handle_focus_item_change();
+        // Focus can change re-entrantly during item-tree construction (e.g. the
+        // rename dialog focusing its LineEdit from `init`), which would leave the
+        // adapter's RefCell already mutably borrowed. Skip the redundant focus
+        // notify in that case — the pending tree update reconciles it — instead
+        // of panicking (`RefCell already borrowed`).
+        if let Ok(mut a) = accesskit_adapter_cell.try_borrow_mut() {
+            a.handle_focus_item_change();
+        }
     }
 
     #[cfg(enable_accesskit)]


### PR DESCRIPTION
重命名弹窗在 init 中同步 focus LineEdit，触发焦点变更可重入，
导致 winit 后端 AccessKit 适配器 handle_focus_change 使用 borrow_mut 时出现 RefCell 已借用而 panic。改用 try_borrow_mut 在重入时安全跳过， 避免闪退。
修复[任意标签页右键菜单进行重命名会导致程序闪退](https://github.com/yituorou/meatshell/issues/407)