### PR TITLE
feat(tabs): 标签页支持跨多标签拖动 (#408)

### DIFF
--- a/src/app/tab_callbacks.rs
+++ b/src/app/tab_callbacks.rs
@@ -82,8 +82,10 @@ pub(super) fn wire_tab_callbacks(
         });
     }
 
-    // Drag-to-reorder within a pane's strip: move the tab at `from` one slot in
-    // `dir`. Only the pane's own tab order changes; content shows by active id.
+    // Drag-to-reorder within a pane's strip (#408). The strip animates the drag on
+    // its own and commits exactly once, here, on drop: the tab at `from` is
+    // re-inserted at `to` (an index into the strip with `from` removed). Only the
+    // pane's own tab order changes; content still shows by active id.
     {
         let weak = window.as_weak();
         let layout = layout.clone();
@@ -91,27 +93,14 @@ pub(super) fn wire_tab_callbacks(
         let tabs_model = tabs_model.clone();
         let panes_model = panes_model.clone();
         let splitters_model = splitters_model.clone();
-        window.on_pane_tab_reorder(move |pane_id: i32, from: i32, dir: i32| {
-            {
-                let mut lay = layout.borrow_mut();
-                if let Some(l) = lay.leaf_mut(pane_id as u64) {
-                    let n = l.tabs.len() as i32;
-                    if n <= 1 {
-                        return;
-                    }
-                    let from = from.clamp(0, n - 1);
-                    let to = (from + dir).clamp(0, n - 1);
-                    if from == to {
-                        return;
-                    }
-                    let item = l.tabs.remove(from as usize);
-                    l.tabs.insert(to as usize, item);
-                }
+        window.on_pane_tab_move(move |pane_id: i32, from: i32, to: i32| {
+            if from < 0 || to < 0 || from == to {
+                return;
             }
+            layout
+                .borrow_mut()
+                .move_tab_within(pane_id as u64, from as usize, to as usize);
             if let Some(w) = weak.upgrade() {
-                // Reordering refreshes the tab model and replaces the original
-                // drag source before it can receive pointer-up. Clear the
-                // insertion caret on this same-pane path before refreshing.
                 w.set_drag_active(false);
                 refresh_panes(
                     &w,
@@ -391,6 +380,25 @@ pub(super) fn wire_tab_callbacks(
         });
     }
 
+    // Where a tab dragged in from elsewhere would land in a pane's strip, as
+    // reported by that strip while the cursor is over it (#408). `-1` means the
+    // cursor left; the drop handler below reads whatever was reported last.
+    let drop_index: Rc<std::cell::Cell<(i32, i32)>> = Rc::new(std::cell::Cell::new((-1, -1)));
+    {
+        let drop_index = drop_index.clone();
+        window.on_pane_tab_drop_index(move |pane_id: i32, index: i32| {
+            if index < 0 {
+                // Only the strip that currently owns the offer may withdraw it:
+                // strips report in an arbitrary order as the cursor crosses them.
+                if drop_index.get().0 == pane_id {
+                    drop_index.set((-1, -1));
+                }
+            } else {
+                drop_index.set((pane_id, index));
+            }
+        });
+    }
+
     // Drag-to-split: while a tab is dragged over the pane area, highlight the
     // drop zone the cursor is in (an edge band → split, the middle → move).
     {
@@ -398,25 +406,48 @@ pub(super) fn wire_tab_callbacks(
         let layout = layout.clone();
         let content_size = content_size.clone();
         let core = core.clone();
-        window.on_tab_drag_move(move |tab_id: SharedString, x: f32, y: f32| {
-            let tab_id = tab_id.to_string();
-            // Cross-window detach/merge owns the feedback once the cursor
-            // leaves the window (the torn-off window follows the pointer,
-            // the window under the cursor lights up) (#tab-detach).
-            if handle_global_tab_drag_move(&core, window_id, &tab_id, x, y) {
-                return;
-            }
-            if let Some(w) = weak.upgrade() {
-                match drag_target(&layout.borrow(), content_size.get(), x, y) {
-                    Some((_, _, (hx, hy, hw, hh))) => {
-                        w.set_drag_active(true);
-                        w.set_drag_hl_x(hx);
-                        w.set_drag_hl_y(hy);
-                        w.set_drag_hl_w(hw);
-                        w.set_drag_hl_h(hh);
-                    }
-                    None => w.set_drag_active(false),
+        window.on_tab_drag_move(
+            move |tab_id: SharedString, x: f32, y: f32, over_own_strip: bool| {
+                let tab_id = tab_id.to_string();
+                // Cross-window detach/merge owns the feedback once the cursor
+                // leaves the window (the torn-off window follows the pointer,
+                // the window under the cursor lights up) (#tab-detach).
+                if handle_global_tab_drag_move(&core, window_id, &tab_id, x, y) {
+                    return;
                 }
+                if let Some(w) = weak.upgrade() {
+                    // The source strip is already showing an insertion gap of its
+                    // own; a pane drop-zone on top of it would just be noise.
+                    if over_own_strip {
+                        w.set_drag_active(false);
+                        return;
+                    }
+                    match drag_target(&layout.borrow(), content_size.get(), x, y) {
+                        Some((_, _, (hx, hy, hw, hh))) => {
+                            w.set_drag_active(true);
+                            w.set_drag_hl_x(hx);
+                            w.set_drag_hl_y(hy);
+                            w.set_drag_hl_w(hw);
+                            w.set_drag_hl_h(hh);
+                        }
+                        None => w.set_drag_active(false),
+                    }
+                }
+            },
+        );
+    }
+
+    // The gesture ended without a drop (the pointer grab was cancelled, or an
+    // in-strip drag landed back on its own slot): drop every highlight it raised.
+    {
+        let weak = window.as_weak();
+        let core = core.clone();
+        let drop_index = drop_index.clone();
+        window.on_tab_drag_cancel(move || {
+            drop_index.set((-1, -1));
+            handle_global_tab_drag_cancel(&core);
+            if let Some(w) = weak.upgrade() {
+                w.set_drag_active(false);
             }
         });
     }
@@ -433,6 +464,7 @@ pub(super) fn wire_tab_callbacks(
         let splitters_model = splitters_model.clone();
         window.on_tab_drag_drop(move |tab_id: SharedString, x: f32, y: f32| {
             let tab_id = tab_id.to_string();
+            let dropped_at = drop_index.replace((-1, -1));
             // A cross-window drag (torn-off window following the cursor) is
             // settled here: merged into the window under the pointer, or
             // kept where it is (#tab-detach).
@@ -458,7 +490,13 @@ pub(super) fn wire_tab_callbacks(
                     }
                     "tabstrip" => {
                         if src != Some(pane) {
-                            lay.move_tab(&tab_id, pane);
+                            // Land it where the strip said it would, not at the end.
+                            match dropped_at {
+                                (p, at) if p == pane as i32 && at >= 0 => {
+                                    lay.move_tab_at(&tab_id, pane, at as usize)
+                                }
+                                _ => lay.move_tab(&tab_id, pane),
+                            }
                         }
                     }
                     _ => {

--- a/src/app/tab_transfer.rs
+++ b/src/app/tab_transfer.rs
@@ -208,6 +208,14 @@ pub(super) fn handle_global_tab_drag_move(
     true
 }
 
+/// A drag that ended without a drop (the pointer grab was cancelled, or the
+/// tab landed back where it started): forget the hover target and take every
+/// window's merge highlight down (#408).
+pub(super) fn handle_global_tab_drag_cancel(core: &Rc<AppCore>) {
+    LAST_TARGET.with(|t| t.set(None));
+    clear_all_highlights(core);
+}
+
 /// Drop handling. Returns true when the drop was consumed here (caller skips
 /// the in-window split logic).
 pub(super) fn handle_global_tab_drag_drop(

--- a/src/layout/impls/panes.rs
+++ b/src/layout/impls/panes.rs
@@ -139,6 +139,14 @@ impl Layout {
     /// Move `tab_id` into existing leaf `to` (e.g. dropped onto another pane's tab
     /// strip). No-op if it's already there. Collapses an emptied source pane.
     pub fn move_tab(&mut self, tab_id: &str, to: u64) {
+        self.move_tab_at(tab_id, to, usize::MAX);
+    }
+
+    /// Same as [`Self::move_tab`], but the tab lands at `index` in the
+    /// destination's strip instead of at the end — a tab dropped at a specific
+    /// spot on another pane's tab strip (#408). `index` is clamped to the
+    /// destination's length, so a stale drop index can never panic.
+    pub fn move_tab_at(&mut self, tab_id: &str, to: u64, index: usize) {
         let from = match self.leaf_of_tab(tab_id) {
             Some(f) => f,
             None => return,
@@ -153,11 +161,32 @@ impl Layout {
             }
         }
         if let Some(dst) = self.leaf_mut(to) {
-            dst.tabs.push(tab_id.to_string());
+            let at = index.min(dst.tabs.len());
+            dst.tabs.insert(at, tab_id.to_string());
             dst.active = tab_id.to_string();
         }
         self.focused = to;
         self.prune();
+    }
+
+    /// Reorder inside one pane's strip: take the tab at `from` and re-insert it at
+    /// `to`, where `to` indexes the strip *with `from` already removed* — the
+    /// insertion index a drag-to-reorder gesture commits on drop (#408). Both
+    /// indices are clamped, so a drag index left over from a stale model can't
+    /// panic. The pane's active tab is untouched: only the display order changes.
+    pub fn move_tab_within(&mut self, leaf_id: u64, from: usize, to: usize) {
+        let Some(leaf) = self.leaf_mut(leaf_id) else {
+            return;
+        };
+        if leaf.tabs.len() < 2 || from >= leaf.tabs.len() {
+            return;
+        }
+        let to = to.min(leaf.tabs.len() - 1);
+        if from == to {
+            return;
+        }
+        let tab = leaf.tabs.remove(from);
+        leaf.tabs.insert(to, tab);
     }
 
     /// Move every tab from `leaf_id` into another existing pane, then collapse
@@ -512,6 +541,111 @@ mod tests {
         rtabs.sort();
         assert_eq!(rtabs, vec!["b".to_string(), "c".to_string()]);
         assert_eq!(ids(&l.flatten(0.0, 0.0, 800.0, 600.0).0).len(), 2);
+    }
+
+    #[test]
+    fn move_tab_at_inserts_at_the_drop_index() {
+        let mut l = Layout::new(
+            vec!["a".into(), "b".into(), "c".into(), "d".into()],
+            "a".into(),
+        );
+        let right = l.split(1, Dir::Horizontal, "d", false).unwrap();
+        l.move_tab("b", right);
+        l.move_tab("c", right);
+        assert_eq!(
+            l.leaf(right).unwrap().tabs,
+            vec!["d".to_string(), "b".to_string(), "c".to_string()]
+        );
+
+        // Dropped between 'd' and 'b' rather than appended.
+        l.move_tab_at("a", right, 1);
+        assert_eq!(
+            l.leaf(right).unwrap().tabs,
+            vec![
+                "d".to_string(),
+                "a".to_string(),
+                "b".to_string(),
+                "c".to_string()
+            ]
+        );
+        assert_eq!(l.leaf(right).unwrap().active, "a");
+        // The source pane emptied, so the split collapsed back to one pane.
+        assert_eq!(l.flatten(0.0, 0.0, 800.0, 600.0).0.len(), 1);
+    }
+
+    #[test]
+    fn move_tab_at_clamps_and_ignores_same_pane() {
+        let mut l = Layout::new(vec!["a".into(), "b".into(), "c".into()], "a".into());
+        let right = l.split(1, Dir::Horizontal, "c", false).unwrap();
+
+        // Way past the end → appended, no panic.
+        l.move_tab_at("a", right, 99);
+        assert_eq!(
+            l.leaf(right).unwrap().tabs,
+            vec!["c".to_string(), "a".to_string()]
+        );
+        // Already in the destination → untouched.
+        l.move_tab_at("a", right, 0);
+        assert_eq!(
+            l.leaf(right).unwrap().tabs,
+            vec!["c".to_string(), "a".to_string()]
+        );
+    }
+
+    #[test]
+    fn move_tab_within_reorders_across_several_slots() {
+        let mut l = Layout::new(
+            vec!["a".into(), "b".into(), "c".into(), "d".into()],
+            "b".into(),
+        );
+
+        // First tab dropped at the end: one drag, three slots.
+        l.move_tab_within(1, 0, 3);
+        assert_eq!(
+            l.leaf(1).unwrap().tabs,
+            vec![
+                "b".to_string(),
+                "c".to_string(),
+                "d".to_string(),
+                "a".to_string()
+            ]
+        );
+        // Last tab dragged back to the front.
+        l.move_tab_within(1, 3, 0);
+        assert_eq!(
+            l.leaf(1).unwrap().tabs,
+            vec![
+                "a".to_string(),
+                "b".to_string(),
+                "c".to_string(),
+                "d".to_string()
+            ]
+        );
+        // The active tab follows the data, not the slot.
+        assert_eq!(l.leaf(1).unwrap().active, "b");
+    }
+
+    #[test]
+    fn move_tab_within_ignores_no_ops_and_bad_indices() {
+        let mut l = Layout::new(vec!["a".into(), "b".into(), "c".into()], "a".into());
+        let before = l.leaf(1).unwrap().tabs.clone();
+
+        l.move_tab_within(1, 1, 1); // same slot
+        l.move_tab_within(1, 9, 0); // stale source index
+        l.move_tab_within(99, 0, 2); // unknown pane
+        assert_eq!(l.leaf(1).unwrap().tabs, before);
+
+        // A target past the end clamps to the last slot instead of panicking.
+        l.move_tab_within(1, 0, 42);
+        assert_eq!(
+            l.leaf(1).unwrap().tabs,
+            vec!["b".to_string(), "c".to_string(), "a".to_string()]
+        );
+
+        // A single-tab strip has nothing to reorder.
+        let mut solo = Layout::new(vec!["only".into()], "only".into());
+        solo.move_tab_within(1, 0, 0);
+        assert_eq!(solo.leaf(1).unwrap().tabs, vec!["only".to_string()]);
     }
 
     #[test]

--- a/ui/app.slint
+++ b/ui/app.slint
@@ -911,12 +911,17 @@ export component AppWindow inherits Window {
     callback tab-closed(string);
     callback new-tab-clicked();
     callback new-window-clicked();   // open another application window (#multi-window)
-    callback tab-reorder(int /* from-index */, int /* dir: -1 left / +1 right */);
     // Per-pane tab actions (v0.5): the int is the pane (leaf) id.
     callback pane-tab-selected(int /* pane-id */, string /* tab-id */);
     callback pane-tab-closed(int /* pane-id */, string /* tab-id */);
     callback pane-new-tab(int /* pane-id */);
-    callback pane-tab-reorder(int /* pane-id */, int /* from */, int /* dir */);
+    // Drag-to-reorder inside a pane's strip (#408), committed once on drop: move
+    // the tab at `from` to `to`, where `to` indexes the list with `from` removed.
+    callback pane-tab-move(int /* pane-id */, int /* from */, int /* to */);
+    // Where a tab dragged in from elsewhere would land in this pane's strip;
+    // -1 when the cursor left it. Rust remembers the last report and uses it when
+    // the drop lands on a tab strip (#408).
+    callback pane-tab-drop-index(int /* pane-id */, int /* index */);
     callback pane-focus(int /* pane-id */);
     callback cycle-tab(bool /* reverse */);
     // Split pane `pane-id`, peeling `tab-id` into a new pane on `dir`
@@ -933,9 +938,21 @@ export component AppWindow inherits Window {
     in-out property <string> tab-rename-id: "";
     in-out property <string> tab-rename-value: "";
     // Drag-to-split (v0.5): cursor moved / dropped while dragging `tab-id`, in
-    // pane-area coordinates. Rust hit-tests the pane + edge zone.
-    callback tab-drag-move(string /* tab-id */, length /* x */, length /* y */);
+    // pane-area coordinates. Rust hit-tests the pane + edge zone. `over-own-strip`
+    // means the source strip is already showing an insertion gap of its own, so no
+    // pane drop-zone must light up (#408).
+    callback tab-drag-move(string /* tab-id */, length /* x */, length /* y */,
+                           bool /* over-own-strip */);
     callback tab-drag-drop(string /* tab-id */, length /* x */, length /* y */);
+    // The drag ended without a drop (pointer grab lost, or an in-strip drag that
+    // landed back on its own slot): clear whatever highlight it put up (#408).
+    callback tab-drag-cancel();
+    // Live tab-drag cursor in pane-area coordinates, republished so every pane's
+    // tab strip can tell whether the drag is hovering over it (#408). Pane rects
+    // come from the model, so the hit-test below needs nothing from the layout.
+    property <bool> tab-drag-live;
+    property <length> tab-drag-px;
+    property <length> tab-drag-py;
     // Drop-zone highlight (set by Rust during a drag): the region the dropped
     // tab's new pane would occupy.
     in property <bool> drag-active;
@@ -1712,25 +1729,42 @@ export component AppWindow inherits Window {
                         can-merge-pane: root.panes.length > 1;
                         tabs: pane.tabs;
                         active-id: pane.active-id;
+                        ext-drag-over: root.tab-drag-live
+                            && root.tab-drag-px >= pane.x
+                            && root.tab-drag-px <= pane.x + pane.w
+                            && root.tab-drag-py >= pane.y
+                            // The strip row is the TabBar's own 36px.
+                            && root.tab-drag-py <= pane.y + 36px;
+                        ext-drag-x: root.tab-drag-px - pane.x;
                         tab-selected(id) => { root.pane-tab-selected(pane.id, id); }
                         tab-closed(id) => { root.pane-tab-closed(pane.id, id); }
                         new-tab() => { root.pane-new-tab(pane.id); }
-                        tab-reorder(from-index, direction) => {
-                            root.pane-tab-reorder(pane.id, from-index, direction);
+                        tab-move(from-index, to-index) => {
+                            root.tab-drag-live = false;
+                            root.pane-tab-move(pane.id, from-index, to-index);
+                        }
+                        drop-index-changed(index) => {
+                            root.pane-tab-drop-index(pane.id, index);
                         }
                         tab-split(id, dir) => { root.pane-split(pane.id, id, dir); }
                         merge-pane() => { root.pane-merge(pane.id); }
                         tab-duplicate(id) => { root.tab-duplicate(id); }
                         tab-rename-request(id) => { root.tab-rename-request(id); }
-                        tab-drag-move(id, ax, ay) => {
-                            root.tab-drag-move(id,
-                                ax - pane-area.absolute-position.x,
-                                ay - pane-area.absolute-position.y);
+                        tab-drag-move(id, ax, ay, own-strip) => {
+                            root.tab-drag-px = ax - pane-area.absolute-position.x;
+                            root.tab-drag-py = ay - pane-area.absolute-position.y;
+                            root.tab-drag-live = true;
+                            root.tab-drag-move(id, root.tab-drag-px, root.tab-drag-py, own-strip);
                         }
                         tab-drag-drop(id, ax, ay) => {
+                            root.tab-drag-live = false;
                             root.tab-drag-drop(id,
                                 ax - pane-area.absolute-position.x,
                                 ay - pane-area.absolute-position.y);
+                        }
+                        tab-drag-cancel() => {
+                            root.tab-drag-live = false;
+                            root.tab-drag-cancel();
                         }
                     }
                 }

--- a/ui/tabs.slint
+++ b/ui/tabs.slint
@@ -13,40 +13,49 @@ export struct TabInfo {
 component SingleTab inherits Rectangle {
     in property <TabInfo> info;
     in property <bool> active;
+    // A ghost is the floating copy that follows the cursor while its original is
+    // being dragged (#408). Purely visual: its TouchArea is off, so it can never
+    // steal the pointer grab from the real tab.
+    in property <bool> ghost: false;
     callback selected();
     callback closed();
     callback duplicated();
-    // Drag-to-reorder (v0.5): emitted while dragging when the tab should hop one
-    // slot left (-1) or right (+1). The model reorders and the tab follows.
-    callback reorder(int /* dir */);
     // Right-click (v0.5): request a context menu at the given absolute position.
     callback context-requested(length /* abs-x */, length /* abs-y */);
-    // Drag-to-split (v0.5): report the absolute cursor while dragging, and the
-    // drop point on release. The parent maps these to pane drop-zones.
+    // Drag lifecycle (#408). The tab only *reports* the gesture; the strip owns
+    // every bit of reorder state and the model is not touched before the drop, so
+    // this element — and with it the pointer grab — survives the whole drag.
+    callback drag-begun(length /* grab-offset */);
     callback drag-moved(length /* abs-x */, length /* abs-y */);
     callback drag-dropped(length /* abs-x */, length /* abs-y */);
+    callback drag-cancelled();
 
     // Where inside the tab the drag began, and whether a drag (vs a click) is in
     // progress. `dragging` suppresses the select-on-release.
     property <length> grab-offset;
     property <bool> pressing;
     out property <bool> dragging;
+    // The dragged original (dimmed in place) and its ghost share the lifted look.
+    property <bool> lifted: root.dragging || root.ghost;
 
     height: 30px;
-    width: clamp(100px, 64px + info.title_len * 7px * Theme.ui-scale, 320px);
-    horizontal-stretch: 0;
     border-radius: Theme.radius-sm;
     border-width: active ? 2px : 0px;
     border-color: active ? Theme.accent : transparent;
-    background: dragging ? Theme.bg-active
+    background: lifted ? Theme.bg-active
         : (active ? Theme.tab-active-bg
         : (touch.has-hover ? Theme.bg-hover : transparent));
     animate background { duration: 120ms; }
+    // Lift the ghost off the strip so it reads as "in hand".
+    drop-shadow-blur: ghost ? 12px : 0px;
+    drop-shadow-color: ghost ? #00000070 : transparent;
 
     // Declared FIRST so the HorizontalLayout's children (close button) are at
     // a higher z-order and receive their own click events.
     touch := TouchArea {
-        mouse-cursor: pointer;
+        // A ghost never takes input: the real tab keeps the grab until the drop.
+        enabled: !root.ghost;
+        mouse-cursor: root.dragging ? move : pointer;
         pointer-event(e) => {
             if (e.kind == PointerEventKind.down && e.button == PointerEventButton.left) {
                 root.grab-offset = self.mouse-x;
@@ -59,9 +68,18 @@ component SingleTab inherits Rectangle {
             } else if (e.kind == PointerEventKind.up) {
                 if (root.pressing && !root.dragging) {
                     root.selected();
-                } else if (root.pressing && root.dragging) {
+                } else if (root.dragging) {
                     root.drag-dropped(self.absolute-position.x + self.mouse-x,
                                       self.absolute-position.y + self.mouse-y);
+                }
+                root.pressing = false;
+                root.dragging = false;
+            } else if (e.kind == PointerEventKind.cancel) {
+                // The grab was taken away (window deactivated, an ancestor
+                // intercepted, the area got disabled). End the gesture without
+                // committing anything so no ghost or highlight is left behind.
+                if (root.dragging) {
+                    root.drag-cancelled();
                 }
                 root.pressing = false;
                 root.dragging = false;
@@ -72,31 +90,16 @@ component SingleTab inherits Rectangle {
                 // A drag begins once the cursor drifts horizontally OR leaves the
                 // tab vertically (so a straight-down drag to split also counts).
                 if (!root.dragging
-                        && (abs(self.mouse-x - root.grab-offset) > 5px
+                        && (abs(self.mouse-x - root.grab-offset) > 4px
                             || self.mouse-y < -6px || self.mouse-y > root.height + 6px)) {
                     root.dragging = true;
+                    root.drag-begun(root.grab-offset);
                 }
-                // Gate everything below on `dragging`: a plain click can emit
-                // tiny `moved` events (macOS), which would otherwise light up
-                // the drop-zone highlight and leave it stuck — no drop ever
-                // follows a click to clear it.
+                // Gate on `dragging`: a plain click can emit tiny `moved` events
+                // (macOS), which would otherwise start a bogus gesture.
                 if (root.dragging) {
-                    // Tell the parent where the cursor is, for drop-to-split zones.
                     root.drag-moved(self.absolute-position.x + self.mouse-x,
                                     self.absolute-position.y + self.mouse-y);
-                    // Reorder within the strip only while the cursor stays on the strip
-                    // row; once it drops into a pane body we hand off to drag-to-split.
-                    // One slot = the tab's own width + the 2px strip spacing; re-anchor
-                    // grab-offset after each hop so the drift resets (no oscillation).
-                    if (self.mouse-y > -10px && self.mouse-y < root.height + 10px) {
-                        if (self.mouse-x - root.grab-offset > (root.width + 2px) / 2) {
-                            root.reorder(1);
-                            root.grab-offset = self.mouse-x - (root.width + 2px);
-                        } else if (self.mouse-x - root.grab-offset < -(root.width + 2px) / 2) {
-                            root.reorder(-1);
-                            root.grab-offset = self.mouse-x + (root.width + 2px);
-                        }
-                    }
                 }
             }
         }
@@ -134,7 +137,7 @@ component SingleTab inherits Rectangle {
     }
 
     // Keep close pinned to the far right even when the title is very short.
-    if info.kind != "welcome" : IconButton {
+    if info.kind != "welcome" && !ghost : IconButton {
         glyph: "×";
         size: 20px;
         x: parent.width - self.width - 6px;
@@ -179,11 +182,23 @@ export component TabBar inherits Rectangle {
     // Keep this much clear on the right so tabs don't slide under the app's
     // top-right toolbar icons, which are positioned over the tab row (#122).
     in property <length> reserve-right: 0px;
+    // Window-wide tab-drag hand-off (#408). The window root hit-tests the live
+    // drag against each pane's rect (pure model data) and hands the hovering strip
+    // the cursor in its own coordinates, so this strip can offer an insertion index
+    // for a tab dropped in from another pane. Keeping the hit-test out of here
+    // matters: every binding a `changed` handler depends on must stay free of
+    // layout results, or its eager first evaluation recurses into the very layout
+    // that is creating this component.
+    in property <bool> ext-drag-over: false;
+    in property <length> ext-drag-x;
+
     callback tab-selected(string);
     callback tab-closed(string);
     callback new-tab();
-    // Drag-to-reorder: move the tab at `from` one slot in `dir` (#v0.5).
-    callback tab-reorder(int /* from */, int /* dir */);
+    // Drag-to-reorder (#408), committed exactly once on drop: move the tab at
+    // `from` to `to`, where `to` is the insertion index AFTER `from` has been
+    // removed from the list.
+    callback tab-move(int /* from */, int /* to */);
     // Split this pane, peeling `tab-id` into a new pane on `dir` (#v0.5).
     callback tab-split(string /* tab-id */, string /* dir */);
     // Open another connection to the same session as `tab-id` (#v0.5).
@@ -192,9 +207,17 @@ export component TabBar inherits Rectangle {
     callback tab-rename-request(string /* tab-id */);
     callback merge-pane();
     // Drag-to-split (#v0.5): cursor moved / dropped while dragging `tab-id`, in
-    // absolute (window) coordinates.
-    callback tab-drag-move(string /* tab-id */, length /* abs-x */, length /* abs-y */);
+    // absolute (window) coordinates. `over-own-strip` tells Rust that this strip
+    // is showing its own insertion gap, so no pane drop-zone must light up.
+    callback tab-drag-move(string /* tab-id */, length /* abs-x */, length /* abs-y */,
+                           bool /* over-own-strip */);
     callback tab-drag-drop(string /* tab-id */, length /* abs-x */, length /* abs-y */);
+    // The gesture ended without a drop (grab lost / nothing to commit): drop any
+    // highlight the drag put up.
+    callback tab-drag-cancel();
+    // Insertion index this strip offers for a tab dragged in from another pane;
+    // -1 while the cursor is somewhere else (#408).
+    callback drop-index-changed(int);
 
     // Right-click context-menu state.
     property <length> menu-x;
@@ -204,6 +227,120 @@ export component TabBar inherits Rectangle {
     height: 36px;
     background: Theme.bg-panel-alt;
 
+    // Width of a tab, from its title length. Shared by the strip's slots and the
+    // drag ghost so the two agree pixel-for-pixel.
+    pure function tab-width(len: int) -> length {
+        return clamp(100px, 64px + len * 7px * Theme.ui-scale, 320px);
+    }
+
+    // --- Drag-to-reorder state (#408) --------------------------------------
+    // Nothing here touches the model: the slots stay exactly where they are for
+    // the whole gesture, which is what keeps the dragged tab's pointer grab (and
+    // therefore the drag) alive across any number of slots. Only the drop commits.
+    //
+    // Everything a `changed` handler below can reach must be computable without
+    // asking the layout for a position — those handlers are evaluated eagerly when
+    // a slot is created, which happens *inside* the layout pass, so a peek at
+    // `x` / `width` / `absolute-position` there recurses. Hence the cursor arrives
+    // pre-converted from the event handler (where reading geometry is safe) and
+    // every tracked binding short-circuits on a plain flag first.
+    property <bool> drag-active;
+    property <int> drag-from: -1;
+    // Insertion index in the "dragged tab removed" list; see `tab-move`.
+    property <int> drag-to: -1;
+    property <length> drag-width;
+    property <length> grab-offset;
+    // Cursor relative to this bar's top-left, and whether it is still on the strip
+    // row. Both are written by `drag-move` rather than bound, to keep them (and the
+    // tracked bindings that read them) independent of the layout.
+    property <length> cursor-x;
+    property <length> cursor-y;
+    property <bool> over-strip;
+    property <bool> reordering: root.drag-active && root.drag-from >= 0 && root.over-strip;
+    // Cursor in strip-content space: past the bar's 3px padding and through the
+    // scroll offset. A binding, not a stored value, so edge auto-scrolling keeps
+    // the ghost and the insertion index live while the pointer stands still.
+    property <length> content-x: root.cursor-x - 3px - flick.viewport-x;
+    // Ghost's left edge, clamped to the visible part of the strip so it can never
+    // be dragged out of sight. Only ever evaluated while a drag is live.
+    property <length> ghost-x: clamp(root.content-x - root.grab-offset,
+        -flick.viewport-x,
+        max(-flick.viewport-x, -flick.viewport-x + flick.width - root.drag-width));
+
+    function begin-drag(index: int, offset: length, slot-width: length) {
+        root.drag-from = index;
+        root.drag-to = index;
+        root.grab-offset = offset;
+        root.drag-width = slot-width;
+        root.drag-active = true;
+    }
+
+    function end-drag() {
+        root.drag-active = false;
+        root.over-strip = false;
+        root.drag-from = -1;
+        root.drag-to = -1;
+    }
+
+    // Absolute cursor -> bar-local. Safe here: an event handler runs with the
+    // layout settled, unlike the bindings above.
+    function track-cursor(ax: length, ay: length) {
+        root.cursor-x = ax - root.absolute-position.x;
+        root.cursor-y = ay - root.absolute-position.y;
+        root.over-strip = root.cursor-x >= 0px && root.cursor-x <= root.width
+            && root.cursor-y >= -10px && root.cursor-y <= root.height + 10px;
+    }
+
+    function drag-move(id: string, ax: length, ay: length) {
+        root.track-cursor(ax, ay);
+        // Reported for every move, in or out of the strip: Rust needs it to track
+        // the cross-window merge target, and the window root republishes it to the
+        // other panes' strips.
+        root.tab-drag-move(id, ax, ay, root.reordering);
+    }
+
+    function drag-drop(id: string, ax: length, ay: length) {
+        root.track-cursor(ax, ay);
+        if (root.reordering) {
+            if (root.drag-to >= 0 && root.drag-to != root.drag-from) {
+                root.tab-move(root.drag-from, root.drag-to);
+            } else {
+                root.tab-drag-cancel();
+            }
+        } else {
+            root.tab-drag-drop(id, ax, ay);
+        }
+        root.end-drag();
+    }
+
+    // Visual let-in: a tab the dragged one has moved past slides over by one slot,
+    // opening the gap it will land in. Each slot decides on its own — the run of
+    // "passed" slots is exactly the run that has to move — so no reduction over the
+    // strip is needed for the animation.
+    pure function slot-shift(i: int, passed: bool) -> length {
+        if (!root.reordering || i == root.drag-from) {
+            return 0px;
+        }
+        if (i > root.drag-from) {
+            return passed ? -(root.drag-width + 2px) : 0px;
+        }
+        return passed ? 0px : root.drag-width + 2px;
+    }
+
+    // --- Insertion index for a tab dragged in from another pane (#408) ------
+    property <bool> ext-hover: root.ext-drag-over && !root.drag-active;
+    property <length> ext-content-x: root.ext-drag-x - 3px - flick.viewport-x;
+    property <int> ext-index: -1;
+    changed ext-hover => {
+        root.ext-index = root.ext-hover ? 0 : -1;
+        root.drop-index-changed(root.ext-index);
+    }
+    changed ext-index => {
+        if (root.ext-hover) {
+            root.drop-index-changed(root.ext-index);
+        }
+    }
+
     // True only when the tabs are wider than the available strip width (#122).
     // Computed from the TabBar's own width (set by the parent), not flick.width,
     // so showing the arrows (which shrink the flickable) can't feed back into this
@@ -211,34 +348,108 @@ export component TabBar inherits Rectangle {
     property <bool> tab-overflow:
         strip.preferred-width > root.width - root.reserve-right - 64px;
 
+    // Drag past either end of an overflowing strip to scroll it (Chrome-style).
+    // `!reordering` first, and a single read of `flick.width`, so this stays out of
+    // the layout while idle: the Timer evaluates `running` eagerly.
+    property <length> edge-step:
+        !root.reordering || !root.tab-overflow ? 0px
+        : (root.cursor-x - 3px < 24px ? -6px
+        : (root.cursor-x - 3px > flick.width - 24px ? 6px : 0px));
+    Timer {
+        interval: 16ms;
+        running: root.edge-step != 0px;
+        triggered => {
+            flick.viewport-x = clamp(flick.viewport-x - root.edge-step,
+                min(0px, flick.width - flick.viewport-width), 0px);
+        }
+    }
+
     HorizontalLayout {
         padding: 3px;
         spacing: 2px;
 
         // Horizontally-scrollable strip: when the tabs overflow the available
-        // width they stay reachable by the arrows or by dragging / trackpad (#122).
+        // width they stay reachable by the arrows or the wheel (#122).
         flick := Flickable {
+            // Non-interactive on purpose (#408): an interactive Flickable delays
+            // the press to its children by 100ms and, once the tabs overflow,
+            // steals the gesture as soon as it travels 8px — which cancelled the
+            // tab drag and scrolled the strip instead. Wheel / trackpad scrolling
+            // is unaffected (the Flickable still handles wheel events), and the
+            // arrows below remain.
+            interactive: false;
             horizontal-stretch: 1;
             viewport-height: self.height;
             viewport-width: max(self.width, strip.preferred-width);
             strip := HorizontalLayout {
                 spacing: 2px;
                 alignment: start;
-                for tab[i] in tabs : SingleTab {
-                    info: tab;
-                    active: tab.id == root.active-id;
-                    selected => { root.tab-selected(tab.id); }
-                    closed => { root.tab-closed(tab.id); }
-                    duplicated => { root.tab-duplicate(tab.id); }
-                    reorder(dir) => { root.tab-reorder(i, dir); }
-                    context-requested(ax, ay) => {
-                        root.menu-target = tab.id;
-                        root.menu-x = ax - root.absolute-position.x;
-                        root.menu-y = ay - root.absolute-position.y;
-                        tab-menu.show();
+                // The slot owns the geometry and never moves during a drag; the
+                // tab inside it is what slides. A layout child cannot have its `x`
+                // set (the layout owns it), hence this wrapper.
+                for tab[i] in tabs : Rectangle {
+                    width: root.tab-width(tab.title_len);
+                    horizontal-stretch: 0;
+                    // Index in the list with the dragged tab removed.
+                    property <int> shifted-index: i < root.drag-from ? i : i - 1;
+                    // Has the ghost's leading edge passed this slot's midpoint in
+                    // the "dragged tab removed" layout? That layout depends only on
+                    // `drag-from`, never on `drag-to`, so the decision can never
+                    // feed back into the let-in animation and oscillate. `self.x` is
+                    // the slot's offset inside the strip, i.e. content space.
+                    property <bool> passed: root.reordering && i != root.drag-from
+                        && root.ghost-x > self.x + self.width / 2
+                            - (i > root.drag-from ? root.drag-width + 2px : 0px);
+                    // Exactly the leading run of slots is "passed", so pushing the
+                    // max/min of the crossed boundaries converges on the insertion
+                    // index however many slots a single move event skipped over.
+                    changed passed => {
+                        if (i != root.drag-from) {
+                            if (self.passed) {
+                                root.drag-to = max(root.drag-to, self.shifted-index + 1);
+                            } else {
+                                root.drag-to = min(root.drag-to, self.shifted-index);
+                            }
+                        }
                     }
-                    drag-moved(ax, ay) => { root.tab-drag-move(tab.id, ax, ay); }
-                    drag-dropped(ax, ay) => { root.tab-drag-drop(tab.id, ax, ay); }
+                    // Same rule for a tab dragged in from another pane, minus the
+                    // removal (nothing leaves this strip).
+                    property <bool> ext-passed:
+                        root.ext-hover && root.ext-content-x > self.x + self.width / 2;
+                    changed ext-passed => {
+                        if (self.ext-passed) {
+                            root.ext-index = max(root.ext-index, i + 1);
+                        } else {
+                            root.ext-index = min(root.ext-index, i);
+                        }
+                    }
+
+                    SingleTab {
+                        x: root.slot-shift(i, parent.passed);
+                        width: parent.width;
+                        height: parent.height;
+                        // The dragged tab leaves a hole; the ghost carries it.
+                        opacity: root.reordering && i == root.drag-from ? 0.0 : 1.0;
+                        animate x { duration: 120ms; easing: ease-out; }
+                        info: tab;
+                        active: tab.id == root.active-id;
+                        selected => { root.tab-selected(tab.id); }
+                        closed => { root.tab-closed(tab.id); }
+                        duplicated => { root.tab-duplicate(tab.id); }
+                        context-requested(ax, ay) => {
+                            root.menu-target = tab.id;
+                            root.menu-x = ax - root.absolute-position.x;
+                            root.menu-y = ay - root.absolute-position.y;
+                            tab-menu.show();
+                        }
+                        drag-begun(offset) => { root.begin-drag(i, offset, parent.width); }
+                        drag-moved(ax, ay) => { root.drag-move(tab.id, ax, ay); }
+                        drag-dropped(ax, ay) => { root.drag-drop(tab.id, ax, ay); }
+                        drag-cancelled => {
+                            root.end-drag();
+                            root.tab-drag-cancel();
+                        }
+                    }
                 }
                 if root.show-new-tab : IconButton {
                     glyph: "+";
@@ -246,6 +457,20 @@ export component TabBar inherits Rectangle {
                     y: (parent.height - self.height) / 2;
                     clicked => { root.new-tab(); }
                 }
+            }
+
+            // The dragged tab's floating copy. It lives in the Flickable (so its x
+            // is already in content space and it is clipped to the strip) and is
+            // declared after `strip`, which puts it on top — Slint's `z` is a
+            // compile-time constant, so stacking has to come from declaration order.
+            if root.reordering && root.drag-from < root.tabs.length : SingleTab {
+                ghost: true;
+                info: root.tabs[root.drag-from];
+                active: root.tabs[root.drag-from].id == root.active-id;
+                x: root.ghost-x;
+                y: 0px;
+                width: root.drag-width;
+                height: 30px;
             }
         }
 


### PR DESCRIPTION
- 拖动期间不再改动 model：被拖标签原位留空，浮层跟随光标，其余标签动画让位，松手时一次性提交最终位置。此前每跳一格就刷新标签模型，重建了正在按住的元素、指针 grab 随即失效，因此一次拖动只能和相邻标签换一次位置
- 标签条 Flickable 改为 interactive: false：它此前把按下事件延迟 100ms 才转发给标签，并在标签溢出后只要移动 8px 就抢走手势去滚动条带，是拖动"很不流畅"的另一个根因；滚轮横滚与左右箭头保持可用
- 插入位置按"移除被拖标签后的布局"逐槽判定，只依赖起始索引而不依赖当前目标，宽窄不一的标签也不会来回抖动；标签溢出时拖到条带左右边缘会自动滚动
- 拖到另一个窗格的标签条上时按落点插入，不再一律追加到末尾（新增 Layout::move_tab_at 与 move_tab_within，含单元测试）
- 补上 PointerEventKind.cancel 处理和 tab-drag-cancel 回调：grab 被抢走后不再残留浮层与 drop-zone 高亮
- pane-tab-reorder(pane, from, dir) 改为 pane-tab-move(pane, from, to)，并删除分屏化后已无人使用的 tab-reorder 回调

实现[标签页可支持跨多标签拖动](https://github.com/yituorou/meatshell/issues/408)