### PR TITLE
fix(terminal): 多行粘贴确认后恢复终端焦点

### DIFF
--- a/ui/app.slint
+++ b/ui/app.slint
@@ -883,6 +883,7 @@ export component AppWindow inherits Window {
     in-out property <string> paste-confirm-text;
     in-out property <string> paste-confirm-preview;
     in-out property <bool> paste-confirm-large: false;
+    property <int> terminal-focus-sequence;
     callback paste-confirmed(string /* tab-id */);
     callback paste-confirm-cancelled();
     callback connect-session(string /* session-id */);
@@ -1882,6 +1883,7 @@ export component AppWindow inherits Window {
                         quick-external-command: root.quick-external-command;
                         quick-external-send-enter: root.quick-external-send-enter;
                         quick-external-sequence: root.quick-external-sequence;
+                        focus-sequence: root.terminal-focus-sequence;
                         command-history: root.command-history;
                         history-view: root.history-view;
                         run-command(cmd, all) => { root.run-command(term.id, cmd, all); }
@@ -4375,10 +4377,12 @@ export component AppWindow inherits Window {
         confirm => {
             root.paste-confirmed(root.paste-confirm-tab);
             root.paste-confirm-open = false;
+            root.terminal-focus-sequence += 1;
         }
         cancel => {
             root.paste-confirm-cancelled();
             root.paste-confirm-open = false;
+            root.terminal-focus-sequence += 1;
         }
     }
 

--- a/ui/terminal_view.slint
+++ b/ui/terminal_view.slint
@@ -245,6 +245,7 @@ export component TerminalView inherits Rectangle {
     in property <string> quick-external-command;
     in property <bool> quick-external-send-enter;
     in property <int> quick-external-sequence;
+    in property <int> focus-sequence;
     in property <string> tab-id;
     in property <string> status-line: @tr("Not connected");
     in property <[TermSpan]> spans;     // coloured runs of the visible screen
@@ -430,6 +431,12 @@ export component TerminalView inherits Rectangle {
                 cmd-input.text = root.quick-external-command;
                 cmd-input.focus();
             }
+        }
+    }
+
+    changed focus-sequence => {
+        if (root.active) {
+            root.focus-pending = true;
         }
     }
 


### PR DESCRIPTION
## 问题描述

粘贴多行内容时显示的确认框按下 Enter 之后，多行内容可以正常写入终端，但键盘焦点还在已经关闭的确认框上...

所以得点两下 Enter 才能执行命令，用起来有点麻烦..

## 原因

多行粘贴确认框为了支持 Enter 确认，会主动取得焦点

确认框关闭之后原有的逻辑只负责发送粘贴内容，没有通知终端重新取得焦点

## 修复内容

- 确认或取消粘贴后，向终端发送一次焦点恢复请求
- 仅由当前活动终端响应该请求
- 复用已有的延迟聚焦机制，在下一次事件循环中恢复隐藏的终端输入框焦点

## 修复后

粘贴多行命令后可以连续按两次 Enter 会发生：

1. 第一次确认粘贴
2. 第二次执行命令

手点粘贴按钮或取消后，终端输入焦点也一样会恢复