### PR TITLE
fix: 命令输入栏文字垂直偏移

### DIFF
--- a/ui/terminal_view.slint
+++ b/ui/terminal_view.slint
@@ -1372,7 +1372,7 @@ export component TerminalView inherits Rectangle {
                             color: Theme.text-primary;
                             font-family: Theme.ui-font-family;
                             font-size: Theme.fs-md;
-                            vertical-alignment: top;
+                            vertical-alignment: center;
                             wrap: char-wrap;
                             page-height: command-scroll.visible-height;
                             cursor-position-changed(position) => {


### PR DESCRIPTION
将命令输入框的 vertical-alignment 从 top 改为 center，使输入命令在输入栏中垂直居中。
修复[命令输入栏中输入的命令存在偏离](https://github.com/yituorou/meatshell/issues/426)