### PR TITLE
feat(dock): stacked dock panels sharing one window edge / 停靠面板同边堆叠

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -23,6 +23,7 @@ mod sidebar;
 mod single_instance;
 mod tab_callbacks;
 mod tab_transfer;
+mod dock_stacks;
 mod terminal_ui;
 mod webdav;
 mod window;
@@ -38,6 +39,7 @@ use self::session_runtime::*;
 use self::sftp_callbacks::*;
 use self::sftp_ui::*;
 use self::sidebar::*;
+use self::dock_stacks::*;
 use self::tab_callbacks::*;
 use self::tab_transfer::*;
 use self::terminal_ui::*;
@@ -1711,6 +1713,39 @@ fn open_window(
     }));
     let content_size: Rc<std::cell::Cell<(f32, f32)>> =
         Rc::new(std::cell::Cell::new((1200.0, 800.0)));
+
+    // Docked-panel edge stacks (#dock-stack): which window panels share an edge
+    // at the same time. Restored from config and applied to the panel dock /
+    // collapse state below, so a persisted stacked layout survives restart
+    // even before the stacked renderer lights up.
+    let dock_stacks: Rc<RefCell<DockStacks>> = Rc::new(RefCell::new(DockStacks::default()));
+    {
+        let saved = store.borrow().dock_stacks();
+        {
+            let mut ds = dock_stacks.borrow_mut();
+            ds.from_saved(&saved);
+        }
+        for e in &saved {
+            for s in &e.slots {
+                let edge: slint::SharedString = e.edge.clone().into();
+                match s.kind.as_str() {
+                    "sidebar" => {
+                        window.set_sidebar_dock(edge.clone());
+                        window.set_sidebar_collapsed(false);
+                    }
+                    "welcome" => {
+                        window.set_welcome_sidebar_dock(edge.clone());
+                        window.set_welcome_collapsed(false);
+                    }
+                    "quick" => {
+                        window.set_quick_panel_dock(edge.clone());
+                        window.set_quick_panel_collapsed(false);
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
     // Persistent pane / splitter models. refresh_panes updates these IN PLACE so
     // the rendered `for pane` / `for sp` elements are reused (terminals survive,
     // and the splitter keeps its pointer-grab during a drag).
@@ -1718,6 +1753,123 @@ fn open_window(
     window.set_panes(ModelRc::from(panes_model.clone()));
     let splitters_model: Rc<VecModel<SplitterInfo>> = Rc::new(VecModel::default());
     window.set_splitters(ModelRc::from(splitters_model.clone()));
+    // The dock-area frame in logical px (window minus title bar), reported by
+    // Slint via dock-area-resized. Rust must lay panels out in THIS frame; the
+    // default matches the legacy dock-central-w/h defaults so the very first
+    // pre-show pass already yields sane geometry.
+    let da_size: Rc<std::cell::Cell<(f32, f32)>> = Rc::new(std::cell::Cell::new((1200.0, 800.0)));
+    // Docked-panel stack models (#dock-stack): absolute rects for every
+    // expanded panel + the dividers between stacked ones. Kept IN PLACE so the
+    // panel components reuse their instances (draft/scroll state survives).
+    let dock_panels_model: Rc<VecModel<PanelGeomInfo>> = Rc::new(VecModel::default());
+    window.set_dock_panels(ModelRc::from(dock_panels_model.clone()));
+    let dock_dividers_model: Rc<VecModel<DividerGeomInfo>> = Rc::new(VecModel::default());
+    window.set_dock_dividers(ModelRc::from(dock_dividers_model.clone()));
+    // First dock-geometry pass after restore; `dock-layout-changed()` keeps it
+    // fresh whenever a panel docks, resizes or collapses.
+    refresh_dock(
+        &window,
+        &dock_stacks,
+        &dock_panels_model,
+        &dock_dividers_model,
+        da_size.get(),
+    );
+    // Any dock/collapse/size change anywhere wants the geometry recomputed.
+    {
+        let weak = window.as_weak();
+        let ds = dock_stacks.clone();
+        let pm = dock_panels_model.clone();
+        let dm = dock_dividers_model.clone();
+        let da = da_size.clone();
+        window.on_dock_layout_changed(move || {
+            if let Some(w) = weak.upgrade() {
+                refresh_dock(&w, &ds, &pm, &dm, da.get());
+            }
+        });
+        // The dock-area frame itself: window resizes change it without any
+        // panel event, and `rest` no longer tracks parent sizes, so this is
+        // the trigger that keeps the whole layout following the window. (Zen
+        // toggles come through `dock-layout-changed` instead — the frame does
+        // not resize there.)
+        let weak4 = window.as_weak();
+        let ds4 = dock_stacks.clone();
+        let pm4 = dock_panels_model.clone();
+        let dm4 = dock_dividers_model.clone();
+        let da4 = da_size.clone();
+        window.on_dock_area_resized(move |w: f32, h: f32| {
+            let next = (w.max(1.0), h.max(1.0));
+            if da4.get() == next {
+                return;
+            }
+            da4.set(next);
+            if let Some(win) = weak4.upgrade() {
+                refresh_dock(&win, &ds4, &pm4, &dm4, next);
+            }
+        });
+        // Dragging a divider between two stacked panels updates their ratio.
+        let weak2 = window.as_weak();
+        let ds2 = dock_stacks.clone();
+        let pm2 = dock_panels_model.clone();
+        let dm2 = dock_dividers_model.clone();
+        let da2 = da_size.clone();
+        window.on_stack_split_drag(move |edge: SharedString, index: i32, pos: f32| {
+            let edge = edge.to_string();
+            // Slint reports divider drags in dock-area coordinates, so the
+            // axis must be the dock-area extent, not the window's.
+            let (w, h) = da2.get();
+            let axis = match edge.as_str() {
+                "left" | "right" => h,
+                _ => w,
+            };
+            let ratio = if axis > 0.0 {
+                (pos / axis).clamp(0.02, 0.98)
+            } else {
+                0.5
+            };
+            {
+                let mut lay = ds2.borrow_mut();
+                lay.set_ratio(&edge, index as usize, ratio);
+            }
+            if let Some(w) = weak2.upgrade() {
+                refresh_dock(&w, &ds2, &pm2, &dm2, da2.get());
+            }
+        });
+        // Dragging a stacked panel's in-edge handle resizes it along the dock
+        // normal and re-runs the geometry pass.
+        let weak3 = window.as_weak();
+        let ds3 = dock_stacks.clone();
+        let pm3 = dock_panels_model.clone();
+        let dm3 = dock_dividers_model.clone();
+        let da3 = da_size.clone();
+        let panels_model_for_extent = dock_panels_model.clone();
+        window.on_panel_extent_drag(
+            move |_panel_index: i32, pos: f32| {
+                let panel = panels_model_for_extent.row_data(_panel_index as usize);
+                if let Some(p) = panel {
+                    let kind = p.kind.to_string();
+                    let edge = p.edge.to_string();
+                    let horizontal_edge = matches!(edge.as_str(), "left" | "right");
+                    let thickness = pos.clamp(MIN_THICK, 2600.0);
+                    if let Some(w) = weak3.upgrade() {
+                        match (kind.as_str(), horizontal_edge) {
+                            ("sidebar", true) => w.set_sidebar_width(thickness),
+                            ("sidebar", false) => w.set_sidebar_height(thickness),
+                            ("welcome", _) => w.set_welcome_sidebar_width(thickness),
+                            ("quick", true) => w.set_quick_panel_width(thickness),
+                            ("quick", false) => w.set_quick_panel_height(thickness),
+                            _ => {}
+                        }
+                        refresh_dock(&w, &ds3, &pm3, &dm3, da3.get());
+                    }
+                }
+            },
+        );
+    }
+    // Snapshot the layout and drop the RefCell guard before mutating Slint
+    // models: a model change can synchronously run binding callbacks, and one
+    // of those re-entering `layout.borrow*()` while this shared guard is still
+    // alive would panic (RefCell already borrowed) → abort in release.
+    let lay = layout.borrow().clone();
     refresh_panes(
         &window,
         &layout.borrow(),
@@ -1733,6 +1885,10 @@ fn open_window(
         let tabs_model = tabs_model.clone();
         let panes_model = panes_model.clone();
         let splitters_model = splitters_model.clone();
+        let cr_dock = dock_stacks.clone();
+        let cr_pm = dock_panels_model.clone();
+        let cr_dm = dock_dividers_model.clone();
+        let cr_da = da_size.clone();
         window.on_content_resized(move |w: f32, h: f32| {
             let next = (w.max(1.0), h.max(1.0));
             if content_size.get() == next {
@@ -1740,6 +1896,7 @@ fn open_window(
             }
             content_size.set(next);
             if let Some(win) = weak.upgrade() {
+                let lay = layout.borrow().clone();
                 refresh_panes(
                     &win,
                     &layout.borrow(),
@@ -1748,6 +1905,7 @@ fn open_window(
                     &panes_model,
                     &splitters_model,
                 );
+                refresh_dock(&win, &cr_dock, &cr_pm, &cr_dm, cr_da.get());
             }
         });
     }
@@ -1761,6 +1919,10 @@ fn open_window(
         let tabs_model = tabs_model.clone();
         let panes_model = panes_model.clone();
         let splitters_model = splitters_model.clone();
+        let wds_dock = dock_stacks.clone();
+        let wds_pm = dock_panels_model.clone();
+        let wds_dm = dock_dividers_model.clone();
+        let wds_da = da_size.clone();
         window.on_set_welcome_as_sidebar(move |v| {
             // The property is two-way-bound through InterfacePanel and changing
             // it destroys/recreates the Welcome subtree that owns the Switch.
@@ -1781,6 +1943,10 @@ fn open_window(
             let tabs_model = tabs_model.clone();
             let panes_model = panes_model.clone();
             let splitters_model = splitters_model.clone();
+            let wds_dock = wds_dock.clone();
+            let wds_pm = wds_pm.clone();
+            let wds_dm = wds_dm.clone();
+            let wds_da = wds_da.clone();
             slint::Timer::single_shot(std::time::Duration::ZERO, move || {
                 if let Some(w) = weak.upgrade() {
                     w.set_welcome_as_sidebar(v);
@@ -1796,6 +1962,7 @@ fn open_window(
                         &panes_model,
                         &splitters_model,
                     );
+                    refresh_dock(&w, &wds_dock, &wds_pm, &wds_dm, wds_da.get());
                 }
             });
         });
@@ -1930,6 +2097,7 @@ fn open_window(
             net_hist: local_net_hist.clone(),
             follow_cd: sftp_follow_cd.clone(),
             layout: layout.clone(),
+            dock_stacks: dock_stacks.clone(),
             tabs_model: tabs_model.clone(),
             terminals_model: terminals_model.clone(),
             panes_model: panes_model.clone(),
@@ -2549,6 +2717,7 @@ fn open_window(
         let ev_exit_confirmed = exit_confirmed.clone();
         let ev_registry = registry.clone();
         let ev_core = core.clone();
+        let ev_ds = dock_stacks.clone();
         let ev_window_size_tracking_ready = window_size_tracking_ready.clone();
         let ev_pending_window_size_restore = pending_window_size_restore.clone();
         let mut last_cursor_logical: Option<(f32, f32)> = None;
@@ -2886,7 +3055,7 @@ fn open_window(
                         ev_exit_confirmed.set(true);
                         // No sessions → the window is about to close; persist layout.
                         if let Some(win) = weak.upgrade() {
-                            save_layout(&win, &ev_store);
+                            save_layout(&win, &ev_store, &ev_ds);
                             clear_zen_on_close(&win, &ev_store);
                         }
                         // The event is not prevented, so Slint will destroy this
@@ -2917,6 +3086,7 @@ fn open_window(
         let proc_weak = proc_win.as_weak();
         let sys_weak = sys_win.as_weak();
         let cc_store = store.clone();
+        let cc_ds = dock_stacks.clone();
         let close_handles = handles.clone();
         let close_sftp_handles = sftp_handles.clone();
         let close_exit_confirmed = exit_confirmed.clone();
@@ -2930,7 +3100,7 @@ fn open_window(
             }
             if let Some(w) = weak.upgrade() {
                 w.set_confirm_close_open(false);
-                save_layout(&w, &cc_store);
+                save_layout(&w, &cc_store, &cc_ds);
                 clear_zen_on_close(&w, &cc_store);
                 let _ = w.hide();
             }
@@ -2983,6 +3153,7 @@ fn open_window(
         let wc_proc_weak = proc_win.as_weak();
         let wc_sys_weak = sys_win.as_weak();
         let wc_store = store.clone();
+        let wc_ds = dock_stacks.clone();
         let wc_exit_confirmed = exit_confirmed.clone();
         let wc_registry = registry.clone();
         let wc_core = core.clone();
@@ -2992,7 +3163,7 @@ fn open_window(
                 if !should_block_close(wc_exit_confirmed.get(), !close_handles.borrow().is_empty())
                 {
                     wc_exit_confirmed.set(true);
-                    save_layout(&w, &wc_store);
+                    save_layout(&w, &wc_store, &wc_ds);
                     clear_zen_on_close(&w, &wc_store);
                     // Tear down this window's workers and hide its monitor
                     // windows; quit only if it was the last one.
@@ -4919,7 +5090,11 @@ fn wire_session_callbacks(
 
 /// Resolve a session's configured SSH jump host to the saved session it points
 /// at, ignoring a missing / dangling / self reference (#211).
-fn save_layout(win: &AppWindow, store: &Rc<RefCell<ConfigStore>>) {
+fn save_layout(
+    win: &AppWindow,
+    store: &Rc<RefCell<ConfigStore>>,
+    dock_stacks: &Rc<RefCell<DockStacks>>,
+) {
     let scale = win.window().scale_factor().max(0.01);
     let size = win.window().size();
     let w = size.width as f32 / scale;
@@ -4937,6 +5112,8 @@ fn save_layout(win: &AppWindow, store: &Rc<RefCell<ConfigStore>>) {
     s.set_quick_panel_width(win.get_quick_panel_width());
     s.set_quick_panel_height(win.get_quick_panel_height());
     s.set_quick_panel_dock(win.get_quick_panel_dock().to_string());
+    // Per-edge stacked panels (#dock-stack), ratios included.
+    s.set_dock_stacks(dock_stacks.borrow().to_saved());
     s.set_welcome_sidebar_width(win.get_welcome_sidebar_width());
     s.set_welcome_sidebar_dock(win.get_welcome_sidebar_dock().to_string());
     s.set_welcome_collapsed(win.get_welcome_collapsed());
@@ -5122,6 +5299,199 @@ fn refresh_panes(
             window.set_active_tab_id(fp.active.clone().into());
         }
     }
+}
+
+// --- Docked-panel edge stacks (#dock-stack) --------------------------------
+
+/// The edge (left|right|top|bottom) a window panel is currently expanded on,
+/// `None` when folded, closed, or off (welcome not in sidebar mode).
+fn panel_edge(window: &AppWindow, kind: &str) -> Option<&'static str> {
+    let norm = |edge: &str| -> &'static str {
+        match edge {
+            "right" => "right",
+            "top" => "top",
+            "bottom" => "bottom",
+            _ => "left",
+        }
+    };
+    match kind {
+        "sidebar" => {
+            (!window.get_sidebar_collapsed()).then(|| norm(window.get_sidebar_dock().as_str()))
+        }
+        "welcome" => {
+            (window.get_welcome_as_sidebar() && !window.get_welcome_collapsed())
+                .then(|| norm(window.get_welcome_sidebar_dock().as_str()))
+        }
+        "quick" => {
+            (window.get_quick_panel_open() && !window.get_quick_panel_collapsed())
+                .then(|| norm(window.get_quick_panel_dock().as_str()))
+        }
+        _ => None,
+    }
+}
+
+/// A panel's preferred thickness along its edge's normal: width on a
+/// left/right edge, height on a top/bottom one (logical px).
+fn panel_extent(window: &AppWindow, kind: &str) -> f32 {
+    let horizontal_edge = matches!(panel_edge(window, kind), Some("left" | "right"));
+    match kind {
+        "sidebar" if horizontal_edge => window.get_sidebar_width(),
+        "sidebar" => window.get_sidebar_height(),
+        "welcome" => window.get_welcome_sidebar_width(),
+        "quick" if horizontal_edge => window.get_quick_panel_width(),
+        "quick" => window.get_quick_panel_height(),
+        _ => 220.0,
+    }
+}
+
+/// Whether the edge shows a 36px collapsed-panel ToolStrip band: any panel
+/// whose folded form docks there (welcome counts only in sidebar mode, where
+/// its strip actually renders). Multiple folded panels on one edge merge
+/// into a single band, hence the boolean.
+fn strip_on_edge(window: &AppWindow, edge: &str) -> bool {
+    let docks = |s: slint::SharedString| s.as_str() == edge;
+    (window.get_sidebar_collapsed() && docks(window.get_sidebar_dock()))
+        || (window.get_welcome_as_sidebar()
+            && window.get_welcome_collapsed()
+            && docks(window.get_welcome_sidebar_dock()))
+        || (window.get_quick_panel_open()
+            && window.get_quick_panel_collapsed()
+            && docks(window.get_quick_panel_dock()))
+}
+
+/// Rebuild the edge stacks from the current window panel state, recompute the
+/// dock geometry and push the result into the UI (models updated in place so
+/// the rendered panel components keep their state). Call whenever a panel
+/// docks, resizes or collapses — the close path then only has to persist the
+/// already-synced stacks.
+/// `area` is the dock-area frame in logical px (Slint reports it through
+/// `dock-area-resized`) — panels lay out in that frame, not the window's.
+///
+/// While a panel drag is live the push is deferred: `set_vec` mid-drag can
+/// re-key `for` rows and destroy the very component holding the pointer grab,
+/// which strands the drag (its end handler never runs). The deferred run
+/// retries until the flag drops, so a release commit still lands ~100ms
+/// later.
+fn refresh_dock(
+    window: &AppWindow,
+    dock_stacks: &Rc<RefCell<DockStacks>>,
+    panels_model: &Rc<VecModel<PanelGeomInfo>>,
+    dividers_model: &Rc<VecModel<DividerGeomInfo>>,
+    area: (f32, f32),
+) {
+    refresh_dock_inner(
+        window.as_weak(),
+        dock_stacks.clone(),
+        panels_model.clone(),
+        dividers_model.clone(),
+        area,
+    );
+}
+
+fn refresh_dock_inner(
+    window: slint::Weak<AppWindow>,
+    dock_stacks: Rc<RefCell<DockStacks>>,
+    panels_model: Rc<VecModel<PanelGeomInfo>>,
+    dividers_model: Rc<VecModel<DividerGeomInfo>>,
+    area: (f32, f32),
+) {
+    let Some(w) = window.upgrade() else {
+        return;
+    };
+    let (cw, ch) = area;
+    // The deferral itself: any refresh while a panel drag holds the pointer
+    // is postponed (and re-postponed until the drag ends), so a mid-drag
+    // relayout can never rebuild the dragged panel out from under the grab.
+    if w.get_panel_dragging() {
+        slint::Timer::single_shot(std::time::Duration::from_millis(100), move || {
+            refresh_dock_inner(window, dock_stacks, panels_model, dividers_model, area);
+        });
+        return;
+    }
+    // Zen mode hides every docked panel and the terminal fills the window.
+    if w.get_zen_mode() {
+        panels_model.set_vec(Vec::new());
+        dividers_model.set_vec(Vec::new());
+        w.set_dock_central_x(0.0);
+        w.set_dock_central_y(0.0);
+        w.set_dock_central_w(cw);
+        w.set_dock_central_h(ch);
+        return;
+    }
+    let saved = dock_stacks.borrow().clone();
+    let geom = {
+        let mut cur = dock_stacks.borrow_mut();
+        cur.rebuild_from(&saved, &|k| panel_edge(&w, k));
+        cur.compute_geom(
+            &|k| panel_extent(&w, k),
+            &|edge| strip_on_edge(&w, edge),
+            cw,
+            ch,
+        )
+    };
+    let panels: Vec<PanelGeomInfo> = geom
+        .panels
+        .iter()
+        .map(|p| PanelGeomInfo {
+            kind: p.kind.into(),
+            edge: p.edge.into(),
+            x: p.rect.x,
+            y: p.rect.y,
+            w: p.rect.w,
+            h: p.rect.h,
+        })
+        .collect();
+    let unchanged_rows = panels_model.row_count() == panels.len()
+            && (panels.is_empty()
+                || (0..panels.len()).all(|i| {
+                    panels_model.row_data(i).is_some_and(|r| {
+                        let p = &panels[i];
+                        r.kind == p.kind
+                            && r.edge == p.edge
+                            && r.x == p.x
+                            && r.y == p.y
+                            && r.w == p.w
+                            && r.h == p.h
+                    })
+                }));
+    if !unchanged_rows {
+        panels_model.set_vec(panels);
+    }
+    let dividers: Vec<DividerGeomInfo> = geom
+        .dividers
+        .iter()
+        .map(|d| DividerGeomInfo {
+            edge: d.edge.into(),
+            index: d.index as i32,
+            x: d.rect.x,
+            y: d.rect.y,
+            w: d.rect.w,
+            h: d.rect.h,
+            vertical: d.vertical,
+        })
+        .collect();
+    if dividers_model.row_count() == dividers.len() {
+        for (i, d) in dividers.into_iter().enumerate() {
+            let unchanged = dividers_model.row_data(i).is_some_and(|old| {
+                old.edge == d.edge
+                    && old.index == d.index
+                    && old.x == d.x
+                    && old.y == d.y
+                    && old.w == d.w
+                    && old.h == d.h
+                    && old.vertical == d.vertical
+            });
+            if !unchanged {
+                dividers_model.set_row_data(i, d);
+            }
+        }
+    } else {
+        dividers_model.set_vec(dividers);
+    }
+    w.set_dock_central_x(geom.central.x);
+    w.set_dock_central_y(geom.central.y);
+    w.set_dock_central_w(geom.central.w);
+    w.set_dock_central_h(geom.central.h);
 }
 
 /// Hit-test a drag point (pane-area coords) to a target pane + drop zone, plus

--- a/src/app/core.rs
+++ b/src/app/core.rs
@@ -11,6 +11,7 @@ use std::sync::{Arc, Mutex};
 use tokio::runtime::Runtime;
 
 use crate::config::ConfigStore;
+use crate::app::dock_stacks::DockStacks;
 use crate::resource::{LocalSnap, NetHist, TabStatuses};
 use crate::sftp::{SftpHandles, SftpLastCwd};
 use crate::ssh::SessionHandle;
@@ -58,6 +59,8 @@ pub struct WindowState {
     pub net_hist: NetHist,
     pub follow_cd: Arc<std::sync::atomic::AtomicBool>,
     pub layout: Rc<RefCell<crate::layout::Layout>>,
+    /// Per-edge stacks of simultaneously-expanded docked panels (#dock-stack).
+    pub dock_stacks: Rc<RefCell<DockStacks>>,
     pub tabs_model: Rc<slint::VecModel<TabInfo>>,
     pub terminals_model: Rc<slint::VecModel<TerminalState>>,
     pub panes_model: Rc<slint::VecModel<PaneInfo>>,

--- a/src/app/dock_stacks.rs
+++ b/src/app/dock_stacks.rs
@@ -1,0 +1,788 @@
+//! Runtime state of the docked-panel edge stacks (#dock-stack).
+//!
+//! Window-level panels (sidebar / welcome / quick) can share one window
+//! edge: `DockStacks` keeps, per edge, the ordered list of simultaneously-
+//! expanded panels and how the edge's secondary axis is divided between them.
+//! Pure logic — no Slint — so it is unit-testable; `app.rs` pushes the stacks
+//! into the UI and persists them via `crate::config`.
+
+use crate::config::{DockEdgeSer, DockSlotSer};
+
+/// One stack slot: which panel and how much of the edge it owns (0..1).
+/// A non-positive ratio is a sentinel for "just joined" — [`rebalance`]
+/// hands such members an even share and squeezes the established ones
+/// around them.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DockSlotInfo {
+    pub kind: &'static str,
+    pub ratio: f32,
+}
+
+/// Smallest share a panel keeps along the stacking axis (ratio, not px).
+const MIN_RATIO: f32 = 0.08;
+
+/// Visible thickness of a divider between two stacked panels, in px.
+pub const DIVIDER: f32 = 4.0;
+
+/// Clamp bounds for a stacked panel's thickness along its edge's normal
+/// (its width on a left/right edge, height on a top/bottom one).
+pub const MIN_THICK: f32 = 120.0;
+/// Max share of the dock-area an edge stack may take. Kept well under half so
+/// the terminal never fully disappears even with opposite edges both maxed.
+const MAX_THICK_FRAC: f32 = 0.38;
+/// Outer band an edge reserves for the collapsed-panel ToolStrip (a folded
+/// panel still shows its 36px icon strip; stacked panels live inside it).
+pub const STRIP: f32 = 36.0;
+
+/// Absolute rectangle in dock-area logical px.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct RectGeom {
+    pub x: f32,
+    pub y: f32,
+    pub w: f32,
+    pub h: f32,
+}
+
+/// One rendered, expanded dock panel placed by [`DockStacks::compute_geom`].
+#[derive(Clone, Debug, PartialEq)]
+pub struct PanelGeom {
+    pub kind: &'static str,
+    /// The dock edge this panel sits on ("left|right|top|bottom") — used by
+    /// the UI to paint the in-edge resize handle on the correct side.
+    pub edge: &'static str,
+    pub rect: RectGeom,
+}
+
+/// A draggable divider between two stacked panels; dragging updates the
+/// boundary via [`DockStacks::set_ratio`] with `index` = the slot before it.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DividerGeom {
+    pub edge: &'static str,
+    pub index: usize,
+    pub rect: RectGeom,
+    /// True when the handle is vertical (left/right edge → drag up/down).
+    pub vertical: bool,
+}
+
+/// Full layout output: the central content rect (after every edge stack is
+/// carved off) plus absolute geoms for every expanded panel and divider.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct DockGeom {
+    pub central: RectGeom,
+    pub panels: Vec<PanelGeom>,
+    pub dividers: Vec<DividerGeom>,
+}
+
+/// Known panel kinds, in the order they appear in the config / UI.
+pub const KINDS: [&str; 3] = ["sidebar", "welcome", "quick"];
+
+fn edges() -> impl Iterator<Item = &'static str> {
+    ["left", "right", "top", "bottom"].into_iter()
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct DockStacks {
+    pub left: Vec<DockSlotInfo>,
+    pub right: Vec<DockSlotInfo>,
+    pub top: Vec<DockSlotInfo>,
+    pub bottom: Vec<DockSlotInfo>,
+}
+
+impl DockStacks {
+    pub fn table_mut(&mut self, edge: &str) -> Option<&mut Vec<DockSlotInfo>> {
+        match edge {
+            "left" => Some(&mut self.left),
+            "right" => Some(&mut self.right),
+            "top" => Some(&mut self.top),
+            "bottom" => Some(&mut self.bottom),
+            _ => None,
+        }
+    }
+
+    fn table(&self, edge: &str) -> Option<&[DockSlotInfo]> {
+        match edge {
+            "left" => Some(&self.left),
+            "right" => Some(&self.right),
+            "top" => Some(&self.top),
+            "bottom" => Some(&self.bottom),
+            _ => None,
+        }
+    }
+
+    /// The edge a panel currently stacks on (None when it is not in any stack).
+    pub fn edge_of(&self, kind: &str) -> Option<&'static str> {
+        for (e, table) in [
+            ("left", self.table("left")),
+            ("right", self.table("right")),
+            ("top", self.table("top")),
+            ("bottom", self.table("bottom")),
+        ] {
+            if table.is_some_and(|t| t.iter().any(|s| s.kind == kind)) {
+                return Some(e);
+            }
+        }
+        None
+    }
+
+    /// Move (or add) `kind` onto `edge`, taking it off whatever edge it was on.
+    /// Ratios are rebalanced evenly for the edge's new member count.
+    pub fn dock_to(&mut self, edge: &str, kind: &'static str) {
+        if let Some(old_edge) = self.edge_of(kind) {
+            if old_edge == edge {
+                return;
+            }
+            if let Some(t) = self.table_mut(old_edge) {
+                t.retain(|s| s.kind != kind);
+            }
+        }
+        let Some(t) = self.table_mut(edge) else { return };
+        if t.iter().any(|s| s.kind == kind) {
+            return;
+        }
+        t.push(DockSlotInfo { kind, ratio: 0.0 });
+        rebalance(t);
+    }
+
+    /// Remove `kind` from `edge` (a fold / close).
+    pub fn remove(&mut self, edge: &str, kind: &str) {
+        if let Some(t) = self.table_mut(edge) {
+            t.retain(|s| s.kind != kind);
+        }
+    }
+
+    /// Set the split boundary after slot `index` so slot `index` holds
+    /// approximately `ratio` of the edge, sliding the two groups around it.
+    pub fn set_ratio(&mut self, edge: &str, index: usize, ratio: f32) {
+        if let Some(t) = self.table_mut(edge) {
+            if index + 1 >= t.len() {
+                return;
+            }
+            let r = ratio.clamp(MIN_RATIO, 1.0 - MIN_RATIO);
+            let group_a: f32 = t.iter().take(index + 1).map(|s| s.ratio).sum();
+            let group_b: f32 = t.iter().skip(index + 1).map(|s| s.ratio).sum();
+            let total = group_a + group_b;
+            if total <= 0.0 {
+                return;
+            }
+            let (a, b) = (r, 1.0 - r);
+            let len = t.len();
+            for (i, s) in t.iter_mut().enumerate() {
+                s.ratio = if i <= index {
+                    a * if group_a > 0.0 { s.ratio / group_a } else { 1.0 / (index + 1) as f32 }
+                } else {
+                    b * if group_b > 0.0 { s.ratio / group_b } else { 1.0 / (len - index - 1) as f32 }
+                };
+                s.ratio = s.ratio.clamp(MIN_RATIO, 1.0 - MIN_RATIO);
+            }
+            rebalance(t);
+        }
+    }
+
+    /// Serialize the current stacks for config persistence (2+ slots only).
+    pub fn to_saved(&self) -> Vec<DockEdgeSer> {
+        edges()
+            .filter_map(|edge| {
+                let slots = self.table(edge)?;
+                if slots.len() < 2 {
+                    return None;
+                }
+                Some(DockEdgeSer {
+                    edge: edge.to_string(),
+                    slots: slots
+                        .iter()
+                        .map(|s| DockSlotSer {
+                            kind: s.kind.to_string(),
+                            ratio: s.ratio,
+                        })
+                        .collect(),
+                })
+            })
+            .collect()
+    }
+
+    /// Replace the state from persisted config (already sanitised by the
+    /// config layer).
+    pub fn from_saved<'a>(&mut self, stacks: impl IntoIterator<Item = &'a DockEdgeSer>) {
+        self.left.clear();
+        self.right.clear();
+        self.top.clear();
+        self.bottom.clear();
+        for e in stacks {
+            let Some(t) = self.table_mut(&e.edge) else { continue };
+            for s in &e.slots {
+                let Some(kind) = KINDS.iter().copied().find(|k| *k == s.kind) else {
+                    continue;
+                };
+                t.push(DockSlotInfo { kind, ratio: s.ratio });
+            }
+            rebalance(t);
+        }
+    }
+
+    /// Rebuild the stacks from the current *expanded* panel set, so the saved
+    /// (kind, edge, ratio) triples survive while panels folded/closed drop out
+    /// and newly-expanded ones join their edge with an even share. `expanded`
+    /// returns the edge a panel is currently docked to (`None` = folded/off).
+    /// Reads order from the previous state first, then new panels afterwards —
+    /// stable so an untouched layout keeps its exact split.
+    pub fn rebuild_from(
+        &mut self,
+        saved: &DockStacks,
+        expanded: &dyn Fn(&str) -> Option<&'static str>,
+    ) {
+        for edge in ["left", "right", "top", "bottom"] {
+            let mut order: Vec<&'static str> = Vec::new();
+            if let Some(slots) = saved.table(edge) {
+                // Keep the persisted order and ratio for panels still on this
+                // edge and still expanded.
+                let mut kept: Vec<&'static str> =
+                    slots.iter().map(|s| s.kind).collect();
+                kept.retain(|k| expanded(k) == Some(edge));
+                order.append(&mut kept);
+            }
+            // Any newly-expanded panel on this edge joins behind the kept ones.
+            for k in KINDS {
+                if expanded(k) == Some(edge) && !order.contains(&k) {
+                    order.push(k);
+                }
+            }
+            if order.is_empty() {
+                if let Some(t) = self.table_mut(edge) {
+                    t.clear();
+                }
+                continue;
+            }
+            // Inherit the saved ratio for panels we already knew; a new
+            // panel takes the leftover of the edge, or an even share of the
+            // whole edge when nothing is left over.
+            let mut slots: Vec<DockSlotInfo> = Vec::with_capacity(order.len());
+            let mut fresh: Vec<&'static str> = Vec::new();
+            let mut known: f32 = 0.0;
+            for k in &order {
+                let ratio = saved
+                    .table(edge)
+                    .and_then(|sl| sl.iter().find(|s| s.kind == *k))
+                    .map(|s| s.ratio);
+                match ratio {
+                    Some(r) => {
+                        known += r;
+                        slots.push(DockSlotInfo { kind: k, ratio: r });
+                    }
+                    None => fresh.push(k),
+                }
+            }
+            if !fresh.is_empty() {
+                // A comfortable leftover keeps the established split intact
+                // (a user-tuned ratio never gets wiped by an unrelated
+                // stack). But a leftover at or below MIN_RATIO means the
+                // edge is already spoken for — handing newcomers the crumbs
+                // would strand them, so push the sentinel instead and let
+                // rebalance squeeze everyone to even shares.
+                let leftover = 1.0 - known;
+                let each = if leftover > MIN_RATIO {
+                    leftover / fresh.len() as f32
+                } else {
+                    0.0
+                };
+                for k in fresh {
+                    slots.push(DockSlotInfo { kind: k, ratio: each });
+                }
+            }
+            if let Some(target) = self.table_mut(edge) {
+                *target = slots;
+                rebalance(target);
+            }
+        }
+    }
+
+    /// Compute absolute rectangles for every expanded panel (and its
+    /// dividers) plus the central content rect, for the given dock-area size
+    /// in logical px. `extent` returns a panel's preferred thickness along its
+    /// edge's normal (width on a left/right edge, height on a top/bottom one).
+    /// `has_strip` marks edges whose collapsed panels still show the outer
+    /// 36px ToolStrip band: the band stays at the very edge and the whole
+    /// stack is carved INSIDE it (the band spans the full edge, so the split
+    /// axis and ratios are unaffected).
+    pub fn compute_geom(
+        &self,
+        extent: &dyn Fn(&str) -> f32,
+        has_strip: &dyn Fn(&str) -> bool,
+        w: f32,
+        h: f32,
+    ) -> DockGeom {
+        let mut g = DockGeom {
+            central: RectGeom {
+                x: 0.0,
+                y: 0.0,
+                w: w.max(1.0),
+                h: h.max(1.0),
+            },
+            ..Default::default()
+        };
+        let (cw, ch) = (w.max(1.0), h.max(1.0));
+        for edge in ["left", "right", "top", "bottom"] {
+            // A collapsed panel's ToolStrip band is reserved even when no
+            // panel on this edge is expanded (the edge is strip-only).
+            let band = if has_strip(edge) { STRIP } else { 0.0 };
+            let slots = match self.table(edge) {
+                Some(t) if !t.is_empty() => t,
+                _ => {
+                    let taken = band;
+                    match edge {
+                        "left" => {
+                            g.central.x += taken;
+                            g.central.w -= taken;
+                        }
+                        "right" => {
+                            g.central.w -= taken;
+                        }
+                        "top" => {
+                            g.central.y += taken;
+                            g.central.h -= taken;
+                        }
+                        _ => {
+                            g.central.h -= taken;
+                        }
+                    }
+                    continue;
+                }
+            };
+            let horizontal = matches!(edge, "left" | "right");
+            // All stacked panels on an edge share its thickness; clamp so the
+            // central area keeps at least half of the dock-area. Tiny
+            // dock-areas (the pre-show 0×0 pass, or a user-shrunk window)
+            // put the cap below MIN_THICK — f32::clamp panics when
+            // min > max, so floor the cap at MIN_THICK; the next real
+            // resize pass overwrites the transient geometry.
+            let cap = ((((if horizontal { cw } else { ch }) - band).max(0.0)) * MAX_THICK_FRAC)
+                .max(MIN_THICK);
+            let thickness = slots
+                .iter()
+                .map(|s| extent(s.kind))
+                .fold(0.0, f32::max)
+                .clamp(MIN_THICK, cap);
+            // The stack sits inside the band; the split axis spans the full
+            // edge (the band runs along it), so only the normal offsets move.
+            let axis = if horizontal { ch } else { cw };
+            let mut pos = 0.0;
+            for (i, s) in slots.iter().enumerate() {
+                let seg = if i == slots.len() - 1 {
+                    (axis - pos).max(0.0)
+                } else {
+                    (s.ratio * axis).max(0.0)
+                };
+                let rect = match edge {
+                    "left" => RectGeom { x: band, y: pos, w: thickness, h: seg },
+                    "right" => RectGeom { x: cw - band - thickness, y: pos, w: thickness, h: seg },
+                    "top" => RectGeom { x: pos, y: band, w: seg, h: thickness },
+                    _ => RectGeom { x: pos, y: ch - band - thickness, w: seg, h: thickness },
+                };
+                g.panels.push(PanelGeom { kind: s.kind, edge, rect });
+                if i < slots.len() - 1 {
+                    let drect = if horizontal {
+                        RectGeom { x: rect.x, y: pos + seg, w: thickness, h: DIVIDER }
+                    } else {
+                        RectGeom { x: pos + seg, y: rect.y, w: DIVIDER, h: thickness }
+                    };
+                    g.dividers.push(DividerGeom {
+                        edge,
+                        index: i,
+                        rect: drect,
+                        vertical: horizontal,
+                    });
+                }
+                pos += seg;
+            }
+            // Carve this edge's band + stack off the central content rect.
+            let taken = band + thickness;
+            match edge {
+                "left" => {
+                    g.central.x += taken;
+                    g.central.w -= taken;
+                }
+                "right" => {
+                    g.central.w -= taken;
+                }
+                "top" => {
+                    g.central.y += taken;
+                    g.central.h -= taken;
+                }
+                "bottom" => {
+                    g.central.h -= taken;
+                }
+                _ => {}
+            }
+        }
+        // Opposite-edge stacks on a tiny dock-area can over-carve the central
+        // rect into negative extents; the UI derives toolbar offsets from it,
+        // so keep the transient geometry at least self-consistent.
+        g.central.w = g.central.w.max(0.0);
+        g.central.h = g.central.h.max(0.0);
+        g
+    }
+}
+
+fn rebalance(t: &mut [DockSlotInfo]) {
+    if t.is_empty() {
+        return;
+    }
+    let n = t.len() as f32;
+    // Sentinels: slots that just joined the edge (see `DockSlotInfo`). Give
+    // each an even 1/n share and squeeze the established members around
+    // them — otherwise a merge onto a fully-occupied edge clamps the
+    // newcomer to MIN_RATIO and strands it as an 8% sliver.
+    let fresh = t.iter().filter(|s| s.ratio <= 0.0).count() as f32;
+    if fresh > 0.0 {
+        let each = 1.0 / n;
+        let known: f32 = t.iter().map(|s| s.ratio.max(0.0)).sum();
+        let scale = if known > 0.0 {
+            (1.0 - each * fresh).max(0.0) / known
+        } else {
+            0.0
+        };
+        for s in t.iter_mut() {
+            if s.ratio <= 0.0 {
+                s.ratio = each;
+            } else {
+                s.ratio *= scale;
+            }
+        }
+    }
+    let total: f32 = t.iter().map(|s| s.ratio).sum();
+    if total <= 0.0 {
+        for s in t.iter_mut() {
+            s.ratio = 1.0 / n;
+        }
+        return;
+    }
+    for s in t.iter_mut() {
+        s.ratio = (s.ratio / total).clamp(MIN_RATIO, 1.0 - MIN_RATIO);
+    }
+    // Absorb the rounding/clamping drift into the last slot: shares are
+    // absolute edge fractions (what compute_geom multiplies by the axis),
+    // so each keeps its own share and only the tail takes the remainder —
+    // a summed 1.0 means an exactly 50/50 two-panel merge.
+    let mut rem: f32 = 1.0;
+    let n = t.len();
+    for (i, s) in t.iter_mut().enumerate() {
+        if i == n - 1 {
+            // Floor the tail: a clamped-up overflow elsewhere could leave
+            // less than MIN here, and a 0.0 ratio persisted by to_saved
+            // would read back as a sentinel — or get dropped by the config
+            // sanitiser — silently losing the panel on the next load.
+            s.ratio = rem.max(MIN_RATIO);
+        } else {
+            let share = s.ratio.min(rem);
+            s.ratio = share;
+            rem -= share;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dock_to_moves_between_edges() {
+        let mut s = DockStacks::default();
+        s.dock_to("left", "sidebar");
+        s.dock_to("left", "quick");
+        assert_eq!(s.left.len(), 2);
+        s.dock_to("right", "sidebar");
+        assert_eq!(s.left.len(), 1);
+        assert_eq!(s.right.len(), 1);
+        assert_eq!(s.right[0].kind, "sidebar");
+        assert_eq!(s.edge_of("sidebar"), Some("right"));
+    }
+
+    #[test]
+    fn dock_to_is_idempotent() {
+        let mut s = DockStacks::default();
+        s.dock_to("left", "quick");
+        s.dock_to("left", "quick");
+        assert_eq!(s.left.len(), 1);
+    }
+
+    #[test]
+    fn remove_folds_panel() {
+        let mut s = DockStacks::default();
+        s.dock_to("left", "sidebar");
+        s.dock_to("left", "quick");
+        s.remove("left", "sidebar");
+        assert_eq!(s.left.len(), 1);
+        assert_eq!(s.left[0].kind, "quick");
+        assert_eq!(s.edge_of("sidebar"), None);
+    }
+
+    #[test]
+    fn ratios_rebalance_evenly_on_add() {
+        let mut s = DockStacks::default();
+        s.dock_to("left", "sidebar");
+        s.dock_to("left", "quick");
+        // A merge onto an occupied edge splits it in halves, not slivers.
+        assert!((s.left[0].ratio - 0.5).abs() < 1e-5);
+        assert!((s.left[1].ratio - 0.5).abs() < 1e-5);
+        s.dock_to("left", "welcome");
+        assert_eq!(s.left.len(), 3);
+        let sum: f32 = s.left.iter().map(|x| x.ratio).sum();
+        assert!((sum - 1.0).abs() < 1e-5);
+        for x in &s.left {
+            assert!((x.ratio - 1.0 / 3.0).abs() < 1e-5);
+        }
+    }
+
+    #[test]
+    fn merge_keeps_established_split_proportional() {
+        let mut s = DockStacks::default();
+        s.dock_to("left", "sidebar");
+        s.dock_to("left", "quick");
+        s.set_ratio("left", 0, 0.7);
+        s.dock_to("left", "welcome");
+        // The 70/30 tuning survives as its original 7:3 ratio inside the
+        // share the newcomer did NOT take; the newcomer itself gets an
+        // even third.
+        assert!((s.left[2].ratio - 1.0 / 3.0).abs() < 1e-3);
+        assert!((s.left[0].ratio / s.left[1].ratio - 7.0 / 3.0).abs() < 0.05);
+        let sum: f32 = s.left.iter().map(|x| x.ratio).sum();
+        assert!((sum - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn rebuild_from_full_edge_expands_evenly() {
+        // Left holds a lone sidebar (ratio 1.0); quick newly expands there.
+        let mut saved = DockStacks::default();
+        saved.dock_to("left", "sidebar");
+        let expanded = |k: &str| match k {
+            "sidebar" | "quick" => Some("left"),
+            _ => None,
+        };
+        let mut cur = DockStacks::default();
+        cur.rebuild_from(&saved, &expanded);
+        assert_eq!(cur.left.len(), 2);
+        assert!((cur.left[0].ratio - 0.5).abs() < 1e-5);
+        assert!((cur.left[1].ratio - 0.5).abs() < 1e-5);
+    }
+
+    #[test]
+    fn rebuild_heals_legacy_sliver_on_reexpand() {
+        // A 92/8 pair (the old merge bug's persisted shape) with the sliver
+        // folded; re-expanding a panel onto the edge normalises to halves.
+        let mut saved = DockStacks::default();
+        saved.left.push(DockSlotInfo {
+            kind: "sidebar",
+            ratio: 0.92,
+        });
+        let expanded = |k: &str| match k {
+            "sidebar" | "welcome" => Some("left"),
+            _ => None,
+        };
+        let mut cur = DockStacks::default();
+        cur.rebuild_from(&saved, &expanded);
+        assert_eq!(cur.left.len(), 2);
+        assert!((cur.left[0].ratio - 0.5).abs() < 1e-5);
+        assert!((cur.left[1].ratio - 0.5).abs() < 1e-5);
+    }
+
+    #[test]
+    fn set_ratio_moves_boundary_and_stays_normalised() {
+        let mut s = DockStacks::default();
+        s.dock_to("left", "sidebar");
+        s.dock_to("left", "quick");
+        s.dock_to("left", "welcome");
+        s.set_ratio("left", 0, 0.6);
+        assert!((s.left[0].ratio - 0.6).abs() < 1e-5);
+        let sum: f32 = s.left.iter().map(|x| x.ratio).sum();
+        assert!((sum - 1.0).abs() < 1e-5);
+        // Out-of-range index is ignored.
+        let before = s.left.clone();
+        s.set_ratio("left", 99, 0.5);
+        assert_eq!(s.left, before);
+    }
+
+    #[test]
+    fn saved_roundtrip_keeps_stack() {
+        let mut s = DockStacks::default();
+        s.dock_to("bottom", "sidebar");
+        s.dock_to("bottom", "welcome");
+        let saved = s.to_saved();
+        assert_eq!(saved.len(), 1);
+        assert_eq!(saved[0].edge, "bottom");
+        let mut t = DockStacks::default();
+        t.from_saved(&saved);
+        assert_eq!(t.bottom.len(), 2);
+        assert_eq!(t.bottom[0].kind, "sidebar");
+        assert_eq!(t.bottom[1].kind, "welcome");
+        assert!((t.bottom.iter().map(|x| x.ratio).sum::<f32>() - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn single_panel_stack_is_not_persisted() {
+        let mut s = DockStacks::default();
+        s.dock_to("left", "sidebar");
+        assert!(s.to_saved().is_empty());
+    }
+
+    #[test]
+    fn from_saved_ignores_unknown_kind_and_edge() {
+        let saved = vec![DockEdgeSer {
+            edge: "left".into(),
+            slots: vec![
+                DockSlotSer { kind: "bogus".into(), ratio: 0.5 },
+                DockSlotSer { kind: "quick".into(), ratio: 0.5 },
+            ],
+        }];
+        let mut t = DockStacks::default();
+        t.from_saved(&saved);
+        assert_eq!(t.left.len(), 1);
+        assert_eq!(t.left[0].kind, "quick");
+    }
+
+    fn extent_220(_: &str) -> f32 {
+        220.0
+    }
+
+    fn no_strip(_: &str) -> bool {
+        false
+    }
+
+    #[test]
+    fn geom_splits_two_panels_vertically_on_left_edge() {
+        let mut s = DockStacks::default();
+        s.dock_to("left", "sidebar");
+        s.dock_to("left", "quick");
+        let g = s.compute_geom(&extent_220, &no_strip, 800.0, 600.0);
+        // Both panels share the left-edge thickness (220) and split the height.
+        assert_eq!(g.panels.len(), 2);
+        assert_eq!(g.panels[0].kind, "sidebar");
+        assert_eq!(g.panels[0].rect, RectGeom { x: 0.0, y: 0.0, w: 220.0, h: 300.0 });
+        assert_eq!(g.panels[1].kind, "quick");
+        assert_eq!(g.panels[1].rect, RectGeom { x: 0.0, y: 300.0, w: 220.0, h: 300.0 });
+        assert_eq!(g.dividers.len(), 1);
+        assert!(g.dividers[0].vertical);
+        assert_eq!(g.dividers[0].rect, RectGeom { x: 0.0, y: 300.0, w: 220.0, h: DIVIDER });
+        assert_eq!(g.central, RectGeom { x: 220.0, y: 0.0, w: 580.0, h: 600.0 });
+    }
+
+    #[test]
+    fn geom_single_panel_carves_edge_full_height() {
+        let mut s = DockStacks::default();
+        s.dock_to("right", "welcome");
+        let g = s.compute_geom(&extent_220, &no_strip, 800.0, 600.0);
+        assert_eq!(g.panels.len(), 1);
+        assert_eq!(g.panels[0].rect, RectGeom { x: 580.0, y: 0.0, w: 220.0, h: 600.0 });
+        assert!(g.dividers.is_empty());
+        assert_eq!(g.central, RectGeom { x: 0.0, y: 0.0, w: 580.0, h: 600.0 });
+    }
+
+    #[test]
+    fn geom_top_edge_splits_horizontally() {
+        let mut s = DockStacks::default();
+        s.dock_to("top", "sidebar");
+        s.dock_to("top", "welcome");
+        let g = s.compute_geom(&extent_220, &no_strip, 800.0, 600.0);
+        assert_eq!(g.panels.len(), 2);
+        assert_eq!(g.panels[0].rect, RectGeom { x: 0.0, y: 0.0, w: 400.0, h: 220.0 });
+        assert_eq!(g.panels[1].rect, RectGeom { x: 400.0, y: 0.0, w: 400.0, h: 220.0 });
+        assert!(!g.dividers[0].vertical);
+        assert_eq!(g.dividers[0].rect, RectGeom { x: 400.0, y: 0.0, w: DIVIDER, h: 220.0 });
+        assert_eq!(g.central, RectGeom { x: 0.0, y: 220.0, w: 800.0, h: 380.0 });
+    }
+
+    #[test]
+    fn geom_no_panels_leaves_central_untouched() {
+        let s = DockStacks::default();
+        let g = s.compute_geom(&extent_220, &no_strip, 800.0, 600.0);
+        assert!(g.panels.is_empty());
+        assert!(g.dividers.is_empty());
+        assert_eq!(g.central, RectGeom { x: 0.0, y: 0.0, w: 800.0, h: 600.0 });
+    }
+
+    #[test]
+    fn geom_clamps_thickness_so_central_survives() {
+        let mut s = DockStacks::default();
+        s.dock_to("left", "sidebar");
+        let g = s.compute_geom(&|_| 900.0, &no_strip, 800.0, 600.0);
+        // cap = 800 → max thickness 304 (0.38 × 800); central keeps ≥ 62%.
+        assert_eq!(g.panels[0].rect.w, 304.0);
+        assert_eq!(g.central.w, 496.0);
+    }
+
+    #[test]
+    fn geom_survives_tiny_dock_area() {
+        let mut s = DockStacks::default();
+        s.dock_to("left", "sidebar");
+        // The pre-show 0×0 pass: before the cap floor, clamp(120, 0.38)
+        // panicked with "min > max" and killed the app at startup.
+        let g = s.compute_geom(&extent_220, &no_strip, 0.0, 0.0);
+        assert_eq!(g.panels[0].rect.w, 120.0);
+        assert_eq!(g.central.w, 0.0);
+        assert_eq!(g.central.h, 1.0);
+    }
+
+    #[test]
+    fn geom_reserves_outer_strip_band() {
+        let mut s = DockStacks::default();
+        s.dock_to("left", "sidebar");
+        s.dock_to("left", "quick");
+        // Left edge stacks behind its band; the right edge is strip-only
+        // (folded panels, nothing expanded) yet still takes its 36px.
+        let strip = |e: &str| e == "left" || e == "right";
+        let g = s.compute_geom(&extent_220, &strip, 800.0, 600.0);
+        assert_eq!(g.panels.len(), 2);
+        assert_eq!(g.panels[0].rect.x, 36.0);
+        // The band runs ALONG the edge: split axis and ratios untouched.
+        assert_eq!(g.panels[0].rect.h, 300.0);
+        assert_eq!(g.panels[1].rect.y, 300.0);
+        assert_eq!(g.central.x, 256.0);
+        assert_eq!(g.central.w, 800.0 - 256.0 - 36.0);
+    }
+
+    fn expanded_left_sidebar_welcome(k: &str) -> Option<&'static str> {
+        matches!(k, "sidebar" | "welcome").then_some("left")
+    }
+
+    fn expanded_none(_: &str) -> Option<&'static str> {
+        None
+    }
+
+    #[test]
+    fn rebuild_inherits_ratio_and_appends_new_panel() {
+        let mut saved = DockStacks::default();
+        saved.dock_to("left", "sidebar");
+        saved.dock_to("left", "quick");
+        saved.set_ratio("left", 0, 0.7);
+        // Quick folds; welcome joins the left edge.
+        let mut cur = DockStacks::default();
+        cur.rebuild_from(&saved, &expanded_left_sidebar_welcome);
+        assert_eq!(cur.left.len(), 2);
+        assert_eq!(cur.left[0].kind, "sidebar");
+        assert_eq!(cur.left[1].kind, "welcome");
+        // The tuned 0.70 split for the surface panel is kept.
+        assert!((cur.left[0].ratio - 0.7).abs() < 1e-3);
+        assert!((cur.left.iter().map(|s| s.ratio).sum::<f32>() - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn rebuild_drops_folded_panels() {
+        let mut saved = DockStacks::default();
+        saved.dock_to("left", "sidebar");
+        saved.dock_to("left", "quick");
+        let mut cur = DockStacks::default();
+        cur.rebuild_from(&saved, &expanded_none);
+        assert!(cur.left.is_empty());
+        assert!(cur.edge_of("sidebar").is_none());
+    }
+
+    #[test]
+    fn rebuild_moves_panel_to_its_new_edge() {
+        let mut saved = DockStacks::default();
+        saved.dock_to("left", "sidebar");
+        let expanded = |k: &str| if k == "sidebar" { Some("right") } else { None };
+        let mut cur = DockStacks::default();
+        cur.rebuild_from(&saved, &expanded);
+        assert!(cur.left.is_empty());
+        assert_eq!(cur.right.len(), 1);
+        assert_eq!(cur.right[0].kind, "sidebar");
+    }
+}

--- a/src/app/tab_transfer.rs
+++ b/src/app/tab_transfer.rs
@@ -483,7 +483,7 @@ pub(super) fn close_window_now(core: &Rc<AppCore>, window_id: u64) {
         return;
     };
     if let Some(win) = st.weak.upgrade() {
-        save_layout(&win, &core.store);
+        save_layout(&win, &core.store, &st.dock_stacks);
         clear_zen_on_close(&win, &core.store);
         teardown_window(
             window_id,

--- a/src/config/impls/config.rs
+++ b/src/config/impls/config.rs
@@ -1422,6 +1422,32 @@ impl ConfigStore {
         self.cache.webdav_accept_invalid_certs = accept_invalid_certs;
     }
 
+    /// Per-edge stacks of simultaneously-expanded docked panels (#dock-stack).
+    /// The stored value is sanitised (unknown kinds dropped, repeated kinds
+    /// collapsed, ratios renormalised to sum to 1) before it is handed out.
+    pub fn dock_stacks(&self) -> Vec<DockEdgeSer> {
+        let mut out: Vec<DockEdgeSer> = Vec::new();
+        // A panel can only occupy one edge: the first edge a kind appears in
+        // wins across the whole store, so a corrupt config with the same panel
+        // on two edges cannot hide it from both.
+        let mut seen: std::collections::HashSet<String> = Default::default();
+        for e in self.cache.dock_stacks.iter().cloned().filter_map(sanitize_edge) {
+            let mut edge = e;
+            edge.slots.retain(|s| seen.insert(s.kind.clone()));
+            if edge.slots.len() >= 2 {
+                out.push(edge);
+            }
+        }
+        out
+    }
+
+    pub fn set_dock_stacks(&mut self, stacks: Vec<DockEdgeSer>) {
+        self.cache.dock_stacks = stacks
+            .into_iter()
+            .filter_map(sanitize_edge)
+            .collect();
+    }
+
     /// Whether each download prompts for a save location (default false) (#87).
     pub fn download_always_ask(&self) -> bool {
         self.cache.download_always_ask

--- a/src/config/struct/config_file.rs
+++ b/src/config/struct/config_file.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use super::{OutputHighlightRule, QuickCommand, Secret, Session};
+use super::{DockEdgeSer, OutputHighlightRule, QuickCommand, Secret, Session};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WslProfile {
@@ -284,6 +284,12 @@ pub struct ConfigFile {
     /// resource panel / wallpaper overlay) to users still sitting on old defaults.
     #[serde(default)]
     pub defaults_rev: u32,
+    /// Per-edge stacks of simultaneously-expanded docked panels (#dock-stack),
+    /// e.g. session list + Quick shared on the left edge, split vertically.
+    /// Empty (or <2 slots on a valid edge) → the legacy single-panel-per-edge
+    /// layout.
+    #[serde(default)]
+    pub dock_stacks: Vec<DockEdgeSer>,
 }
 
 /// Portable export file (issue #46): sessions with everything in plaintext

--- a/src/config/struct/dock_stack.rs
+++ b/src/config/struct/dock_stack.rs
@@ -1,0 +1,174 @@
+//! Docked-panel edge stacks (#dock-stack).
+//!
+//! Window-level panels (sidebar / welcome / quick) can share the same
+//! window edge at the same time, stacked along that edge. A `DockEdgeSer`
+//! records, per edge, the ordered list of simultaneously-expanded panels and
+//! how that edge's secondary axis is divided between them. Legacy configs have
+//! an empty list → the old single-panel-per-edge layout keeps working.
+
+use serde::{Deserialize, Serialize};
+
+/// One panel in an edge stack. `kind` is one of
+/// `"sidebar" | "welcome" | "quick"`; `ratio` divides the edge's
+/// secondary axis among the stacked panels (0..1 — the stack is renormalised
+/// when loaded, so stale ratios can never sum away from 1).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct DockSlotSer {
+    #[serde(default)]
+    pub kind: String,
+    #[serde(default)]
+    pub ratio: f32,
+}
+
+/// The ordered stack of simultaneously-expanded panels on one window edge.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct DockEdgeSer {
+    /// `"left" | "right" | "top" | "bottom"` — the edge this stack owns.
+    #[serde(default)]
+    pub edge: String,
+    #[serde(default)]
+    pub slots: Vec<DockSlotSer>,
+}
+
+pub(crate) fn valid_edge(edge: &str) -> bool {
+    matches!(edge, "left" | "right" | "top" | "bottom")
+}
+
+pub(crate) fn valid_kind(kind: &str) -> bool {
+    matches!(kind, "sidebar" | "welcome" | "quick")
+}
+
+/// Normalise one edge stack so it is safe to apply:
+/// - drops unknown/empty kinds and out-of-range ratios;
+/// - a kind repeated on one edge collapses to its first occurrence;
+/// - the surviving ratios are clamped to a sane minimum and renormalised to
+///   sum to 1, so a corrupt config can never gap or overflow the edge.
+pub(crate) fn sanitize_edge(mut edge: DockEdgeSer) -> Option<DockEdgeSer> {
+    if !valid_edge(&edge.edge) {
+        return None;
+    }
+    edge.slots.retain(|s| valid_kind(&s.kind) && s.ratio.is_finite() && s.ratio > 0.0);
+    if edge.slots.len() < 2 {
+        // A single-panel stack is just the legacy layout; do not store it.
+        return None;
+    }
+    let mut seen = std::collections::HashSet::new();
+    let mut dedup = Vec::with_capacity(edge.slots.len());
+    for s in edge.slots {
+        if seen.insert(s.kind.clone()) {
+            dedup.push(s);
+        }
+    }
+    if dedup.len() < 2 {
+        return None;
+    }
+    let total: f32 = dedup.iter().map(|s| s.ratio).sum();
+    for s in &mut dedup {
+        s.ratio = (s.ratio / total).clamp(0.05, 0.95);
+    }
+    // Renormalise again after clamping so the sum is exactly 1.
+    let total: f32 = dedup.iter().map(|s| s.ratio).sum();
+    if total <= 0.0 {
+        return None;
+    }
+    for s in &mut dedup {
+        s.ratio = (s.ratio / total).clamp(0.0, 1.0);
+    }
+    edge.slots = dedup;
+    Some(edge)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn slot(kind: &str, ratio: f32) -> DockSlotSer {
+        DockSlotSer {
+            kind: kind.to_string(),
+            ratio,
+        }
+    }
+
+    fn edge(edge: &str, slots: Vec<DockSlotSer>) -> DockEdgeSer {
+        DockEdgeSer {
+            edge: edge.to_string(),
+            slots,
+        }
+    }
+
+    #[test]
+    fn serde_roundtrip_preserves_stacks() {
+        let cfg = crate::config::ConfigFile {
+            dock_stacks: vec![edge(
+                "left",
+                vec![slot("sidebar", 0.7), slot("quick", 0.3)],
+            )],
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&cfg).unwrap();
+        let back: crate::config::ConfigFile = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.dock_stacks, cfg.dock_stacks);
+    }
+
+    #[test]
+    fn missing_field_defaults_to_empty_stacks() {
+        let back: crate::config::ConfigFile = serde_json::from_str("{}").unwrap();
+        assert!(back.dock_stacks.is_empty());
+    }
+
+    #[test]
+    fn sanitize_keeps_valid_edge_and_renormalises() {
+        let out = sanitize_edge(edge("right", vec![slot("sidebar", 1.0), slot("quick", 1.0)]))
+            .expect("valid two-panel stack survives");
+        assert_eq!(out.edge, "right");
+        assert_eq!(out.slots.len(), 2);
+        assert!((out.slots.iter().map(|s| s.ratio).sum::<f32>() - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn sanitize_drops_unknown_kinds() {
+        let out = sanitize_edge(edge(
+            "bottom",
+            vec![slot("sidebar", 0.5), slot("bogus", 0.5), slot("quick", 0.5)],
+        ))
+        .expect("survives after dropping the unknown kind");
+        // ["bogus"] filtered → sidebar + quick remain, renormalised.
+        assert_eq!(out.slots.len(), 2);
+        assert!(out.slots.iter().all(|s| matches!(s.kind.as_str(), "sidebar" | "quick")));
+    }
+
+    #[test]
+    fn sanitize_deduplicates_repeated_kinds() {
+        let out = sanitize_edge(edge(
+            "left",
+            vec![slot("welcome", 0.5), slot("welcome", 0.2), slot("quick", 0.3)],
+        ))
+        .expect("deduplicated stack survives");
+        // First welcome survives, the later duplicate is dropped.
+        assert_eq!(out.slots.len(), 2);
+        assert_eq!(out.slots[0].kind, "welcome");
+        assert_eq!(out.slots[1].kind, "quick");
+    }
+
+    #[test]
+    fn sanitize_rejects_single_panel_or_bad_edge() {
+        assert!(sanitize_edge(edge("left", vec![slot("sidebar", 1.0)])).is_none());
+        assert!(sanitize_edge(edge("middle", vec![slot("sidebar", 0.5), slot("quick", 0.5)])).is_none());
+        assert!(sanitize_edge(edge("left", Vec::new())).is_none());
+        // Zero/negative ratios leave fewer than 2 valid panels → rejected.
+        assert!(sanitize_edge(edge("left", vec![slot("sidebar", 0.0), slot("quick", 0.0)])).is_none());
+    }
+
+    #[test]
+    fn sanitize_clamps_ratios_within_range() {
+        let out = sanitize_edge(edge(
+            "top",
+            vec![slot("sidebar", 0.0001), slot("quick", 999.0)],
+        ))
+        .expect("stack survives");
+        assert!(out.slots[0].ratio >= 0.05);
+        assert!(out.slots[1].ratio <= 0.95);
+        let sum: f32 = out.slots.iter().map(|s| s.ratio).sum();
+        assert!((sum - 1.0).abs() < 1e-6);
+    }
+}

--- a/src/config/struct/mod.rs
+++ b/src/config/struct/mod.rs
@@ -1,11 +1,13 @@
 mod config_file;
 mod config_store;
+mod dock_stack;
 mod quick_command;
 mod secret;
 mod session;
 
 pub(crate) use config_file::*;
 pub(crate) use config_store::*;
+pub(crate) use dock_stack::*;
 pub(crate) use quick_command::*;
 pub(crate) use secret::*;
 pub(crate) use session::*;

--- a/ui/app.slint
+++ b/ui/app.slint
@@ -112,6 +112,32 @@ export struct SplitterInfo {
     vertical: bool,   // true = vertical handle (drag left/right)
 }
 
+// A docked panel placed absolutely by the Rust dock-geometry engine
+// (#dock-stack). `kind` selects which panel component to render; `edge` is
+// the dock edge it sits on so the UI can draw the in-edge resize handle.
+export struct PanelGeomInfo {
+    kind: string,
+    edge: string,
+    x: length,
+    y: length,
+    w: length,
+    h: length,
+}
+
+// A draggable divider between two stacked docked panels (#dock-stack).
+// `edge` + `index` identify the boundary so Rust can update the ratio;
+// `edge` is the dock edge ("left|right|top|bottom") and `index` is the slot
+// *before* the boundary.
+export struct DividerGeomInfo {
+    edge: string,
+    index: int,
+    x: length,
+    y: length,
+    w: length,
+    h: length,
+    vertical: bool,   // true = vertical handle (drag up/down)
+}
+
 // A 26×26 top-bar icon button with a hover tooltip (right-aligned so it never
 // runs off the window edge). `active` keeps the hover background lit (e.g. while
 // its popup is open).
@@ -405,7 +431,9 @@ export component AppWindow inherits Window {
     property <bool> sidebar-horizontal: root.sidebar-dock == "left" || root.sidebar-dock == "right";
     // Drag-to-dock state: while a panel's header is dragged, a 4-edge snap
     // overlay shows and `dock-target` tracks the edge under the cursor.
-    property <bool> panel-dragging;
+    // `out` (Rust-read) backs the drag-aware deferral in refresh_dock: the
+    // push must wait while a panel drag holds the pointer.
+    out property <bool> panel-dragging;
     property <float> drag-nx;   // cursor x within the dock area, 0..1
     property <float> drag-ny;   // cursor y within the dock area, 0..1
     property <string> dock-target:
@@ -419,35 +447,9 @@ export component AppWindow inherits Window {
     // The top-right toolbar icons float over the tab row; when the sidebar docks
     // top/right it covers that corner, so shift the icons to stay over the tabs.
     property <length> toolbar-x-off:
-        (root.sidebar-dock == "right"
-            ? (root.sidebar-collapsed ? 36px : root.sidebar-width + 4px)
-            : 0px)
-        + ((root.welcome-as-sidebar && root.welcome-sidebar-dock == "right")
-            ? root.welcome-sidebar-taken
-            : 0px)
-        + ((root.quick-panel-open && root.quick-panel-dock == "right")
-            ? (root.quick-panel-collapsed
-                ? ((root.welcome-as-sidebar && root.welcome-collapsed
-                        && root.welcome-sidebar-dock == "right")
-                    || (root.sidebar-collapsed && root.sidebar-dock == "right")
-                    ? 0px : 36px)
-                : root.quick-panel-width + 4px)
-            : 0px);
+        root.dock-right-gap + 4px;
     property <length> toolbar-y-off:
-        (root.sidebar-dock == "top"
-            ? (root.sidebar-collapsed ? 36px : root.sidebar-height + 4px)
-            : 0px)
-        + ((root.welcome-as-sidebar && root.welcome-sidebar-dock == "top")
-            ? root.welcome-sidebar-taken
-            : 0px)
-        + ((root.quick-panel-open && root.quick-panel-dock == "top")
-            ? (root.quick-panel-collapsed
-                ? ((root.welcome-as-sidebar && root.welcome-collapsed
-                        && root.welcome-sidebar-dock == "top")
-                    || (root.sidebar-collapsed && root.sidebar-dock == "top")
-                    ? 0px : 36px)
-                : root.quick-panel-height + 4px)
-            : 0px);
+        root.dock-top-gap;
     property <length> toolbar-y:
         (root.custom-titlebar ? 43px : 5px + root.titlebar-inset) + root.toolbar-y-off;
     in-out property <bool> about-open: false;     // centered About dialog
@@ -654,6 +656,11 @@ export component AppWindow inherits Window {
     callback set-extra-paste-shortcuts-enabled(bool);
     in-out property <bool> zen-mode: false;
     callback set-zen-mode(bool);
+    // Zen empties/restores the whole dock stack without resizing the frame, so
+    // every entry point (keyboard toggle AND the settings switch through the
+    // two-way binding) must re-run the dock geometry — one hook covers them all
+    // (#dock-stack).
+    changed zen-mode => { root.dock-layout-changed(); }
     // Collapse-by-default settings + shared SFTP collapse state (#78).
     in-out property <bool> collapse-sidebar-default: false;
     callback set-collapse-sidebar-default(bool);   // apply + persist
@@ -824,6 +831,33 @@ export component AppWindow inherits Window {
     // --- Split panes (v0.5) — flattened from the Rust split tree -----------
     in property <[PaneInfo]> panes;
     in property <[SplitterInfo]> splitters;
+    // --- Docked-panel edge stacks (#dock-stack) ---------------------------
+    // Every expanded dock panel's absolute rect plus the dividers between
+    // stacked panels, computed by Rust from `DockStacks::compute_geom`.
+    in property <[PanelGeomInfo]> dock-panels;
+    in property <[DividerGeomInfo]> dock-dividers;
+    // Central content rect (the terminal) left over after every edge stack is
+    // carved off; gaps are the taken thickness on each side.
+    in-out property <length> dock-central-x: 0px;
+    in-out property <length> dock-central-y: 0px;
+    in-out property <length> dock-central-w: 1200px;
+    in-out property <length> dock-central-h: 800px;
+    property <length> dock-left-gap: root.dock-central-x;
+    property <length> dock-right-gap: root.width - root.dock-central-x - root.dock-central-w;
+    property <length> dock-top-gap: root.dock-central-y;
+    property <length> dock-bottom-gap: root.height - root.dock-central-y - root.dock-central-h;
+    callback stack-split-drag(string /* edge */, int /* index */, float /* pos */);
+    // Reports the real dock-area size (window minus title bar): the Rust dock
+    // engine must measure in THIS frame, not the window frame, or every panel
+    // sits ~43px too low at the bottom edge (#dock-stack).
+    callback dock-area-resized(length /* w */, length /* h */);
+    // Any panel dock/collapse/size change must land in Rust to recompute the
+    // dock geometry (#dock-stack).
+    callback dock-layout-changed();
+    // Drag a stacked panel's in-edge (central-facing) resize handle. `gi` is
+    // the index into dock-panels; `pos` is the cursor's distance from the
+    // panel's outer edge along the dock normal (the new extent, px).
+    callback panel-extent-drag(int /* panel index */, float /* pos */);
     in-out property <string> active-tab-id: "welcome";
     in property <[TerminalState]> terminals;
 
@@ -1075,6 +1109,7 @@ export component AppWindow inherits Window {
     toggle-zen-key => {
         root.zen-mode = !root.zen-mode;
         root.set-zen-mode(root.zen-mode);
+        // (Dock recompute comes from `changed zen-mode` on root.)
         // Entering zen with no terminals can leave nothing focused (the
         // welcome page may be hidden as a sidebar), which would strand the
         // Ctrl+Alt+Z escape shortcut — anchor focus on the shortcut scope.
@@ -1225,6 +1260,11 @@ export component AppWindow inherits Window {
             // `sidebar-dock`, so the sidebar can sit on any window edge (#dock).
             dock-area := Rectangle {
             vertical-stretch: 1;
+            // Feed the Rust dock engine the real area it lays panels into, and
+            // re-run the geometry whenever that frame changes (window resize,
+            // zen toggle) — `rest` no longer tracks parent sizes itself.
+            changed width => { root.dock-area-resized(self.width, self.height); }
+            changed height => { root.dock-area-resized(self.width, self.height); }
             // Left-edge layout (welcome-as-sidebar mode): a thin always-on icon strip
             // (IDEA-style) + the welcome/session sidebar (0 when collapsed). The rest
             // (resource panel + central terminal, which never collapses) sits to their
@@ -1279,15 +1319,7 @@ export component AppWindow inherits Window {
                 tooltip: @tr("Quick commands");
                 expand => {
                     root.quick-panel-collapsed = false;
-                    if (root.sidebar-dock == root.quick-panel-dock) {
-                        root.sidebar-collapsed = true;
-                        root.set-sidebar-collapsed(true);
-                    }
-                    if (root.welcome-as-sidebar
-                            && root.welcome-sidebar-dock == root.quick-panel-dock) {
-                        root.welcome-collapsed = true;
-                        root.set-welcome-collapsed(true);
-                    }
+                    root.dock-layout-changed();
                 }
             }
 
@@ -1312,27 +1344,55 @@ export component AppWindow inherits Window {
                 expand => {
                     root.welcome-collapsed = false;
                     root.set-welcome-collapsed(false);
-                    if (root.sidebar-dock == root.welcome-sidebar-dock) {
-                        root.sidebar-collapsed = true;
-                        root.set-sidebar-collapsed(true);
-                    }
-                    if (root.quick-panel-open
-                            && root.quick-panel-dock == root.welcome-sidebar-dock) {
-                        root.quick-panel-collapsed = true;
-                    }
+                    root.dock-layout-changed();
                 }
                 expand-second => {
                     if (parent.combine-collapsed-tools) {
                         root.sidebar-collapsed = false;
                         root.set-sidebar-collapsed(false);
-                        if (root.quick-panel-open && root.quick-panel-dock == root.sidebar-dock) {
-                            root.quick-panel-collapsed = true;
-                        }
-                    } else {
+                    } else if (parent.quick-merge-welcome) {
                         root.quick-panel-collapsed = false;
                     }
+                    root.dock-layout-changed();
                 }
-                expand-third => { root.quick-panel-collapsed = false; }
+                expand-third => {
+                    if (parent.combine-collapsed-tools && parent.quick-merge-welcome) {
+                        root.quick-panel-collapsed = false;
+                    }
+                    root.dock-layout-changed();
+                }
+            }
+
+            // Collapsed resource panel → a ToolStrip icon bar at the same docked
+            // edge (M5), anchored to the OUTER edge of dock-area so it lines up
+            // with the 36px band the Rust dock engine reserves for it (#dock-stack).
+            if !root.zen-mode && root.sidebar-collapsed && !dock-area.combine-collapsed-tools && !dock-area.sidebar-strip-outside : ToolStrip {
+                x: root.sidebar-dock == "right"
+                    ? parent.width - 36px - parent.quick-right
+                    : parent.quick-left;
+                y: root.sidebar-dock == "bottom"
+                    ? parent.height - 36px - parent.quick-bottom
+                    : parent.quick-top;
+                width: root.sidebar-horizontal
+                    ? 36px : parent.width - parent.quick-left - parent.quick-right;
+                height: root.sidebar-horizontal
+                    ? parent.height - parent.quick-top - parent.quick-bottom
+                    : 36px;
+                dock-edge: root.sidebar-dock;
+                glyph: "\u{E871}";   // dashboard — resource panel
+                show-second: dock-area.quick-merge-sidebar;
+                second-glyph: "\u{E3E7}";
+                expand => {
+                    root.sidebar-collapsed = false;
+                    root.set-sidebar-collapsed(false);
+                    root.dock-layout-changed();
+                }
+                expand-second => {
+                    if (dock-area.quick-merge-sidebar) {
+                        root.quick-panel-collapsed = false;
+                    }
+                    root.dock-layout-changed();
+                }
             }
 
             if dock-area.sidebar-strip-outside : ToolStrip {
@@ -1353,24 +1413,29 @@ export component AppWindow inherits Window {
                 expand => {
                     root.sidebar-collapsed = false;
                     root.set-sidebar-collapsed(false);
-                    root.welcome-collapsed = true;
-                    root.set-welcome-collapsed(true);
-                    if (root.quick-panel-open && root.quick-panel-dock == root.sidebar-dock) {
-                        root.quick-panel-collapsed = true;
-                    }
+                    root.dock-layout-changed();
                 }
-                expand-second => { root.quick-panel-collapsed = false; }
+                expand-second => {
+                    if (parent.quick-merge-sidebar) {
+                        root.quick-panel-collapsed = false;
+                    }
+                    root.dock-layout-changed();
+                }
             }
 
             // Welcome / session list, to the right of the icon strip. Hidden when
             // collapsed — its icon stays in the strip; clicking it re-opens.
-            if root.welcome-as-sidebar && !root.welcome-collapsed : Rectangle {
-                x: root.welcome-sidebar-dock == "right" ? parent.width - parent.quick-right - parent.sidebar-outside-strip - parent.welcome-size
-                 : root.welcome-sidebar-dock == "left" ? parent.quick-left + parent.sidebar-outside-strip
-                 : parent.quick-left;
-                y: root.welcome-sidebar-dock == "bottom" ? parent.height - parent.quick-bottom - parent.sidebar-outside-strip - parent.welcome-size
-                 : root.welcome-sidebar-dock == "top" ? parent.quick-top + parent.sidebar-outside-strip
-                 : parent.quick-top;
+            if false : Rectangle {
+                x: root.welcome-sidebar-dock == "right"
+                    ? parent.width - parent.quick-right - parent.sidebar-outside-strip - parent.welcome-size
+                  : root.welcome-sidebar-dock == "left"
+                    ? parent.quick-left + parent.sidebar-outside-strip
+                  : parent.quick-left;
+                y: root.welcome-sidebar-dock == "bottom"
+                    ? parent.height - parent.quick-bottom - parent.sidebar-outside-strip - parent.welcome-size
+                  : root.welcome-sidebar-dock == "top"
+                    ? parent.quick-top + parent.sidebar-outside-strip
+                  : parent.quick-top;
                 width: parent.welcome-horizontal ? parent.welcome-size
                     : parent.width - parent.quick-left - parent.quick-right;
                 height: parent.welcome-horizontal
@@ -1444,13 +1509,13 @@ export component AppWindow inherits Window {
             }
 
             // Drag the welcome sidebar's right edge to resize it (v0.5 M3b).
-            if root.welcome-as-sidebar && !root.welcome-collapsed : Rectangle {
+            if false : Rectangle {
                 x: root.welcome-sidebar-dock == "left" ? parent.quick-left + parent.sidebar-outside-strip + parent.welcome-size - 2px
-                 : root.welcome-sidebar-dock == "right" ? parent.width - parent.quick-right - parent.sidebar-outside-strip - parent.welcome-size - 2px
-                 : parent.quick-left;
+                  : root.welcome-sidebar-dock == "right" ? parent.width - parent.quick-right - parent.sidebar-outside-strip - parent.welcome-size - 2px
+                  : parent.quick-left;
                 y: root.welcome-sidebar-dock == "top" ? parent.quick-top + parent.sidebar-outside-strip + parent.welcome-size - 2px
-                 : root.welcome-sidebar-dock == "bottom" ? parent.height - parent.quick-bottom - parent.sidebar-outside-strip - parent.welcome-size - 2px
-                 : parent.quick-top;
+                  : root.welcome-sidebar-dock == "bottom" ? parent.height - parent.quick-bottom - parent.sidebar-outside-strip - parent.welcome-size - 2px
+                  : parent.quick-top;
                 width: parent.welcome-horizontal ? 4px
                     : parent.width - parent.quick-left - parent.quick-right;
                 height: parent.welcome-horizontal
@@ -1494,28 +1559,20 @@ export component AppWindow inherits Window {
             // Everything except the welcome strip/sidebar — the resource panel,
             // splitter and the central tab/pane content — sits to the right of them.
             rest := Rectangle {
-            x: (root.welcome-sidebar-dock == "left" ? parent.welcome-taken : 0px)
-                + parent.quick-left;
-            y: (root.welcome-sidebar-dock == "top" ? parent.welcome-taken : 0px)
-                + parent.quick-top;
-            width: parent.width
-                - (parent.welcome-horizontal ? parent.welcome-taken : 0px)
-                - parent.quick-left - parent.quick-right;
-            height: parent.height
-                - (!parent.welcome-horizontal ? parent.welcome-taken : 0px)
-                - parent.quick-top - parent.quick-bottom;
+            // Geometry is owned by the Rust dock engine (#dock-stack): the
+            // central rect left over after every edge stack is carved off.
+            x: root.dock-central-x;
+            y: root.dock-central-y;
+            width: root.dock-central-w;
+            height: root.dock-central-h;
             // A shared ToolStrip is already reserved outside `rest` while the
             // welcome panel is expanded, or by the merged welcome strip while both
             // panels are collapsed. Do not reserve the same 36px a second time.
             property <length> sb-w: root.zen-mode ? 0px
-                : dock-area.sidebar-strip-outside
-                    || dock-area.combine-collapsed-tools ? 0px
-                : root.sidebar-collapsed ? 36px : root.sidebar-width;
+                : root.sidebar-collapsed ? 36px : 0px;
             property <length> sb-h: root.zen-mode ? 0px
-                : dock-area.sidebar-strip-outside
-                    || dock-area.combine-collapsed-tools ? 0px
-                : root.sidebar-collapsed ? 36px : root.sidebar-height;
-            property <length> sp: root.zen-mode || root.sidebar-collapsed ? 0px : 4px;
+                : root.sidebar-collapsed ? 36px : 0px;
+            property <length> sp: 0px;
             // The collapsed bar (sb-h) already reserves the bottom strip now.
             property <length> bottom-strip-h: 0px;
 
@@ -1523,7 +1580,7 @@ export component AppWindow inherits Window {
             // Only shown while expanded; collapsing swaps it for the ToolStrip icon
             // bar below (mirrors the welcome sidebar), so no clipped widgets bleed
             // through the 36px strip (#resource-collapse).
-            if !root.sidebar-collapsed : Rectangle {
+            if false : Rectangle {
                 x: root.sidebar-dock == "right" ? parent.width - parent.sb-w
                  : 0px;
                 y: root.sidebar-dock == "bottom" ? parent.height - parent.sb-h
@@ -1592,35 +1649,10 @@ export component AppWindow inherits Window {
                 }
             }
 
-            // Collapsed resource panel → a ToolStrip icon bar at the same docked edge
-            // (M5), in place of the old floating expand button.
-            if root.sidebar-collapsed && !dock-area.combine-collapsed-tools && !dock-area.sidebar-strip-outside : ToolStrip {
-                x: root.sidebar-dock == "right" ? parent.width - parent.sb-w : 0px;
-                y: root.sidebar-dock == "bottom" ? parent.height - parent.sb-h : 0px;
-                width: root.sidebar-horizontal ? parent.sb-w : parent.width;
-                height: root.sidebar-horizontal ? parent.height : parent.sb-h;
-                dock-edge: root.sidebar-dock;
-                glyph: "\u{E871}";   // dashboard — resource panel
-                show-second: dock-area.quick-merge-sidebar;
-                second-glyph: "\u{E3E7}";
-                expand => {
-                    root.sidebar-collapsed = false;
-                    root.set-sidebar-collapsed(false);
-                    if (root.welcome-as-sidebar && root.welcome-sidebar-dock == root.sidebar-dock) {
-                        root.welcome-collapsed = true;
-                        root.set-welcome-collapsed(true);
-                    }
-                    if (root.quick-panel-open && root.quick-panel-dock == root.sidebar-dock) {
-                        root.quick-panel-collapsed = true;
-                    }
-                }
-                expand-second => { root.quick-panel-collapsed = false; }
-            }
-
             // Splitter — drag to resize the sidebar. Orientation + which dimension it
             // adjusts follow the dock edge. Hidden while collapsed.
             Rectangle {
-                visible: !root.sidebar-collapsed;
+                visible: false;
                 // Horizontal docks → a vertical 4px bar at the sidebar's inner edge;
                 // vertical docks → a horizontal 4px bar.
                 x: root.sidebar-dock == "left"   ? parent.sb-w
@@ -1678,19 +1710,16 @@ export component AppWindow inherits Window {
             // panel can never bleed (visually or for clicks) onto a panel docked on
             // the bottom or right (#dock).
             quick-area := Rectangle {
-                x: root.sidebar-dock == "left" ? parent.sb-w + parent.sp : 0px;
-                y: root.sidebar-dock == "top"  ? parent.sb-h + parent.sp : 0px;
-                width:  root.sidebar-horizontal ? parent.width - parent.sb-w - parent.sp : parent.width;
-                height: root.sidebar-horizontal ? parent.height : parent.height - parent.sb-h - parent.sp - parent.bottom-strip-h;
+                x: 0px;
+                y: 0px;
+                width: parent.width;
+                height: parent.height;
                 clip: true;
                 property <bool> quick-horizontal:
                     root.quick-panel-dock == "left" || root.quick-panel-dock == "right";
-                property <length> quick-w:
-                    !root.zen-mode && root.quick-panel-open && !root.quick-panel-collapsed ? root.quick-panel-width : 0px;
-                property <length> quick-h:
-                    !root.zen-mode && root.quick-panel-open && !root.quick-panel-collapsed ? root.quick-panel-height : 0px;
-                property <length> quick-sp:
-                    !root.zen-mode && root.quick-panel-open && !root.quick-panel-collapsed ? 4px : 0px;
+                property <length> quick-w: 0px;
+                property <length> quick-h: 0px;
+                property <length> quick-sp: 0px;
 
                 central := Rectangle {
                 x: root.quick-panel-open && !root.quick-panel-collapsed && root.quick-panel-dock == "left"
@@ -1906,15 +1935,7 @@ export component AppWindow inherits Window {
                                 root.quick-panel-dock = root.dock-target;
                                 root.quick-panel-open = true;
                                 root.quick-panel-collapsed = false;
-                                if (root.sidebar-dock == root.dock-target) {
-                                    root.sidebar-collapsed = true;
-                                    root.set-sidebar-collapsed(true);
-                                }
-                                if (root.welcome-as-sidebar
-                                        && root.welcome-sidebar-dock == root.dock-target) {
-                                    root.welcome-collapsed = true;
-                                    root.set-welcome-collapsed(true);
-                                }
+                                root.dock-layout-changed();
                             }
                             root.panel-dragging = false;
                         }
@@ -2067,7 +2088,7 @@ export component AppWindow inherits Window {
                 }
             }
 
-            if root.quick-panel-open && !root.quick-panel-collapsed : QuickDockPanel {
+            if false : QuickDockPanel {
                 x: root.quick-panel-dock == "right" ? parent.width - parent.quick-w : 0px;
                 y: root.quick-panel-dock == "bottom" ? parent.height - parent.quick-h : 0px;
                 width: parent.quick-horizontal ? parent.quick-w : parent.width;
@@ -2111,7 +2132,7 @@ export component AppWindow inherits Window {
             }
 
             Rectangle {
-                visible: root.quick-panel-open && !root.quick-panel-collapsed;
+                visible: false;
                 x: root.quick-panel-dock == "left" ? parent.quick-w
                  : root.quick-panel-dock == "right" ? parent.width - parent.quick-w - 4px
                  : 0px;
@@ -2150,18 +2171,267 @@ export component AppWindow inherits Window {
                     }
                 }
             }
-            }
+
+
+                        }
             }
 
-            // (Resource collapse now uses a ToolStrip inside `rest`, above.)
+            // Stacked docked panels (#dock-stack): every expanded panel is
+            // placed here at the absolute rect Rust computed, so multiple
+            // panels can share one edge (split by the dividers below). `if`
+            // branches select the panel component; the old per-panel geometry
+            // blocks above use `if false` and are kept for reference.
+            for gp[gi] in root.dock-panels : Rectangle {
+                x: gp.x;
+                y: gp.y;
+                width: gp.w;
+                height: gp.h;
+                clip: true;
+                background: Theme.bg-panel;
+
+                if gp.kind == "sidebar" : Sidebar {
+                    width: parent.width;
+                    height: parent.height;
+                    lay-horizontal: gp.edge == "top" || gp.edge == "bottom";
+                    dock-edge: gp.edge;
+                    connection-state: root.connection-state;
+                    conn-host: root.conn-host;
+                    conn-state: root.conn-state;
+                    resource-title: root.resource-title;
+                    cpu-percent: root.cpu-percent;
+                    mem-percent: root.mem-percent;
+                    swap-percent: root.swap-percent;
+                    mem-detail: root.mem-detail;
+                    swap-detail: root.swap-detail;
+                    net-top-up: root.net-top-up;
+                    net-top-down: root.net-top-down;
+                    net-top-history: root.net-top-history;
+                    net-bot-up: root.net-bot-up;
+                    net-bot-down: root.net-bot-down;
+                    net-bot-history: root.net-bot-history;
+                    net-ifaces: root.net-ifaces;
+                    net-selected: root.net-selected;
+                    net-show-selector: root.net-show-selector;
+                    disks: root.disks;
+                    system-info-available: root.system-info-available;
+                    proc-available: root.proc-available;
+                    app-version: root.app-version;
+                    select-net-iface(i) => { root.select-net-iface(i); }
+                    show-system-info() => { root.open-system-info(); }
+                    show-processes() => { root.open-processes(); }
+                    copy-host(h) => { root.copy-text(h); }
+                    dock-drag-move(ax, ay) => {
+                        root.panel-dragging = true;
+                        root.drag-nx = (ax - dock-area.absolute-position.x) / dock-area.width;
+                        root.drag-ny = (ay - dock-area.absolute-position.y) / dock-area.height;
+                    }
+                    dock-drag-end() => {
+                        if (root.dock-target != "") {
+                            root.sidebar-dock = root.dock-target;
+                            root.persist-sidebar-dock(root.sidebar-dock);
+                            root.dock-layout-changed();
+                        }
+                        root.panel-dragging = false;
+                    }
+                    toggle-collapse() => {
+                        root.sidebar-collapsed = !root.sidebar-collapsed;
+                        root.set-sidebar-collapsed(root.sidebar-collapsed);
+                        root.dock-layout-changed();
+                    }
+                }
+                if gp.kind == "welcome" : Welcome {
+                    width: parent.width;
+                    height: parent.height;
+                    compact: true;
+                    dock-edge: gp.edge;
+                    sessions: root.sessions;
+                    import-hint: root.ssh-import-hint;
+                    search-query <=> root.host-search-query;
+                    sessions-revision: root.sessions-revision;
+                    search-changed(query) => { root.host-search-changed(query); }
+                    collapse => {
+                        root.welcome-collapsed = true;
+                        root.set-welcome-collapsed(true);
+                        root.dock-layout-changed();
+                    }
+                    dock-drag-move(ax, ay) => {
+                        root.panel-dragging = true;
+                        root.drag-nx = (ax - dock-area.absolute-position.x) / dock-area.width;
+                        root.drag-ny = (ay - dock-area.absolute-position.y) / dock-area.height;
+                    }
+                    dock-drag-end() => {
+                        if (root.dock-target != "") {
+                            root.welcome-sidebar-dock = root.dock-target;
+                            root.persist-welcome-sidebar-dock(root.welcome-sidebar-dock);
+                            root.dock-layout-changed();
+                        }
+                        root.panel-dragging = false;
+                    }
+                    new-session => { root.new-session-clicked(); }
+                    import-ssh-config => { root.import-ssh-config(); }
+                    connect-session(id) => { root.connect-session(id); }
+                    edit-session(id) => { root.edit-session(id); }
+                    duplicate-session(id) => { root.duplicate-session(id); }
+                    move-session(id, group) => { root.move-session(id, group); }
+                    reorder-session(id, dir) => { return root.reorder-session(id, dir); }
+                    reorder-end => { root.reorder-session-end(); }
+                    toggle-group(group) => { root.toggle-group(group); }
+                    new-group => {
+                        root.group-dialog-orig = "";
+                        root.group-dialog-name = "";
+                        root.group-dialog-error = "";
+                        root.group-dialog-open = true;
+                    }
+                    edit-group(name) => {
+                        root.group-dialog-orig = name;
+                        root.group-dialog-name = name;
+                        root.group-dialog-error = "";
+                        root.group-dialog-open = true;
+                    }
+                    delete-group(name) => { root.delete-group(name); }
+                    remove-session(id) => { root.remove-session(id); }
+                }
+                if gp.kind == "quick" : QuickDockPanel {
+                    width: parent.width;
+                    height: parent.height;
+                    commands: root.quick-commands;
+                    dock-edge: gp.edge;
+                    activate(command, send-enter) => {
+                        root.quick-external-command = command;
+                        root.quick-external-send-enter = send-enter;
+                        root.quick-external-sequence += 1;
+                    }
+                    toggle-group(group) => { root.toggle-quick-group(group); }
+                    manage => {
+                        root.qcm-name = "";
+                        root.qcm-command = "";
+                        root.qcm-group = "";
+                        root.qcm-edit-index = -1;
+                        root.quick-cmd-manage-open = true;
+                    }
+                    close => { root.quick-panel-collapsed = true; root.dock-layout-changed(); }
+                    dock-drag-move(ax, ay) => {
+                        root.panel-dragging = true;
+                        root.drag-nx = (ax - dock-area.absolute-position.x) / dock-area.width;
+                        root.drag-ny = (ay - dock-area.absolute-position.y) / dock-area.height;
+                    }
+                    dock-drag-end => {
+                        if (root.dock-target != "") {
+                            root.quick-panel-dock = root.dock-target;
+                            root.dock-layout-changed();
+                        }
+                        root.panel-dragging = false;
+                    }
+                }
+                // Drag the panel's in-edge (central-facing) edge to resize its
+                // extent along the dock normal (width on left/right, height on
+                // top/bottom) — the stacked renderer's replacement for the old
+                // per-panel splitter (#dock-stack). Measured against the PANEL
+                // origin (gp.x/gp.y already include any collapsed-strip band),
+                // so the value lands straight on the panel's width/height prop.
+                if gp.edge == "left" : Rectangle {
+                    x: parent.width - 2px; y: 0px;
+                    width: 4px; height: parent.height;
+                    background: rr-l.has-hover ? Theme.accent : Theme.border-subtle;
+                    rr-l := TouchArea {
+                        mouse-cursor: ew-resize;
+                        moved => {
+                            if (self.pressed) {
+                                root.panel-extent-drag(gi,
+                                    ((self.absolute-position.x + self.mouse-x)
+                                        - dock-area.absolute-position.x - gp.x) / 1px);
+                            }
+                        }
+                    }
+                }
+                if gp.edge == "right" : Rectangle {
+                    x: 0px; y: 0px;
+                    width: 4px; height: parent.height;
+                    background: rr-r.has-hover ? Theme.accent : Theme.border-subtle;
+                    rr-r := TouchArea {
+                        mouse-cursor: ew-resize;
+                        moved => {
+                            if (self.pressed) {
+                                root.panel-extent-drag(gi,
+                                    (gp.x + gp.w
+                                        - ((self.absolute-position.x + self.mouse-x)
+                                            - dock-area.absolute-position.x)) / 1px);
+                            }
+                        }
+                    }
+                }
+                if gp.edge == "top" : Rectangle {
+                    x: 0px; y: parent.height - 2px;
+                    width: parent.width; height: 4px;
+                    background: rr-t.has-hover ? Theme.accent : Theme.border-subtle;
+                    rr-t := TouchArea {
+                        mouse-cursor: ns-resize;
+                        moved => {
+                            if (self.pressed) {
+                                root.panel-extent-drag(gi,
+                                    ((self.absolute-position.y + self.mouse-y)
+                                        - dock-area.absolute-position.y - gp.y) / 1px);
+                            }
+                        }
+                    }
+                }
+                if gp.edge == "bottom" : Rectangle {
+                    x: 0px; y: 0px;
+                    width: parent.width; height: 4px;
+                    background: rr-b.has-hover ? Theme.accent : Theme.border-subtle;
+                    rr-b := TouchArea {
+                        mouse-cursor: ns-resize;
+                        moved => {
+                            if (self.pressed) {
+                                root.panel-extent-drag(gi,
+                                    (gp.y + gp.h
+                                        - ((self.absolute-position.y + self.mouse-y)
+                                            - dock-area.absolute-position.y)) / 1px);
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Dividers between stacked panels on the same edge (#dock-stack).
+            for dd[di] in root.dock-dividers : Rectangle {
+                x: dd.x;
+                y: dd.y;
+                width: dd.w;
+                height: dd.h;
+                background: dd-ta.pressed ? Theme.accent : Theme.border-strong;
+                animate background { duration: 100ms; }
+                dd-ta := TouchArea {
+                    mouse-cursor: dd.vertical ? ns-resize : ew-resize;
+                    moved => {
+                        if (self.pressed) {
+                            root.stack-split-drag(dd.edge, dd.index,
+                                dd.vertical
+                                    ? ((self.absolute-position.y + self.mouse-y)
+                                        - dock-area.absolute-position.y) / 1px
+                                    : ((self.absolute-position.x + self.mouse-x)
+                                        - dock-area.absolute-position.x) / 1px);
+                        }
+                    }
+                }
+            }
 
             // Drag-to-dock snap overlay — four edge zones; the one under the cursor
-            // (root.dock-target) lights up. Purely visual (no TouchArea) so the
-            // header's drag keeps receiving move events (#dock).
+            // (root.dock-target) lights up. The zones stay input-transparent; the
+            // single TouchArea below only ever sees a press when the drag lifecycle
+            // broke (a live drag keeps its grab on the source), so a stranded
+            // frame can be cleared with one click (#dock).
             if root.panel-dragging : Rectangle {
                 x: 0; y: 0;
                 width: parent.width;
                 height: parent.height;
+                // Self-heal: during a live drag the source keeps the pointer
+                // grab, so this area sees nothing. The only way a press ever
+                // lands here is a stale frame (the drag's end was lost) — one
+                // click then clears it instead of stranding the preview.
+                TouchArea {
+                    clicked => { root.panel-dragging = false; }
+                }
                 Rectangle {   // left zone
                     x: 0; y: 0; width: parent.width * 0.22; height: parent.height;
                     background: root.dock-target == "left"

--- a/ui/sftp_panel.slint
+++ b/ui/sftp_panel.slint
@@ -164,11 +164,16 @@ export component SftpPanel inherits Rectangle {
     dock-bg := TouchArea {
         mouse-cursor: move;
         moved => {
-            root.dock-drag-move(self.absolute-position.x + self.mouse-x,
-                                self.absolute-position.y + self.mouse-y);
+            if (self.pressed) {
+                root.dock-drag-move(self.absolute-position.x + self.mouse-x,
+                                    self.absolute-position.y + self.mouse-y);
+            }
         }
         pointer-event(ev) => {
             if (ev.kind == PointerEventKind.up) { root.dock-drag-end(); }
+            // Grab taken away (popup, deactivation): end the gesture
+            // anyway so no dock preview is stranded.
+            else if (ev.kind == PointerEventKind.cancel) { root.dock-drag-end(); }
         }
     }
 
@@ -209,11 +214,16 @@ export component SftpPanel inherits Rectangle {
                     grip-ta := TouchArea {
                         mouse-cursor: move;
                         moved => {
-                            root.dock-drag-move(self.absolute-position.x + self.mouse-x,
-                                                self.absolute-position.y + self.mouse-y);
+                            if (self.pressed) {
+                                root.dock-drag-move(self.absolute-position.x + self.mouse-x,
+                                                    self.absolute-position.y + self.mouse-y);
+                            }
                         }
                         pointer-event(ev) => {
                             if (ev.kind == PointerEventKind.up) { root.dock-drag-end(); }
+                            // Grab taken away (popup, deactivation): end the
+                            // gesture anyway so no dock preview is stranded.
+                            else if (ev.kind == PointerEventKind.cancel) { root.dock-drag-end(); }
                         }
                     }
                     Text {

--- a/ui/sidebar.slint
+++ b/ui/sidebar.slint
@@ -209,11 +209,16 @@ component StatusBlock inherits Rectangle {
     TouchArea {
         mouse-cursor: move;
         moved => {
-            root.dock-drag-move(self.absolute-position.x + self.mouse-x,
-                                self.absolute-position.y + self.mouse-y);
+            if (self.pressed) {
+                root.dock-drag-move(self.absolute-position.x + self.mouse-x,
+                                    self.absolute-position.y + self.mouse-y);
+            }
         }
         pointer-event(ev) => {
             if (ev.kind == PointerEventKind.up) { root.dock-drag-end(); }
+            // Grab taken away (popup, deactivation): end the gesture
+            // anyway so no dock preview is stranded.
+            else if (ev.kind == PointerEventKind.cancel) { root.dock-drag-end(); }
         }
     }
     VerticalLayout {
@@ -490,11 +495,16 @@ export component Sidebar inherits Rectangle {
     dock-bg := TouchArea {
         mouse-cursor: move;
         moved => {
-            root.dock-drag-move(self.absolute-position.x + self.mouse-x,
-                                self.absolute-position.y + self.mouse-y);
+            if (self.pressed) {
+                root.dock-drag-move(self.absolute-position.x + self.mouse-x,
+                                    self.absolute-position.y + self.mouse-y);
+            }
         }
         pointer-event(ev) => {
             if (ev.kind == PointerEventKind.up) { root.dock-drag-end(); }
+            // Grab taken away (popup, deactivation): end the gesture
+            // anyway so no dock preview is stranded.
+            else if (ev.kind == PointerEventKind.cancel) { root.dock-drag-end(); }
         }
     }
 

--- a/ui/terminal_view.slint
+++ b/ui/terminal_view.slint
@@ -121,6 +121,9 @@ export component QuickDockPanel inherits Rectangle {
                 }
                 pointer-event(ev) => {
                     if (ev.kind == PointerEventKind.up) { root.dock-drag-end(); }
+                    // Grab taken away (popup, deactivation): end the gesture
+                    // anyway so no dock preview is stranded.
+                    else if (ev.kind == PointerEventKind.cancel) { root.dock-drag-end(); }
                 }
             }
             HorizontalLayout {
@@ -1782,6 +1785,13 @@ export component TerminalView inherits Rectangle {
                                         }
                                         pointer-event(ev) => {
                                             if (ev.kind == PointerEventKind.up) {
+                                                root.quick-open = false;
+                                                root.quick-dock-drag-end();
+                                            }
+                                            // Grab taken away (popup, deactivation): end the
+                                            // gesture anyway so no dock preview is stranded
+                                            // (mirrors up, which also closes the popup).
+                                            else if (ev.kind == PointerEventKind.cancel) {
                                                 root.quick-open = false;
                                                 root.quick-dock-drag-end();
                                             }

--- a/ui/welcome.slint
+++ b/ui/welcome.slint
@@ -477,11 +477,16 @@ export component Welcome inherits Rectangle {
                         enabled: root.compact;
                         mouse-cursor: move;
                         moved => {
-                            root.dock-drag-move(self.absolute-position.x + self.mouse-x,
-                                                self.absolute-position.y + self.mouse-y);
+                            if (self.pressed) {
+                                root.dock-drag-move(self.absolute-position.x + self.mouse-x,
+                                                    self.absolute-position.y + self.mouse-y);
+                            }
                         }
                         pointer-event(ev) => {
                             if (ev.kind == PointerEventKind.up) { root.dock-drag-end(); }
+                            // Grab taken away (popup, deactivation): end the gesture
+                            // anyway so no dock preview is stranded.
+                            else if (ev.kind == PointerEventKind.cancel) { root.dock-drag-end(); }
                         }
                     }
                     header-row := HorizontalLayout {


### PR DESCRIPTION
## 改动内容 / Changes
- 同边停靠面板可同时展开多个（资源侧栏 / 会话列表 / 快捷命令），沿边缘用可拖分隔条分割。
  Multiple docked panels (resource sidebar / welcome session list / quick commands) can now share the same window edge at once, split by draggable dividers.
- 几何由 Rust 引擎统一计算（refresh_dock）：绝对矩形渲染、in-edge 把手调整厚度、小窗口 panic 钳位、36px 折叠条带预留、合并面板均分边缘而非细条。
  Rendering is driven by a Rust geometry engine: absolute rects per panel, in-edge resize handles, clamping for tiny dock areas, the 36px collapsed-strip band, and even-half splits on merge.
- 配置持久化 `dock_stacks`（含旧配置/损坏配置消毒回退单面板布局）；拖拽持锁期间延迟推送 dock 模型，卡死的 snap 预览自愈。
  Config persistence with sanitising fallback to the legacy layout; dock model pushes are deferred while a panel drag holds the pointer, and stranded snap previews self-heal.

## 测试 / Tests
dock_stacks 边缘栈模型与几何单元测试（cargo test dock_stacks）。13 files changed, +1826/−152.