### PR TITLE
fix(paste): 截断粘贴确认预览，修复超长文本软件渲染闪退 (#434)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -175,11 +175,12 @@ use crate::ssh::{
 #[cfg(windows)]
 use crate::terminal::c0_letter_key_down;
 use crate::terminal::{
-    bare_ctrl_marker_workaround_enabled, cell_prefix, compile_output_rules,
-    encode_command_bar_input, encode_mouse_event, encode_pasted_text, is_terminal_interrupt,
-    key_to_pty_bytes, paste_requires_large_review, should_drop_bare_ctrl_marker,
-    terminal_uses_bracketed_paste, CsiState, OutputHighlightPreset, RenderGates, TabRenderGate,
-    TermBuffer, TermBufferHandle, TermBuffers,
+    bare_ctrl_marker_workaround_enabled, cell_prefix, clear_pending_paste,
+    compile_output_rules, encode_command_bar_input, encode_mouse_event, encode_pasted_text,
+    is_terminal_interrupt, key_to_pty_bytes, paste_requires_large_review,
+    should_drop_bare_ctrl_marker, store_pending_paste, take_pending_paste,
+    terminal_uses_bracketed_paste, CsiState, OutputHighlightPreset, PendingPaste, RenderGates,
+    TabRenderGate, TermBuffer, TermBufferHandle, TermBuffers,
 };
 #[cfg(test)]
 use crate::terminal::{
@@ -6012,10 +6013,17 @@ fn wire_key_input(
     }
 
     // Middle-click / Ctrl+Shift+V: paste clipboard text into PTY.
+    //
+    // Full clipboard payload for an open multi-line review dialog lives only
+    // in `pending_paste` (not in a Slint string property): the software
+    // renderer panics when a huge Text layout overflows i16 coordinates
+    // (#434 / slint#12985).
+    let pending_paste: Arc<PendingPaste> = Arc::new(Mutex::new(None));
     {
         let handles = handles.clone();
         let bufs = bufs.clone();
         let weak = window.as_weak();
+        let pending_paste = pending_paste.clone();
         window.on_paste_from_clipboard(move |tab_id: SharedString| {
             // Clone the (Send) command sender for this tab so the clipboard read
             // can run off the UI thread.  Reading arboard on the event-loop
@@ -6032,6 +6040,7 @@ fn wire_key_input(
                 .map(|w| w.get_paste_confirm_enabled())
                 .unwrap_or(true);
             let weak = weak.clone();
+            let pending_paste = pending_paste.clone();
             let tab_id = tab_id.to_string();
             std::thread::spawn(move || {
                 match arboard::Clipboard::new().and_then(|mut cb| cb.get_text()) {
@@ -6039,11 +6048,13 @@ fn wire_key_input(
                         let force_review = text.len() > 100 * 1024;
                         if text.contains(['\r', '\n']) && (confirm_multiline || force_review) {
                             let large = paste_requires_large_review(&text);
-                            let preview = text.clone();
+                            // Only a bounded preview enters the UI tree. Confirm
+                            // reads the full payload via take_pending_paste.
+                            let preview =
+                                store_pending_paste(&pending_paste, tab_id.clone(), text);
                             let _ = slint::invoke_from_event_loop(move || {
                                 if let Some(w) = weak.upgrade() {
                                     w.set_paste_confirm_tab(tab_id.into());
-                                    w.set_paste_confirm_text(text.into());
                                     w.set_paste_confirm_preview(preview.into());
                                     w.set_paste_confirm_large(large);
                                     w.set_paste_confirm_open(true);
@@ -6064,6 +6075,7 @@ fn wire_key_input(
     {
         let handles_paste = handles.clone();
         let bufs_paste = bufs.clone();
+        let pending_paste = pending_paste.clone();
         let weak = window.as_weak();
         window.on_paste_confirmed(move |tab_id: SharedString| {
             let Some(sender) = handles_paste
@@ -6073,17 +6085,27 @@ fn wire_key_input(
             else {
                 return;
             };
-            let Some(w) = weak.upgrade() else { return };
-            let text = w.get_paste_confirm_text().to_string();
+            let text = take_pending_paste(&pending_paste, tab_id.as_str());
+            if let Some(w) = weak.upgrade() {
+                w.set_paste_confirm_open(false);
+            }
+            let Some(text) = text else {
+                tracing::warn!("paste_confirmed: no pending paste payload for tab {tab_id}");
+                return;
+            };
             let bracketed = terminal_uses_bracketed_paste(&bufs_paste, tab_id.as_str());
             let _ = sender.send(SessionCommand::RawInput(encode_pasted_text(
                 &text, bracketed,
             )));
-            w.set_paste_confirm_open(false);
         });
     }
 
-    window.on_paste_confirm_cancelled(|| {});
+    {
+        let pending_paste = pending_paste.clone();
+        window.on_paste_confirm_cancelled(move || {
+            clear_pending_paste(&pending_paste);
+        });
+    }
 
     // Context menu → 清空缓存: reset the local vt100 buffer (drops scrollback),
     // wipe the displayed screen, then nudge the remote to redraw a fresh prompt.

--- a/src/terminal/impls/input.rs
+++ b/src/terminal/impls/input.rs
@@ -112,6 +112,118 @@ pub(crate) fn paste_requires_large_review(text: &str) -> bool {
     text.chars().count() > COMPACT_CHAR_LIMIT || lines > COMPACT_LINE_LIMIT
 }
 
+/// Bounds for the paste-confirm preview string.
+///
+/// Slint's software renderer stores glyph geometry in i16 (slint#12985 /
+/// #12994). Binding a multi-thousand-line clipboard payload to the confirm
+/// dialog's `Text` laid out coordinates past ±32767 and panicked. The full
+/// paste stays in Rust until the user confirms; only this bounded preview
+/// enters the UI tree (#434).
+pub(crate) fn build_paste_preview(text: &str) -> String {
+    const MAX_LINES: usize = 48;
+    const MAX_LINE_CHARS: usize = 240;
+    const MAX_CHARS: usize = 6 * 1024;
+    const NOTICE_RESERVE: usize = 120;
+    const ELLIPSIS: &str = "…";
+
+    if text.is_empty() {
+        return String::new();
+    }
+
+    let total_lines = text.lines().count();
+    let total_chars = text.chars().count();
+
+    let mut out = String::new();
+    let mut taken = 0usize;
+    let mut truncated = false;
+
+    for line in text.lines() {
+        if taken >= MAX_LINES {
+            truncated = true;
+            break;
+        }
+
+        let mut display = String::new();
+        let mut n = 0usize;
+        for ch in line.chars() {
+            if n >= MAX_LINE_CHARS {
+                display.push_str(ELLIPSIS);
+                truncated = true;
+                break;
+            }
+            display.push(ch);
+            n += 1;
+        }
+
+        if out.chars().count() + display.chars().count() + 1 + NOTICE_RESERVE > MAX_CHARS {
+            truncated = true;
+            break;
+        }
+        if !out.is_empty() {
+            out.push('\n');
+        }
+        out.push_str(&display);
+        taken += 1;
+    }
+
+    if truncated || taken < total_lines {
+        if !out.is_empty() {
+            out.push('\n');
+        }
+        out.push_str(&format!(
+            "{}{taken}/{total_lines}{}{total_chars}{}",
+            crate::i18n::t(
+                "…（预览已截断：显示 ",
+                "… (preview truncated: showing ",
+            ),
+            crate::i18n::t(" 行，共 ", " lines, "),
+            crate::i18n::t(
+                " 字符；确认后粘贴完整内容）",
+                " chars; confirming pastes the full content)",
+            ),
+        ));
+    }
+
+    out
+}
+
+/// Full payload for an open multi-line paste review. Keyed by tab so a
+/// confirm for the wrong session cannot steal another tab's clipboard.
+pub(crate) type PendingPaste = std::sync::Mutex<Option<(String /* tab_id */, String /* full */)>>;
+
+/// Store the full clipboard text and return the bounded UI preview (#434).
+///
+/// Callers must only put the returned preview into Slint. The full text stays
+/// here until [`take_pending_paste`] on confirm.
+pub(crate) fn store_pending_paste(
+    pending: &PendingPaste,
+    tab_id: String,
+    full_text: String,
+) -> String {
+    let preview = build_paste_preview(&full_text);
+    if let Ok(mut slot) = pending.lock() {
+        *slot = Some((tab_id, full_text));
+    }
+    preview
+}
+
+/// Take the full paste for `tab_id` (confirm). Returns `None` when empty or
+/// when the pending payload belongs to a different tab.
+pub(crate) fn take_pending_paste(pending: &PendingPaste, tab_id: &str) -> Option<String> {
+    let mut slot = pending.lock().ok()?;
+    match slot.as_ref() {
+        Some((pending_tab, _)) if pending_tab == tab_id => slot.take().map(|(_, text)| text),
+        _ => None,
+    }
+}
+
+/// Drop any pending full paste (cancel / replace).
+pub(crate) fn clear_pending_paste(pending: &PendingPaste) {
+    if let Ok(mut slot) = pending.lock() {
+        *slot = None;
+    }
+}
+
 #[cfg(any(target_os = "windows", test))]
 pub(crate) fn windows_process_ctrl_release(
     state: i_slint_backend_winit::winit::event::ElementState,

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -33,10 +33,10 @@ pub(crate) use input::c0_letter_key_down;
 #[cfg(test)]
 pub(crate) use input::normalize_pasted_newlines;
 pub(crate) use input::{
-    bare_ctrl_marker_workaround_enabled, encode_command_bar_input, encode_mouse_event,
-    encode_pasted_text, is_terminal_interrupt, key_to_pty_bytes, paste_requires_large_review,
-    should_drop_bare_ctrl_marker,
-    terminal_uses_bracketed_paste,
+    bare_ctrl_marker_workaround_enabled, build_paste_preview, clear_pending_paste,
+    encode_command_bar_input, encode_mouse_event, encode_pasted_text, is_terminal_interrupt,
+    key_to_pty_bytes, paste_requires_large_review, should_drop_bare_ctrl_marker,
+    store_pending_paste, take_pending_paste, terminal_uses_bracketed_paste, PendingPaste,
 };
 pub(crate) use charset::CharsetTracker;
 pub(crate) use encoding::TerminalEncoding;

--- a/tests/app/terminal_input/paste/mod.rs
+++ b/tests/app/terminal_input/paste/mod.rs
@@ -1,4 +1,5 @@
 use super::super::*;
+use crate::terminal::build_paste_preview;
 
 #[test]
 fn paste_normalizes_newlines_to_cr() {
@@ -55,4 +56,117 @@ fn long_pastes_switch_to_large_review() {
     assert!(paste_requires_large_review(&"a".repeat(601)));
     assert!(!paste_requires_large_review(&vec!["line"; 12].join("\r\n")));
     assert!(paste_requires_large_review(&vec!["line"; 13].join("\r\n")));
+}
+
+#[test]
+fn paste_preview_passes_short_text_through() {
+    assert_eq!(build_paste_preview(""), "");
+    assert_eq!(build_paste_preview("hello"), "hello");
+    assert_eq!(build_paste_preview("a\nb\nc"), "a\nb\nc");
+}
+
+/// Slint's software renderer uses i16 coordinates (~±32767). A Text that
+/// lays out thousands of lines (or one multi-kilobyte line) overflows and
+/// panics (slint#12985 / #434). The preview must stay well inside that range.
+#[test]
+fn paste_preview_stays_within_i16_safe_layout_bounds() {
+    // ~3000 lines of typical code — the #434 repro shape.
+    let text = (0..3000)
+        .map(|i| format!("fn handler_{i}() {{ let x = {i}; }}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let preview = build_paste_preview(&text);
+
+    // 48 content lines + 1 notice ≪ 32767 / ~20px line height.
+    assert!(
+        preview.lines().count() <= 50,
+        "preview lines {} exceed i16-safe budget",
+        preview.lines().count()
+    );
+    // Longest display line is capped at 240 + ellipsis.
+    let max_line = preview.lines().map(|l| l.chars().count()).max().unwrap_or(0);
+    assert!(
+        max_line <= 250,
+        "preview max line {max_line} exceeds i16-safe width"
+    );
+    assert!(preview.chars().count() < 8 * 1024);
+    assert!(preview.starts_with("fn handler_0"));
+    assert!(preview.contains("3000") || preview.contains("48/"));
+}
+
+#[test]
+fn paste_preview_caps_long_single_line() {
+    let text = "x".repeat(50_000);
+    let preview = build_paste_preview(&text);
+    assert!(preview.chars().count() < 8 * 1024);
+    assert!(preview.contains('…') || preview.contains("..."));
+    // One display line plus a notice line.
+    assert!(preview.lines().count() <= 3);
+}
+
+/// End-to-end contract for #434 at the logic layer:
+/// 1. UI preview is truncated (so software-renderer layout stays in i16).
+/// 2. Confirm still yields the FULL original payload (so paste is not lossy).
+/// 3. Cancel drops the payload.
+/// 4. Confirm for another tab does not steal the pending paste.
+#[test]
+fn pending_paste_keeps_full_payload_while_ui_only_sees_preview() {
+    let pending: PendingPaste = std::sync::Mutex::new(None);
+    let full: String = (0..3000)
+        .map(|i| format!("line {i} content for vim insert-mode paste"))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let preview = store_pending_paste(&pending, "tab-a".into(), full.clone());
+
+    // (1) Preview must not be the full payload and must be bounded.
+    assert_ne!(preview, full);
+    assert!(preview.len() < full.len() / 10);
+    assert!(preview.lines().count() <= 50);
+
+    // (2) Confirm path recovers the exact full text (not the preview).
+    let taken = take_pending_paste(&pending, "tab-a").expect("full payload for matching tab");
+    assert_eq!(taken, full);
+    assert_ne!(taken, preview);
+
+    // Empty after take.
+    assert!(take_pending_paste(&pending, "tab-a").is_none());
+
+    // (3) Cancel clears.
+    store_pending_paste(&pending, "tab-a".into(), full.clone());
+    clear_pending_paste(&pending);
+    assert!(take_pending_paste(&pending, "tab-a").is_none());
+
+    // (4) Wrong tab cannot steal.
+    store_pending_paste(&pending, "tab-a".into(), full.clone());
+    assert!(take_pending_paste(&pending, "tab-b").is_none());
+    assert_eq!(take_pending_paste(&pending, "tab-a").unwrap(), full);
+}
+
+/// Confirm must encode the full payload into the PTY bytes, not the preview.
+#[test]
+fn confirmed_paste_bytes_come_from_full_payload_not_preview() {
+    let pending: PendingPaste = std::sync::Mutex::new(None);
+    let full = vec!["echo step"; 3000].join("\n");
+    let preview = store_pending_paste(&pending, "tab".into(), full.clone());
+    let taken = take_pending_paste(&pending, "tab").unwrap();
+
+    let from_full = encode_pasted_text(&taken, false);
+    let from_preview = encode_pasted_text(&preview, false);
+    let expected = normalize_pasted_newlines(&full).into_bytes();
+
+    assert_eq!(from_full, expected, "confirm must paste the full clipboard");
+    assert_ne!(
+        from_full, from_preview,
+        "preview must not be what reaches the PTY"
+    );
+}
+
+#[test]
+fn paste_preview_never_matches_full_multithousand_line_payload() {
+    // Regression for #434: the UI must never receive the full payload.
+    let text = vec!["fn main() { println!(\"hi\"); }"; 3000].join("\n");
+    let preview = build_paste_preview(&text);
+    assert!(preview.len() < text.len() / 10);
+    assert_ne!(preview, text);
 }

--- a/ui/app.slint
+++ b/ui/app.slint
@@ -880,7 +880,8 @@ export component AppWindow inherits Window {
     // Multi-line terminal paste safety prompt (#262).
     in-out property <bool> paste-confirm-open: false;
     in-out property <string> paste-confirm-tab;
-    in-out property <string> paste-confirm-text;
+    // Preview only — Rust truncates this before set. The full paste payload
+    // lives on the Rust side until the user confirms (#434 / slint#12985).
     in-out property <string> paste-confirm-preview;
     in-out property <bool> paste-confirm-large: false;
     callback paste-confirmed(string /* tab-id */);


### PR DESCRIPTION
多行粘贴确认框原先把完整剪贴板内容绑定到 Slint Text。软件渲染器
坐标为 i16，vim 插入模式粘贴数千行时布局溢出并 panic。

现在 UI 只接收有界预览（约 48 行 / 每行约 240 字符）；完整粘贴
数据暂存在 Rust 侧，确认后仍按原文写入终端，取消则丢弃。

修复bug: [vim编辑模式粘贴超长文本闪退#434](https://github.com/yituorou/meatshell/issues/434)